### PR TITLE
Run importmap install before cache clear

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -72,6 +72,13 @@ jobs:
           ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_HOST \
           "cd /var/www/cleanwhiskers.com && php bin/console --no-interaction --allow-no-migration doctrine:migrations:migrate"
 
+      - name: Install Importmap on Production Server
+        run: |
+          echo "$SSH_PRIVATE_KEY" > private_key.pem
+          chmod 600 private_key.pem
+          ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_HOST \
+          "cd /var/www/cleanwhiskers.com && php bin/console importmap:install"
+
       - name: Clear Cache on Production Server
         run: |
           echo "$SSH_PRIVATE_KEY" > private_key.pem

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -81,6 +81,13 @@ jobs:
           ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_STAGING_HOST \
           "cd /var/www/staging.cleanwhiskers.com && php bin/console --no-interaction --allow-no-migration doctrine:migrations:migrate"
 
+      - name: Install Importmap on Staging Server
+        run: |
+          echo "$SSH_PRIVATE_KEY" > private_key.pem
+          chmod 600 private_key.pem
+          ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_STAGING_HOST \
+          "cd /var/www/staging.cleanwhiskers.com && php bin/console importmap:install"
+
       - name: Clear Cache on Staging Server
         run: |
           echo "$SSH_PRIVATE_KEY" > private_key.pem


### PR DESCRIPTION
## Summary
- ensure staging and production deploy workflows run `php bin/console importmap:install` before clearing Symfony cache

## Testing
- `./bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*
- `composer install` *(fails: failed to download dependencies due to missing GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68985cfe81d883228de4d1a40c2858dd