### PR TITLE
feat: add groomer profile entity and repository

### DIFF
--- a/migrations/Version20250810150100.php
+++ b/migrations/Version20250810150100.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250810150100 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create groomer_profile table with foreign keys to user and city';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->createTable('groomer_profile');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('user_id', Types::INTEGER);
+        $table->addColumn('city_id', Types::INTEGER);
+        $table->addColumn('business_name', Types::STRING, ['length' => 255]);
+        $table->addColumn('slug', Types::STRING, ['length' => 255]);
+        $table->addColumn('about', Types::TEXT);
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['slug'], 'UNIQ_GROOMER_PROFILE_SLUG');
+        $table->addIndex(['slug'], 'idx_groomer_profile_slug');
+        $table->addForeignKeyConstraint('`user`', ['user_id'], ['id'], ['onDelete' => 'CASCADE']);
+        $table->addForeignKeyConstraint('city', ['city_id'], ['id'], ['onDelete' => 'CASCADE']);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable('groomer_profile');
+    }
+}

--- a/src/Entity/GroomerProfile.php
+++ b/src/Entity/GroomerProfile.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\GroomerProfileRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: GroomerProfileRepository::class)]
+#[ORM\Table(name: 'groomer_profile')]
+#[ORM\Index(name: 'idx_groomer_profile_slug', fields: ['slug'])]
+class GroomerProfile
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    /** @phpstan-ignore-next-line */
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private User $user;
+
+    #[ORM\ManyToOne(targetEntity: City::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private City $city;
+
+    #[ORM\Column(name: 'business_name', length: 255)]
+    private string $businessName;
+
+    #[ORM\Column(length: 255, unique: true)]
+    private string $slug;
+
+    #[ORM\Column(type: 'text')]
+    private string $about;
+
+    public function __construct(User $user, City $city, string $businessName, string $slug, string $about)
+    {
+        if (!in_array(User::ROLE_GROOMER, $user->getRoles(), true)) {
+            throw new \InvalidArgumentException('User must have groomer role.');
+        }
+
+        $this->user = $user;
+        $this->city = $city;
+        $this->businessName = $businessName;
+        $this->slug = $slug;
+        $this->about = $about;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function getCity(): City
+    {
+        return $this->city;
+    }
+
+    public function getBusinessName(): string
+    {
+        return $this->businessName;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getAbout(): string
+    {
+        return $this->about;
+    }
+}

--- a/src/Repository/GroomerProfileRepository.php
+++ b/src/Repository/GroomerProfileRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\GroomerProfile;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<GroomerProfile>
+ */
+class GroomerProfileRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, GroomerProfile::class);
+    }
+
+    public function findOneBySlug(string $slug): ?GroomerProfile
+    {
+        return $this->findOneBy(['slug' => $slug]);
+    }
+}

--- a/tests/Integration/Repository/GroomerProfileRepositoryTest.php
+++ b/tests/Integration/Repository/GroomerProfileRepositoryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\User;
+use App\Repository\GroomerProfileRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class GroomerProfileRepositoryTest extends KernelTestCase
+{
+    private GroomerProfileRepository $repository;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+        $this->em = $container->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $this->repository = $this->em->getRepository(GroomerProfile::class);
+    }
+
+    public function testFindOneBySlug(): void
+    {
+        $user = (new User())
+            ->setEmail('groomer@example.com')
+            ->setPassword('hash')
+            ->setRoles([User::ROLE_GROOMER]);
+        $city = new City('Sofia', 'sofia');
+
+        $this->em->persist($user);
+        $this->em->persist($city);
+        $this->em->flush();
+
+        $profile = new GroomerProfile($user, $city, 'Best Groomers', 'best-groomers', 'About us');
+        $this->em->persist($profile);
+        $this->em->flush();
+        $this->em->clear();
+
+        $found = $this->repository->findOneBySlug('best-groomers');
+        self::assertNotNull($found);
+        self::assertSame('Best Groomers', $found->getBusinessName());
+    }
+}

--- a/tests/Unit/Entity/GroomerProfileTest.php
+++ b/tests/Unit/Entity/GroomerProfileTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+final class GroomerProfileTest extends TestCase
+{
+    public function testConstructSetsProperties(): void
+    {
+        $user = (new User())
+            ->setEmail('groomer@example.com')
+            ->setRoles([User::ROLE_GROOMER])
+            ->setPassword('hash');
+        $city = new City('Sofia', 'sofia');
+
+        $profile = new GroomerProfile($user, $city, 'Best Groomers', 'best-groomers', 'About us');
+
+        self::assertSame($user, $profile->getUser());
+        self::assertSame($city, $profile->getCity());
+        self::assertSame('Best Groomers', $profile->getBusinessName());
+        self::assertSame('best-groomers', $profile->getSlug());
+        self::assertSame('About us', $profile->getAbout());
+    }
+
+    public function testConstructorRejectsNonGroomerUser(): void
+    {
+        $user = (new User())
+            ->setEmail('owner@example.com')
+            ->setRoles([User::ROLE_PET_OWNER])
+            ->setPassword('hash');
+        $city = new City('Sofia', 'sofia');
+
+        $this->expectException(\InvalidArgumentException::class);
+        new GroomerProfile($user, $city, 'Biz', 'biz', 'About');
+    }
+}


### PR DESCRIPTION
## Summary
- add GroomerProfile entity tied to User and City
- support slug lookups via GroomerProfileRepository
- create migration and tests for groomer profiles

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`
- `php bin/phpunit --testsuite integration`
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6898bd8271c48322abb19e3d29dc4223