### PR TITLE
feat: add City entity and repository

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -12,7 +12,7 @@ CleanWhiskers is an early-stage Symfony application. The codebase currently expo
 
 ## Current Features
 - `HomepageController` maps `/` to `templates/homepage/index.html.twig`, rendering a welcome message.
-- No domain entities or repositories have been defined yet.
+- `City` entity stores a city's name, unique slug, and creation timestamp, accessed via `CityRepository::findOneBySlug()`.
 - `AppFixtures` class exists but loads no data.
 
 ## Development Setup
@@ -23,7 +23,7 @@ CleanWhiskers is an early-stage Symfony application. The codebase currently expo
 
 ## Testing & QA
 - Quality scripts are expected: `composer lint:php`, `composer stan`, and `composer test`
-- Unit tests bootstrap via `tests/bootstrap.php`; no test cases implemented yet
+- Unit and integration tests cover the `City` entity and repository
 
 ## Notes
 - `PROJECT_CONTEXT.md` should be updated whenever project state changes

--- a/migrations/Version20250810150028.php
+++ b/migrations/Version20250810150028.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250810150028 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE city (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name VARCHAR(255) NOT NULL, slug VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_2D5B0234989D9B62 ON city (slug)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE city');
+    }
+}

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -18,8 +18,11 @@
     </php>
 
     <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>tests</directory>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
 

--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\CityRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: CityRepository::class)]
+#[ORM\Table(name: 'city')]
+#[ORM\Index(name: 'idx_city_slug', fields: ['slug'])]
+class City
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private string $name;
+
+    #[ORM\Column(length: 255, unique: true)]
+    private string $slug;
+
+    #[ORM\Column(name: 'created_at', type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(string $name, string $slug)
+    {
+        $this->name = $name;
+        $this->slug = $slug;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/src/Repository/CityRepository.php
+++ b/src/Repository/CityRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\City;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class CityRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, City::class);
+    }
+
+    public function findOneBySlug(string $slug): ?City
+    {
+        return $this->findOneBy(['slug' => $slug]);
+    }
+}

--- a/tests/Integration/Repository/CityRepositoryTest.php
+++ b/tests/Integration/Repository/CityRepositoryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository;
+
+use App\Repository\CityRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class CityRepositoryTest extends KernelTestCase
+{
+    public function testFindOneBySlugReturnsNullWhenNoCityExists(): void
+    {
+        self::bootKernel();
+
+        /** @var CityRepository $repository */
+        $repository = self::getContainer()->get(CityRepository::class);
+
+        self::assertNull($repository->findOneBySlug('sofia'));
+    }
+}

--- a/tests/Unit/Entity/CityTest.php
+++ b/tests/Unit/Entity/CityTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\City;
+use PHPUnit\Framework\TestCase;
+
+class CityTest extends TestCase
+{
+    public function testConstructSetsProperties(): void
+    {
+        $city = new City('Sofia', 'sofia');
+
+        self::assertSame('Sofia', $city->getName());
+        self::assertSame('sofia', $city->getSlug());
+        self::assertInstanceOf(\DateTimeImmutable::class, $city->getCreatedAt());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce City entity with unique slug and timestamp
- add CityRepository with findOneBySlug
- create migration, tests, and project context updates

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --diff`
- `composer fix:php` (fails: There are no commands defined in the "fix" namespace.)
- `composer stan` (fails: Command "stan" is not defined.)
- `vendor/bin/phpstan analyse` (fails: extension.neon is missing)
- `composer test` (fails: Command "test" is not defined.)
- `APP_ENV=test DATABASE_URL='sqlite:///%kernel.project_dir%/var/test.db' php bin/console doctrine:migrations:migrate --no-interaction`
- `APP_ENV=test DATABASE_URL='sqlite:///%kernel.project_dir%/var/test.db' vendor/bin/phpunit --testdox`
- `APP_ENV=test DATABASE_URL='sqlite:///%kernel.project_dir%/var/test.db' vendor/bin/phpunit --testsuite integration`
- `APP_ENV=test DATABASE_URL='sqlite:///%kernel.project_dir%/var/test.db' bin/phpunit --testsuite integration`
- `make test -k` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_6898b37861c88322a636f712d4050a38