### PR TITLE
feat: add booking request entity

### DIFF
--- a/migrations/Version20250810160647.php
+++ b/migrations/Version20250810160647.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250810160647 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create booking_request table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->createTable('booking_request');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('groomer_id', Types::INTEGER);
+        $table->addColumn('pet_owner_id', Types::INTEGER);
+        $table->addColumn('service_id', Types::INTEGER, ['notnull' => false]);
+        $table->addColumn('status', Types::STRING, ['length' => 20]);
+        $table->addColumn('requested_at', Types::DATETIME_IMMUTABLE);
+        $table->addColumn('notes', Types::TEXT, ['notnull' => false]);
+        $table->setPrimaryKey(['id']);
+        $table->addIndex(['service_id'], 'idx_booking_request_service');
+        $table->addIndex(['groomer_id'], 'idx_booking_request_groomer');
+        $table->addIndex(['pet_owner_id'], 'idx_booking_request_pet_owner');
+        $table->addIndex(['status'], 'idx_booking_request_status');
+        $table->addForeignKeyConstraint('groomer_profile', ['groomer_id'], ['id'], ['onDelete' => 'CASCADE']);
+        $table->addForeignKeyConstraint('`user`', ['pet_owner_id'], ['id'], ['onDelete' => 'CASCADE']);
+        $table->addForeignKeyConstraint('service', ['service_id'], ['id'], ['onDelete' => 'SET NULL']);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable('booking_request');
+    }
+}

--- a/src/Entity/BookingRequest.php
+++ b/src/Entity/BookingRequest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\BookingRequestRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: BookingRequestRepository::class)]
+#[ORM\Table(name: 'booking_request')]
+#[ORM\Index(name: 'idx_booking_request_groomer', columns: ['groomer_id'])]
+#[ORM\Index(name: 'idx_booking_request_pet_owner', columns: ['pet_owner_id'])]
+#[ORM\Index(name: 'idx_booking_request_status', columns: ['status'])]
+class BookingRequest
+{
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_ACCEPTED = 'accepted';
+    public const STATUS_DECLINED = 'declined';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    /** @phpstan-ignore-next-line */
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: GroomerProfile::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private GroomerProfile $groomer;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'pet_owner_id', referencedColumnName: 'id', nullable: false)]
+    private User $petOwner;
+
+    #[ORM\ManyToOne(targetEntity: Service::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?Service $service = null;
+
+    #[ORM\Column(length: 20)]
+    private string $status = self::STATUS_PENDING;
+
+    #[ORM\Column(name: 'requested_at')]
+    private \DateTimeImmutable $requestedAt;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $notes = null;
+
+    public function __construct(GroomerProfile $groomer, User $petOwner)
+    {
+        $this->groomer = $groomer;
+        $this->petOwner = $petOwner;
+        $this->requestedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getGroomer(): GroomerProfile
+    {
+        return $this->groomer;
+    }
+
+    public function getPetOwner(): User
+    {
+        return $this->petOwner;
+    }
+
+    public function getService(): ?Service
+    {
+        return $this->service;
+    }
+
+    public function setService(?Service $service): self
+    {
+        $this->service = $service;
+
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $allowed = [self::STATUS_PENDING, self::STATUS_ACCEPTED, self::STATUS_DECLINED];
+        if (!in_array($status, $allowed, true)) {
+            throw new \InvalidArgumentException('Invalid status.');
+        }
+
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getRequestedAt(): \DateTimeImmutable
+    {
+        return $this->requestedAt;
+    }
+
+    public function getNotes(): ?string
+    {
+        return $this->notes;
+    }
+
+    public function setNotes(?string $notes): self
+    {
+        $this->notes = $notes;
+
+        return $this;
+    }
+}

--- a/src/Repository/BookingRequestRepository.php
+++ b/src/Repository/BookingRequestRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\BookingRequest;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<BookingRequest>
+ */
+class BookingRequestRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, BookingRequest::class);
+    }
+}

--- a/tests/Unit/Entity/BookingRequestTest.php
+++ b/tests/Unit/Entity/BookingRequestTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\BookingRequest;
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Service;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+final class BookingRequestTest extends TestCase
+{
+    public function testGettersAndSetters(): void
+    {
+        $groomerUser = (new User())
+            ->setEmail('groomer@example.com')
+            ->setRoles([User::ROLE_GROOMER])
+            ->setPassword('hash');
+        $city = new City('Sofia', 'sofia');
+        $groomer = new GroomerProfile($groomerUser, $city, 'Biz', 'biz', 'About');
+
+        $owner = (new User())
+            ->setEmail('owner@example.com')
+            ->setRoles([User::ROLE_PET_OWNER])
+            ->setPassword('hash');
+
+        $request = new BookingRequest($groomer, $owner);
+
+        self::assertSame($groomer, $request->getGroomer());
+        self::assertSame($owner, $request->getPetOwner());
+        self::assertSame(BookingRequest::STATUS_PENDING, $request->getStatus());
+        self::assertInstanceOf(\DateTimeImmutable::class, $request->getRequestedAt());
+
+        $service = (new Service())
+            ->setName('Bath')
+            ->setSlug('bath');
+        $request->setService($service);
+        $request->setNotes('Please be gentle');
+        $request->setStatus(BookingRequest::STATUS_ACCEPTED);
+
+        self::assertSame($service, $request->getService());
+        self::assertSame('Please be gentle', $request->getNotes());
+        self::assertSame(BookingRequest::STATUS_ACCEPTED, $request->getStatus());
+    }
+
+    public function testSetStatusRejectsInvalid(): void
+    {
+        $groomerUser = (new User())
+            ->setEmail('groomer@example.com')
+            ->setRoles([User::ROLE_GROOMER])
+            ->setPassword('hash');
+        $city = new City('Sofia', 'sofia');
+        $groomer = new GroomerProfile($groomerUser, $city, 'Biz', 'biz', 'About');
+
+        $owner = (new User())
+            ->setEmail('owner@example.com')
+            ->setRoles([User::ROLE_PET_OWNER])
+            ->setPassword('hash');
+
+        $request = new BookingRequest($groomer, $owner);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $request->setStatus('foo');
+    }
+}


### PR DESCRIPTION
## Summary
- add BookingRequest entity with status, relations, and notes
- store requests via BookingRequestRepository
- create migration with indexes and FK constraints
- cover entity behavior with unit tests

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*
- `composer fix:php`
- `composer stan`
- `composer test`
- `APP_ENV=test bin/phpunit --testsuite integration`


------
https://chatgpt.com/codex/tasks/task_e_6898c041a208832296753638d400cd07