### PR TITLE
Implement core domain entities

### DIFF
--- a/src/Entity/BookingRequest.php
+++ b/src/Entity/BookingRequest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Entity;
+
+use App\Entity\Traits\Timestampable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'booking_request', indexes: [
+    new ORM\Index(name: 'idx_booking_groomer', columns: ['groomer_id']),
+    new ORM\Index(name: 'idx_booking_status', columns: ['status']),
+    new ORM\Index(name: 'idx_booking_created_at', columns: ['created_at'])
+])]
+class BookingRequest
+{
+    use Timestampable;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: GroomerProfile::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private GroomerProfile $groomer;
+
+    #[ORM\ManyToOne(targetEntity: User::class, nullable: true)]
+    private ?User $requester = null;
+
+    #[ORM\ManyToOne(targetEntity: Service::class, nullable: true)]
+    private ?Service $service = null;
+
+    #[ORM\ManyToOne(targetEntity: City::class, nullable: true)]
+    private ?City $city = null;
+
+    #[ORM\Column(length: 120)]
+    private string $name;
+
+    #[ORM\Column(length: 180)]
+    private string $email;
+
+    #[ORM\Column(length: 30, nullable: true)]
+    private ?string $phone = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $message = null;
+
+    #[ORM\Column(length: 20, options: ['default' => 'new'])]
+    private string $status = 'new';
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getGroomer(): GroomerProfile
+    {
+        return $this->groomer;
+    }
+
+    public function setGroomer(GroomerProfile $groomer): self
+    {
+        $this->groomer = $groomer;
+        return $this;
+    }
+
+    public function getRequester(): ?User
+    {
+        return $this->requester;
+    }
+
+    public function setRequester(?User $requester): self
+    {
+        $this->requester = $requester;
+        return $this;
+    }
+
+    public function getService(): ?Service
+    {
+        return $this->service;
+    }
+
+    public function setService(?Service $service): self
+    {
+        $this->service = $service;
+        return $this;
+    }
+
+    public function getCity(): ?City
+    {
+        return $this->city;
+    }
+
+    public function setCity(?City $city): self
+    {
+        $this->city = $city;
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    public function getPhone(): ?string
+    {
+        return $this->phone;
+    }
+
+    public function setPhone(?string $phone): self
+    {
+        $this->phone = $phone;
+        return $this;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function setMessage(?string $message): self
+    {
+        $this->message = $message;
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+}

--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Entity;
+
+use App\Entity\Traits\Timestampable;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\DBAL\Types\Types;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'city', uniqueConstraints: [
+    new ORM\UniqueConstraint(name: 'uniq_city_slug', columns: ['slug'])
+], indexes: [
+    new ORM\Index(name: 'idx_city_country_code', columns: ['country_code']),
+    new ORM\Index(name: 'idx_city_name', columns: ['name'])
+])]
+class City
+{
+    use Timestampable;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 120)]
+    private string $name;
+
+    #[ORM\Column(length: 140, unique: true)]
+    private string $slug;
+
+    #[ORM\Column(length: 100, nullable: true)]
+    private ?string $state = null;
+
+    #[ORM\Column(length: 2)]
+    private string $countryCode;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 7, nullable: true)]
+    private ?string $lat = null;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 7, nullable: true)]
+    private ?string $lng = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $seoIntro = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): self
+    {
+        $this->slug = $slug;
+        return $this;
+    }
+
+    public function getState(): ?string
+    {
+        return $this->state;
+    }
+
+    public function setState(?string $state): self
+    {
+        $this->state = $state;
+        return $this;
+    }
+
+    public function getCountryCode(): string
+    {
+        return $this->countryCode;
+    }
+
+    public function setCountryCode(string $countryCode): self
+    {
+        $this->countryCode = $countryCode;
+        return $this;
+    }
+
+    public function getLat(): ?string
+    {
+        return $this->lat;
+    }
+
+    public function setLat(?string $lat): self
+    {
+        $this->lat = $lat;
+        return $this;
+    }
+
+    public function getLng(): ?string
+    {
+        return $this->lng;
+    }
+
+    public function setLng(?string $lng): self
+    {
+        $this->lng = $lng;
+        return $this;
+    }
+
+    public function getSeoIntro(): ?string
+    {
+        return $this->seoIntro;
+    }
+
+    public function setSeoIntro(?string $seoIntro): self
+    {
+        $this->seoIntro = $seoIntro;
+        return $this;
+    }
+}

--- a/src/Entity/GroomerProfile.php
+++ b/src/Entity/GroomerProfile.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace App\Entity;
+
+use App\Entity\Traits\Timestampable;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'groomer_profile', uniqueConstraints: [
+    new ORM\UniqueConstraint(name: 'uniq_groomer_slug', columns: ['slug'])
+], indexes: [
+    new ORM\Index(name: 'idx_groomer_primary_city', columns: ['primary_city_id']),
+    new ORM\Index(name: 'idx_groomer_rating_avg', columns: ['rating_avg']),
+    new ORM\Index(name: 'idx_groomer_is_verified', columns: ['is_verified'])
+])]
+class GroomerProfile
+{
+    use Timestampable;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    private ?User $owner = null;
+
+    #[ORM\Column(length: 150)]
+    private string $name;
+
+    #[ORM\Column(length: 170, unique: true)]
+    private string $slug;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $bio = null;
+
+    #[ORM\Column(length: 30, nullable: true)]
+    private ?string $phone = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $website = null;
+
+    #[ORM\Column]
+    private bool $isMobile = true;
+
+    #[ORM\Column]
+    private bool $isVerified = false;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $address = null;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 7, nullable: true)]
+    private ?string $lat = null;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 7, nullable: true)]
+    private ?string $lng = null;
+
+    #[ORM\Column(type: Types::FLOAT, options: ['default' => 0])]
+    private float $ratingAvg = 0.0;
+
+    #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
+    private int $ratingCount = 0;
+
+    #[ORM\ManyToOne(targetEntity: City::class)]
+    private ?City $primaryCity = null;
+
+    #[ORM\OneToMany(mappedBy: 'groomer', targetEntity: GroomerService::class, cascade: ['persist', 'remove'])]
+    private Collection $services;
+
+    #[ORM\OneToMany(mappedBy: 'groomer', targetEntity: Review::class, cascade: ['remove'])]
+    private Collection $reviews;
+
+    public function __construct()
+    {
+        $this->services = new ArrayCollection();
+        $this->reviews = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getOwner(): ?User
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(?User $owner): self
+    {
+        $this->owner = $owner;
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): self
+    {
+        $this->slug = $slug;
+        return $this;
+    }
+
+    public function getBio(): ?string
+    {
+        return $this->bio;
+    }
+
+    public function setBio(?string $bio): self
+    {
+        $this->bio = $bio;
+        return $this;
+    }
+
+    public function getPhone(): ?string
+    {
+        return $this->phone;
+    }
+
+    public function setPhone(?string $phone): self
+    {
+        $this->phone = $phone;
+        return $this;
+    }
+
+    public function getWebsite(): ?string
+    {
+        return $this->website;
+    }
+
+    public function setWebsite(?string $website): self
+    {
+        $this->website = $website;
+        return $this;
+    }
+
+    public function isMobile(): bool
+    {
+        return $this->isMobile;
+    }
+
+    public function setIsMobile(bool $isMobile): self
+    {
+        $this->isMobile = $isMobile;
+        return $this;
+    }
+
+    public function isVerified(): bool
+    {
+        return $this->isVerified;
+    }
+
+    public function setIsVerified(bool $isVerified): self
+    {
+        $this->isVerified = $isVerified;
+        return $this;
+    }
+
+    public function getAddress(): ?string
+    {
+        return $this->address;
+    }
+
+    public function setAddress(?string $address): self
+    {
+        $this->address = $address;
+        return $this;
+    }
+
+    public function getLat(): ?string
+    {
+        return $this->lat;
+    }
+
+    public function setLat(?string $lat): self
+    {
+        $this->lat = $lat;
+        return $this;
+    }
+
+    public function getLng(): ?string
+    {
+        return $this->lng;
+    }
+
+    public function setLng(?string $lng): self
+    {
+        $this->lng = $lng;
+        return $this;
+    }
+
+    public function getRatingAvg(): float
+    {
+        return $this->ratingAvg;
+    }
+
+    public function setRatingAvg(float $ratingAvg): self
+    {
+        $this->ratingAvg = $ratingAvg;
+        return $this;
+    }
+
+    public function getRatingCount(): int
+    {
+        return $this->ratingCount;
+    }
+
+    public function setRatingCount(int $ratingCount): self
+    {
+        $this->ratingCount = $ratingCount;
+        return $this;
+    }
+
+    public function getPrimaryCity(): ?City
+    {
+        return $this->primaryCity;
+    }
+
+    public function setPrimaryCity(?City $primaryCity): self
+    {
+        $this->primaryCity = $primaryCity;
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, GroomerService>
+     */
+    public function getServices(): Collection
+    {
+        return $this->services;
+    }
+
+    public function addService(GroomerService $service): self
+    {
+        if (!$this->services->contains($service)) {
+            $this->services->add($service);
+            $service->setGroomer($this);
+        }
+        return $this;
+    }
+
+    public function removeService(GroomerService $service): self
+    {
+        if ($this->services->removeElement($service)) {
+            if ($service->getGroomer() === $this) {
+                $service->setGroomer($this);
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Review>
+     */
+    public function getReviews(): Collection
+    {
+        return $this->reviews;
+    }
+
+    public function addReview(Review $review): self
+    {
+        if (!$this->reviews->contains($review)) {
+            $this->reviews->add($review);
+            $review->setGroomer($this);
+        }
+        return $this;
+    }
+
+    public function removeReview(Review $review): self
+    {
+        if ($this->reviews->removeElement($review)) {
+            if ($review->getGroomer() === $this) {
+                $review->setGroomer($this);
+            }
+        }
+        return $this;
+    }
+}

--- a/src/Entity/GroomerService.php
+++ b/src/Entity/GroomerService.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\DBAL\Types\Types;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'groomer_service', uniqueConstraints: [
+    new ORM\UniqueConstraint(name: 'uniq_groomer_service', columns: ['groomer_id', 'service_id'])
+])]
+class GroomerService
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: GroomerProfile::class, inversedBy: 'services')]
+    #[ORM\JoinColumn(nullable: false)]
+    private GroomerProfile $groomer;
+
+    #[ORM\ManyToOne(targetEntity: Service::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private Service $service;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $priceFrom = null;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $durationMin = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getGroomer(): GroomerProfile
+    {
+        return $this->groomer;
+    }
+
+    public function setGroomer(GroomerProfile $groomer): self
+    {
+        $this->groomer = $groomer;
+        return $this;
+    }
+
+    public function getService(): Service
+    {
+        return $this->service;
+    }
+
+    public function setService(Service $service): self
+    {
+        $this->service = $service;
+        return $this;
+    }
+
+    public function getPriceFrom(): ?int
+    {
+        return $this->priceFrom;
+    }
+
+    public function setPriceFrom(?int $priceFrom): self
+    {
+        $this->priceFrom = $priceFrom;
+        return $this;
+    }
+
+    public function getDurationMin(): ?int
+    {
+        return $this->durationMin;
+    }
+
+    public function setDurationMin(?int $durationMin): self
+    {
+        $this->durationMin = $durationMin;
+        return $this;
+    }
+}

--- a/src/Entity/Review.php
+++ b/src/Entity/Review.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Entity;
+
+use App\Entity\Traits\Timestampable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'review', uniqueConstraints: [
+    new ORM\UniqueConstraint(name: 'uniq_review_author_groomer', columns: ['author_id', 'groomer_id'])
+], indexes: [
+    new ORM\Index(name: 'idx_review_groomer', columns: ['groomer_id']),
+    new ORM\Index(name: 'idx_review_created_at', columns: ['created_at']),
+    new ORM\Index(name: 'idx_review_status', columns: ['status'])
+])]
+class Review
+{
+    use Timestampable;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: GroomerProfile::class, inversedBy: 'reviews')]
+    #[ORM\JoinColumn(nullable: false)]
+    private GroomerProfile $groomer;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    private ?User $author = null;
+
+    #[ORM\Column(type: Types::SMALLINT)]
+    private int $rating;
+
+    #[ORM\Column(length: 140, nullable: true)]
+    private ?string $title = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $body = null;
+
+    #[ORM\Column(length: 20, options: ['default' => 'pending'])]
+    private string $status = 'pending';
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getGroomer(): GroomerProfile
+    {
+        return $this->groomer;
+    }
+
+    public function setGroomer(GroomerProfile $groomer): self
+    {
+        $this->groomer = $groomer;
+        return $this;
+    }
+
+    public function getAuthor(): ?User
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(?User $author): self
+    {
+        $this->author = $author;
+        return $this;
+    }
+
+    public function getRating(): int
+    {
+        return $this->rating;
+    }
+
+    public function setRating(int $rating): self
+    {
+        $this->rating = $rating;
+        return $this;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): self
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function getBody(): ?string
+    {
+        return $this->body;
+    }
+
+    public function setBody(?string $body): self
+    {
+        $this->body = $body;
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+}

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Entity;
+
+use App\Entity\Traits\Timestampable;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'service', uniqueConstraints: [
+    new ORM\UniqueConstraint(name: 'uniq_service_slug', columns: ['slug'])
+], indexes: [
+    new ORM\Index(name: 'idx_service_category', columns: ['category'])
+])]
+class Service
+{
+    use Timestampable;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 120)]
+    private string $name;
+
+    #[ORM\Column(length: 140, unique: true)]
+    private string $slug;
+
+    #[ORM\Column(length: 120, nullable: true)]
+    private ?string $category = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): self
+    {
+        $this->slug = $slug;
+        return $this;
+    }
+
+    public function getCategory(): ?string
+    {
+        return $this->category;
+    }
+
+    public function setCategory(?string $category): self
+    {
+        $this->category = $category;
+        return $this;
+    }
+}

--- a/src/Entity/Traits/Timestampable.php
+++ b/src/Entity/Traits/Timestampable.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Entity\Traits;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\DBAL\Types\Types;
+
+#[ORM\HasLifecycleCallbacks]
+trait Timestampable
+{
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    #[ORM\PrePersist]
+    public function setCreatedAtValue(): void
+    {
+        $now = new \DateTimeImmutable();
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    #[ORM\PreUpdate]
+    public function setUpdatedAtValue(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Entity;
+
+use App\Entity\Traits\Timestampable;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'user', uniqueConstraints: [
+    new ORM\UniqueConstraint(name: 'uniq_user_email', columns: ['email'])
+])]
+class User implements UserInterface, PasswordAuthenticatedUserInterface
+{
+    use Timestampable;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 180)]
+    private string $email;
+
+    #[ORM\Column(type: 'json')]
+    private array $roles = [];
+
+    #[ORM\Column]
+    private string $password;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    public function getRoles(): array
+    {
+        $roles = $this->roles;
+        $roles[] = 'ROLE_USER';
+        return array_unique($roles);
+    }
+
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+        return $this;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): self
+    {
+        $this->password = $password;
+        return $this;
+    }
+
+    public function eraseCredentials(): void
+    {
+        // If you store any temporary sensitive data, clear it here
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->email;
+    }
+}


### PR DESCRIPTION
## Summary
- add City, Service, User, GroomerProfile, GroomerService, Review, and BookingRequest entities
- introduce Timestampable trait for automatic created/updated tracking

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689863e5d7dc8322a1f97f339d8d7ca7