### PR TITLE
Implement SEO-safe slug generation

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,5 +16,8 @@ services:
     App\:
         resource: '../src/'
 
+    App\Util\Slugger:
+        autowire: true
+
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -4,9 +4,11 @@ namespace App\Entity;
 
 use App\Entity\Traits\Timestampable;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\String\Slugger\AsciiSlugger;
 use Doctrine\DBAL\Types\Types;
 
 #[ORM\Entity]
+#[ORM\HasLifecycleCallbacks]
 #[ORM\Table(name: 'city', uniqueConstraints: [
     new ORM\UniqueConstraint(name: 'uniq_city_slug', columns: ['slug'])
 ], indexes: [
@@ -68,6 +70,14 @@ class City
     {
         $this->slug = $slug;
         return $this;
+    }
+
+    #[ORM\PrePersist]
+    public function ensureSlug(): void
+    {
+        if (!$this->slug) {
+            $this->slug = (new AsciiSlugger())->slug($this->name)->lower()->toString();
+        }
     }
 
     public function getState(): ?string

--- a/src/Entity/GroomerProfile.php
+++ b/src/Entity/GroomerProfile.php
@@ -7,8 +7,10 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\String\Slugger\AsciiSlugger;
 
 #[ORM\Entity]
+#[ORM\HasLifecycleCallbacks]
 #[ORM\Table(name: 'groomer_profile', uniqueConstraints: [
     new ORM\UniqueConstraint(name: 'uniq_groomer_slug', columns: ['slug'])
 ], indexes: [
@@ -115,6 +117,14 @@ class GroomerProfile
     {
         $this->slug = $slug;
         return $this;
+    }
+
+    #[ORM\PrePersist]
+    public function ensureSlug(): void
+    {
+        if (!$this->slug) {
+            $this->slug = (new AsciiSlugger())->slug($this->name)->lower()->toString();
+        }
     }
 
     public function getBio(): ?string

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -4,8 +4,10 @@ namespace App\Entity;
 
 use App\Entity\Traits\Timestampable;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\String\Slugger\AsciiSlugger;
 
 #[ORM\Entity]
+#[ORM\HasLifecycleCallbacks]
 #[ORM\Table(name: 'service', uniqueConstraints: [
     new ORM\UniqueConstraint(name: 'uniq_service_slug', columns: ['slug'])
 ], indexes: [
@@ -54,6 +56,14 @@ class Service
     {
         $this->slug = $slug;
         return $this;
+    }
+
+    #[ORM\PrePersist]
+    public function ensureSlug(): void
+    {
+        if (!$this->slug) {
+            $this->slug = (new AsciiSlugger())->slug($this->name)->lower()->toString();
+        }
     }
 
     public function getCategory(): ?string

--- a/src/Util/Slugger.php
+++ b/src/Util/Slugger.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Util;
+
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+class Slugger
+{
+    private AsciiSlugger $slugger;
+
+    public function __construct()
+    {
+        $this->slugger = new AsciiSlugger();
+    }
+
+    public function slugify(string $string): string
+    {
+        return $this->slugger->slug($string)->lower()->toString();
+    }
+}


### PR DESCRIPTION
## Summary
- Add Slugger service to create lowercase ASCII slugs
- Generate slugs on entity creation without changing existing slugs

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68986718805483229eddee1b7c26c5f0