### PR TITLE
Add service relation to groomer profiles

### DIFF
--- a/migrations/Version20250810150105.php
+++ b/migrations/Version20250810150105.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250810150105 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create groomer_profile_service join table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->createTable('groomer_profile_service');
+        $table->addColumn('groomer_profile_id', Types::INTEGER);
+        $table->addColumn('service_id', Types::INTEGER);
+        $table->setPrimaryKey(['groomer_profile_id', 'service_id']);
+        $table->addIndex(['groomer_profile_id'], 'IDX_GROOMER_PROFILE_SERVICE_GROOMER_PROFILE_ID');
+        $table->addIndex(['service_id'], 'IDX_GROOMER_PROFILE_SERVICE_SERVICE_ID');
+        $table->addForeignKeyConstraint('groomer_profile', ['groomer_profile_id'], ['id'], ['onDelete' => 'CASCADE']);
+        $table->addForeignKeyConstraint('service', ['service_id'], ['id'], ['onDelete' => 'CASCADE']);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable('groomer_profile_service');
+    }
+}

--- a/src/Entity/GroomerProfile.php
+++ b/src/Entity/GroomerProfile.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use App\Repository\GroomerProfileRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: GroomerProfileRepository::class)]
@@ -35,6 +37,11 @@ class GroomerProfile
     #[ORM\Column(type: 'text')]
     private string $about;
 
+    /** @var Collection<int, Service> */
+    #[ORM\ManyToMany(targetEntity: Service::class)]
+    #[ORM\JoinTable(name: 'groomer_profile_service')]
+    private Collection $services;
+
     public function __construct(User $user, City $city, string $businessName, string $slug, string $about)
     {
         if (!in_array(User::ROLE_GROOMER, $user->getRoles(), true)) {
@@ -46,6 +53,7 @@ class GroomerProfile
         $this->businessName = $businessName;
         $this->slug = $slug;
         $this->about = $about;
+        $this->services = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -76,5 +84,29 @@ class GroomerProfile
     public function getAbout(): string
     {
         return $this->about;
+    }
+
+    /**
+     * @return Collection<int, Service>
+     */
+    public function getServices(): Collection
+    {
+        return $this->services;
+    }
+
+    public function addService(Service $service): self
+    {
+        if (!$this->services->contains($service)) {
+            $this->services->add($service);
+        }
+
+        return $this;
+    }
+
+    public function removeService(Service $service): self
+    {
+        $this->services->removeElement($service);
+
+        return $this;
     }
 }

--- a/tests/Unit/Entity/GroomerProfileServicesTest.php
+++ b/tests/Unit/Entity/GroomerProfileServicesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Service;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+final class GroomerProfileServicesTest extends TestCase
+{
+    public function testAddAndRemoveServices(): void
+    {
+        $user = (new User())
+            ->setEmail('groomer@example.com')
+            ->setRoles([User::ROLE_GROOMER])
+            ->setPassword('hash');
+        $city = new City('Sofia', 'sofia');
+
+        $profile = new GroomerProfile($user, $city, 'Best Groomers', 'best-groomers', 'About');
+        $service = (new Service())
+            ->setName('Bath')
+            ->setSlug('bath');
+
+        $profile->addService($service);
+        self::assertTrue($profile->getServices()->contains($service));
+
+        $profile->removeService($service);
+        self::assertFalse($profile->getServices()->contains($service));
+    }
+}


### PR DESCRIPTION
## Summary
- allow groomer profiles to reference many services with helper methods
- create join table to link groomer profiles and services
- cover service linking behavior with new unit test

## Testing
- `PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix src/Entity/GroomerProfile.php tests/Unit/Entity/GroomerProfileServicesTest.php migrations/Version20250810150105.php --diff --config=.php-cs-fixer.dist.php`
- `composer stan`
- `./vendor/bin/phpunit tests/Unit/Entity/GroomerProfileServicesTest.php`
- `bin/phpunit --testsuite integration`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6898c02565f883229dd724a12879173b