### PR TITLE
Add city & groomer routes with repository pagination

### DIFF
--- a/src/Controller/CityController.php
+++ b/src/Controller/CityController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\CityRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/cities')]
+class CityController extends AbstractController
+{
+    #[Route('/{slug}', name: 'city_show', methods: ['GET'])]
+    public function show(CityRepository $repo, string $slug): Response
+    {
+        $city = $repo->findOneBy(['slug' => $slug])
+            ?? throw $this->createNotFoundException();
+
+        return $this->render('city/show.html.twig', compact('city'));
+    }
+}

--- a/src/Controller/GroomerController.php
+++ b/src/Controller/GroomerController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\CityRepository;
+use App\Repository\GroomerProfileRepository;
+use App\Repository\ServiceRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/groomers')]
+class GroomerController extends AbstractController
+{
+    #[Route('/{slug}', name: 'groomer_show', methods: ['GET'])]
+    public function show(GroomerProfileRepository $repo, string $slug): Response
+    {
+        $groomer = $repo->findOneBy(['slug' => $slug])
+            ?? throw $this->createNotFoundException();
+
+        return $this->render('groomer/show.html.twig', compact('groomer'));
+    }
+
+    #[Route('/{citySlug}/{serviceSlug}', name: 'groomer_list_city_service', methods: ['GET'])]
+    public function list(
+        Request $req,
+        CityRepository $cities,
+        ServiceRepository $services,
+        GroomerProfileRepository $groomers,
+        string $citySlug,
+        string $serviceSlug
+    ): Response {
+        $city = $cities->findOneBy(['slug' => $citySlug])
+            ?? throw $this->createNotFoundException();
+        $service = $services->findOneBy(['slug' => $serviceSlug])
+            ?? throw $this->createNotFoundException();
+        $page = max(1, (int) $req->query->get('page', 1));
+        $sort = $req->query->get('sort', 'rating'); // rating|reviews|name
+
+        $pager = $groomers->paginatedByCityAndService($city, $service, $page, $sort);
+
+        return $this->render('groomer/list.html.twig', compact('city', 'service', 'pager', 'sort'));
+    }
+}

--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -3,11 +3,12 @@
 namespace App\Entity;
 
 use App\Entity\Traits\Timestampable;
+use App\Repository\CityRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 use Doctrine\DBAL\Types\Types;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: CityRepository::class)]
 #[ORM\HasLifecycleCallbacks]
 #[ORM\Table(name: 'city', uniqueConstraints: [
     new ORM\UniqueConstraint(name: 'uniq_city_slug', columns: ['slug'])

--- a/src/Entity/GroomerProfile.php
+++ b/src/Entity/GroomerProfile.php
@@ -3,20 +3,19 @@
 namespace App\Entity;
 
 use App\Entity\Traits\Timestampable;
+use App\Repository\GroomerProfileRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: GroomerProfileRepository::class)]
 #[ORM\HasLifecycleCallbacks]
 #[ORM\Table(name: 'groomer_profile', uniqueConstraints: [
     new ORM\UniqueConstraint(name: 'uniq_groomer_slug', columns: ['slug'])
 ], indexes: [
-    new ORM\Index(name: 'idx_groomer_primary_city', columns: ['primary_city_id']),
-    new ORM\Index(name: 'idx_groomer_rating_avg', columns: ['rating_avg']),
-    new ORM\Index(name: 'idx_groomer_is_verified', columns: ['is_verified'])
+    new ORM\Index(name: 'idx_groomer_search', columns: ['primary_city_id', 'is_verified', 'rating_avg', 'rating_count'])
 ])]
 class GroomerProfile
 {

--- a/src/Entity/GroomerService.php
+++ b/src/Entity/GroomerService.php
@@ -8,6 +8,8 @@ use Doctrine\DBAL\Types\Types;
 #[ORM\Entity]
 #[ORM\Table(name: 'groomer_service', uniqueConstraints: [
     new ORM\UniqueConstraint(name: 'uniq_groomer_service', columns: ['groomer_id', 'service_id'])
+], indexes: [
+    new ORM\Index(name: 'idx_service_groomer', columns: ['service_id', 'groomer_id'])
 ])]
 class GroomerService
 {

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -3,10 +3,11 @@
 namespace App\Entity;
 
 use App\Entity\Traits\Timestampable;
+use App\Repository\ServiceRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: ServiceRepository::class)]
 #[ORM\HasLifecycleCallbacks]
 #[ORM\Table(name: 'service', uniqueConstraints: [
     new ORM\UniqueConstraint(name: 'uniq_service_slug', columns: ['slug'])

--- a/src/Repository/CityRepository.php
+++ b/src/Repository/CityRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\City;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class CityRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, City::class);
+    }
+}

--- a/src/Repository/GroomerProfileRepository.php
+++ b/src/Repository/GroomerProfileRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Service;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Persistence\ManagerRegistry;
+
+class GroomerProfileRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, GroomerProfile::class);
+    }
+
+    public function paginatedByCityAndService(City $city, Service $service, int $page, string $sort): Paginator
+    {
+        $qb = $this->createQueryBuilder('g')
+            ->innerJoin('g.services', 'gs')
+            ->andWhere('g.primaryCity = :city')->setParameter('city', $city)
+            ->andWhere('gs.service = :service')->setParameter('service', $service)
+            ->andWhere('g.isVerified = true');
+
+        $order = match ($sort) {
+            'name'    => ['g.name' => 'ASC'],
+            'reviews' => ['g.ratingCount' => 'DESC', 'g.ratingAvg' => 'DESC'],
+            default   => ['g.ratingAvg' => 'DESC', 'g.ratingCount' => 'DESC'],
+        };
+        foreach ($order as $field => $direction) {
+            $qb->addOrderBy($field, $direction);
+        }
+
+        return $this->paginate($qb, $page, 20);
+    }
+
+    private function paginate(QueryBuilder $qb, int $page, int $limit): Paginator
+    {
+        $query = $qb->getQuery()
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit);
+
+        return new Paginator($query);
+    }
+}

--- a/src/Repository/ServiceRepository.php
+++ b/src/Repository/ServiceRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Service;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class ServiceRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Service::class);
+    }
+}


### PR DESCRIPTION
## Summary
- add city and groomer controllers with attribute routes
- paginate groomer listings with sorting in repository
- wire entities to dedicated repositories and add supporting DB indexes

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68986a2dea948322a443a0a13011d8f5