### PR TITLE
Use PAT for auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-staging.yml
+++ b/.github/workflows/auto-merge-staging.yml
@@ -15,10 +15,18 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Ensure GH_PAT secret is set
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          if [ -z "$GH_PAT" ]; then
+            echo "GH_PAT secret is not configured" >&2
+            exit 1
+          fi
       - name: Merge the PR into staging
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT || github.token }}
+          github-token: ${{ secrets.GH_PAT }}
           script: |
             const pr = context.payload.workflow_run.pull_requests[0];
             if (!pr) {
@@ -59,7 +67,7 @@ jobs:
         if: success()
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT || github.token }}
+          github-token: ${{ secrets.GH_PAT }}
           script: |
             const pr = context.payload.workflow_run.pull_requests[0];
             // Only attempt deletion if the branch is in the same repository


### PR DESCRIPTION
## Summary
- require `GH_PAT` secret in auto-merge workflow and fail fast if missing
- use the PAT for merge and branch deletion actions

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6897671e4aac8322b137842ca379ea69