### PR TITLE
chore: use PAT for auto merge workflow

### DIFF
--- a/.github/workflows/auto-merge-staging.yml
+++ b/.github/workflows/auto-merge-staging.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Merge the PR into staging
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT || github.token }}
+          github-token: ${{ secrets.GH_PAT }}
           script: |
             const pr = context.payload.workflow_run.pull_requests[0];
             if (!pr) {
@@ -59,7 +59,7 @@ jobs:
         if: success()
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT || github.token }}
+          github-token: ${{ secrets.GH_PAT }}
           script: |
             const pr = context.payload.workflow_run.pull_requests[0];
             // Only attempt deletion if the branch is in the same repository


### PR DESCRIPTION
## Summary
- use `GH_PAT` secret for auto-merge workflow

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_68975a3487c48322ad826303fd152b02