### PR TITLE
feat: add user entity

### DIFF
--- a/migrations/Version20250810150057.php
+++ b/migrations/Version20250810150057.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250810150057 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create user table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($this->connection->getDatabasePlatform()->getName() === 'sqlite') {
+            $this->addSql('CREATE TABLE "user" (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, email VARCHAR(180) NOT NULL, roles CLOB NOT NULL, password VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL)');
+            $this->addSql('CREATE UNIQUE INDEX UNIQ_8D93D649E7927C74 ON "user" (email)');
+
+            return;
+        }
+
+        $this->addSql("CREATE TABLE `user` (id INT AUTO_INCREMENT NOT NULL, email VARCHAR(180) NOT NULL, roles JSON NOT NULL, password VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', UNIQUE INDEX UNIQ_8D93D649E7927C74 (email), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB");
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($this->connection->getDatabasePlatform()->getName() === 'sqlite') {
+            $this->addSql('DROP TABLE "user"');
+        } else {
+            $this->addSql('DROP TABLE `user`');
+        }
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\UserRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+#[ORM\Entity(repositoryClass: UserRepository::class)]
+#[ORM\Table(name: '`user`')]
+class User implements UserInterface, PasswordAuthenticatedUserInterface
+{
+    public const ROLE_GROOMER = 'ROLE_GROOMER';
+    public const ROLE_PET_OWNER = 'ROLE_PET_OWNER';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 180, unique: true)]
+    private ?string $email = null;
+
+    #[ORM\Column(type: Types::JSON)]
+    private array $roles = [];
+
+    #[ORM\Column]
+    private ?string $password = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct()
+    {
+        $this->roles = [];
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+
+        return $this;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): self
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return (string) $this->email;
+    }
+
+    public function eraseCredentials(): void
+    {
+        // No-op: password is already hashed
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<User>
+ */
+class UserRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, User::class);
+    }
+
+    public function save(User $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->persist($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function remove(User $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->remove($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+}

--- a/tests/Integration/Repository/UserRepositoryTest.php
+++ b/tests/Integration/Repository/UserRepositoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class UserRepositoryTest extends KernelTestCase
+{
+    private UserRepository $repository;
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        $this->entityManager = $container->get(EntityManagerInterface::class);
+        $this->repository = $container->get(UserRepository::class);
+    }
+
+    public function testUniqueEmailIsEnforced(): void
+    {
+        $user1 = (new User())
+            ->setEmail('foo@example.com')
+            ->setPassword('hash');
+        $this->repository->save($user1, true);
+
+        $user2 = (new User())
+            ->setEmail('foo@example.com')
+            ->setPassword('hash');
+        $this->repository->save($user2);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+        $this->entityManager->flush();
+    }
+}

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+class UserTest extends TestCase
+{
+    public function testNewUserHasEmptyRoles(): void
+    {
+        $user = new User();
+        self::assertSame([], $user->getRoles());
+    }
+
+    public function testCreatedAtIsInitialized(): void
+    {
+        $user = new User();
+        self::assertInstanceOf(\DateTimeImmutable::class, $user->getCreatedAt());
+    }
+}


### PR DESCRIPTION
## Summary
- add User entity with roles and creation timestamp
- persist users via repository and migration
- cover user defaults and unique email with tests

## Testing
- `PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --diff`
- `vendor/bin/phpstan analyse --memory-limit=1G` *(fails: File '/workspace/cleanwhiskers/vendor/phpstan/phpstan-doctrine/extension.neon' is missing or is not readable.)*
- `APP_ENV=test DATABASE_URL="sqlite:///%kernel.project_dir%/var/test.db" ./vendor/bin/phpunit --testdox`
- `APP_ENV=test DATABASE_URL="sqlite:///%kernel.project_dir%/var/test.db" ./vendor/bin/phpunit --testsuite Integration` *(fails: No tests executed!)*
- `make setup` *(fails: No rule to make target 'setup'. Stop.)*
- `make test -k` *(fails: No rule to make target 'test'.)*

------
https://chatgpt.com/codex/tasks/task_e_6898b3924ca0832289a4e27fd8a8d084