### PR TITLE
Ensure cache permissions set after cache clearing

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -78,3 +78,11 @@ jobs:
           chmod 600 private_key.pem
           ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_HOST \
           "cd /var/www/cleanwhiskers.com && php bin/console cache:clear"
+
+      - name: Set Cache Directory Permissions on Production Server
+        run: |
+          echo "$SSH_PRIVATE_KEY" > private_key.pem
+          chmod 600 private_key.pem
+          ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_HOST \
+          "cd /var/www/cleanwhiskers.com && sudo chown -R www-data:www-data var/cache/prod && sudo chmod -R 775 var/cache/prod/"
+

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -87,3 +87,10 @@ jobs:
           chmod 600 private_key.pem
           ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_STAGING_HOST \
           "cd /var/www/staging.cleanwhiskers.com && php bin/console cache:clear"
+
+      - name: Set Cache Directory Permissions on Staging Server
+        run: |
+          echo "$SSH_PRIVATE_KEY" > private_key.pem
+          chmod 600 private_key.pem
+          ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_STAGING_HOST \
+          "cd /var/www/staging.cleanwhiskers.com && sudo chown -R www-data:www-data var/cache/prod && sudo chmod -R 775 var/cache/prod/"


### PR DESCRIPTION
## Summary
- add chown/chmod step after cache clear in production deploy workflow
- add chown/chmod step after cache clear in staging deploy workflow

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/prod-deploy.yml"); YAML.load_file(".github/workflows/staging-deploy.yml"); puts "YAML OK"'`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_6898593346288322a0f020958a197f26