### PR TITLE
feat: add automatic slug generation

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,5 +16,6 @@ services:
     App\:
         resource: '../src/'
 
+
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/Domain/Shared/SluggerTrait.php
+++ b/src/Domain/Shared/SluggerTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Shared;
+
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+trait SluggerTrait
+{
+    public function refreshSlugFrom(string $source): void
+    {
+        $this->slug = (new AsciiSlugger())->slug($source)->lower()->toString();
+    }
+}

--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Domain\Shared\SluggerTrait;
 use App\Repository\CityRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
@@ -13,6 +14,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(name: 'idx_city_slug', fields: ['slug'])]
 class City
 {
+    use SluggerTrait;
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -23,12 +25,12 @@ class City
     private string $name;
 
     #[ORM\Column(length: 255, unique: true)]
-    private string $slug;
+    private string $slug = '';
 
     #[ORM\Column(name: 'created_at', type: Types::DATETIME_IMMUTABLE)]
     private \DateTimeImmutable $createdAt;
 
-    public function __construct(string $name, string $slug)
+    public function __construct(string $name, string $slug = '')
     {
         $this->name = $name;
         $this->slug = $slug;
@@ -48,6 +50,13 @@ class City
     public function getSlug(): string
     {
         return $this->slug;
+    }
+
+    public function setSlug(string $slug): self
+    {
+        $this->slug = $slug;
+
+        return $this;
     }
 
     public function getCreatedAt(): \DateTimeImmutable

--- a/src/Entity/GroomerProfile.php
+++ b/src/Entity/GroomerProfile.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Domain\Shared\SluggerTrait;
 use App\Repository\GroomerProfileRepository;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -12,6 +13,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(name: 'idx_groomer_profile_slug', fields: ['slug'])]
 class GroomerProfile
 {
+    use SluggerTrait;
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -30,12 +32,12 @@ class GroomerProfile
     private string $businessName;
 
     #[ORM\Column(length: 255, unique: true)]
-    private string $slug;
+    private string $slug = '';
 
     #[ORM\Column(type: 'text')]
     private string $about;
 
-    public function __construct(User $user, City $city, string $businessName, string $slug, string $about)
+    public function __construct(User $user, City $city, string $businessName, string $about, string $slug = '')
     {
         if (!in_array(User::ROLE_GROOMER, $user->getRoles(), true)) {
             throw new \InvalidArgumentException('User must have groomer role.');
@@ -44,8 +46,8 @@ class GroomerProfile
         $this->user = $user;
         $this->city = $city;
         $this->businessName = $businessName;
-        $this->slug = $slug;
         $this->about = $about;
+        $this->slug = $slug;
     }
 
     public function getId(): ?int
@@ -71,6 +73,13 @@ class GroomerProfile
     public function getSlug(): string
     {
         return $this->slug;
+    }
+
+    public function setSlug(string $slug): self
+    {
+        $this->slug = $slug;
+
+        return $this;
     }
 
     public function getAbout(): string

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Domain\Shared\SluggerTrait;
 use App\Repository\ServiceRepository;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -11,6 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Table(name: 'service')]
 class Service
 {
+    use SluggerTrait;
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -21,7 +23,7 @@ class Service
     private string $name;
 
     #[ORM\Column(length: 255, unique: true)]
-    private string $slug;
+    private string $slug = '';
 
     public function getId(): ?int
     {

--- a/src/Infrastructure/Doctrine/SlugListener.php
+++ b/src/Infrastructure/Doctrine/SlugListener.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Doctrine;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Service;
+use App\Repository\CityRepository;
+use App\Repository\GroomerProfileRepository;
+use App\Repository\ServiceRepository;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Query;
+
+#[AsDoctrineListener(event: Events::prePersist)]
+#[AsDoctrineListener(event: Events::preUpdate)]
+class SlugListener
+{
+    public function __construct(
+        private CityRepository $cityRepository,
+        private ServiceRepository $serviceRepository,
+        private GroomerProfileRepository $groomerProfileRepository,
+    ) {
+    }
+
+    public function prePersist(PrePersistEventArgs $args): void
+    {
+        $this->handleEvent($args->getObject());
+    }
+
+    public function preUpdate(PreUpdateEventArgs $args): void
+    {
+        $this->handleEvent($args->getObject());
+    }
+
+    private function handleEvent(object $entity): void
+    {
+        if ($entity instanceof City) {
+            $this->ensureSlug($entity, $this->cityRepository, $entity->getName());
+        } elseif ($entity instanceof Service) {
+            $this->ensureSlug($entity, $this->serviceRepository, $entity->getName());
+        } elseif ($entity instanceof GroomerProfile) {
+            $this->ensureSlug($entity, $this->groomerProfileRepository, $entity->getBusinessName());
+        }
+    }
+
+    private function ensureSlug(
+        object $entity,
+        CityRepository|ServiceRepository|GroomerProfileRepository $repository,
+        string $source,
+    ): void {
+        if (method_exists($entity, 'getSlug') && method_exists($entity, 'refreshSlugFrom')) {
+            /** @var string $slug */
+            $slug = $entity->getSlug();
+            if ('' === $slug) {
+                $entity->refreshSlugFrom($source);
+                /** @var string $slug */
+                $slug = $entity->getSlug();
+            }
+
+            $existing = $repository->createQueryBuilder('e')
+                ->where('e.slug = :slug')
+                ->setParameter('slug', $slug)
+                ->getQuery()
+                ->setMaxResults(1)
+                ->setHint(Query::HINT_REFRESH, true)
+                ->getOneOrNullResult();
+
+            if (null !== $existing && $existing !== $entity) {
+                throw new \InvalidArgumentException('Slug already exists.');
+            }
+        }
+    }
+}

--- a/tests/Integration/Infrastructure/SlugListenerTest.php
+++ b/tests/Integration/Infrastructure/SlugListenerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure;
+
+use App\Entity\City;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class SlugListenerTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        $this->em = $container->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testCitySlugCollisionThrows(): void
+    {
+        $city1 = new City('Sofia');
+        $this->em->persist($city1);
+        $this->em->flush();
+
+        self::assertSame('sofia', $city1->getSlug());
+
+        $city2 = new City('Sofia');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->em->persist($city2);
+        $this->em->flush();
+    }
+}

--- a/tests/Integration/Repository/GroomerProfileRepositoryTest.php
+++ b/tests/Integration/Repository/GroomerProfileRepositoryTest.php
@@ -34,13 +34,13 @@ final class GroomerProfileRepositoryTest extends KernelTestCase
             ->setEmail('groomer@example.com')
             ->setPassword('hash')
             ->setRoles([User::ROLE_GROOMER]);
-        $city = new City('Sofia', 'sofia');
+        $city = new City('Sofia');
 
         $this->em->persist($user);
         $this->em->persist($city);
         $this->em->flush();
 
-        $profile = new GroomerProfile($user, $city, 'Best Groomers', 'best-groomers', 'About us');
+        $profile = new GroomerProfile($user, $city, 'Best Groomers', 'About us', 'best-groomers');
         $this->em->persist($profile);
         $this->em->flush();
         $this->em->clear();

--- a/tests/Unit/Entity/CityTest.php
+++ b/tests/Unit/Entity/CityTest.php
@@ -11,10 +11,10 @@ class CityTest extends TestCase
 {
     public function testConstructSetsProperties(): void
     {
-        $city = new City('Sofia', 'sofia');
+        $city = new City('Sofia');
 
         self::assertSame('Sofia', $city->getName());
-        self::assertSame('sofia', $city->getSlug());
+        self::assertSame('', $city->getSlug());
         self::assertInstanceOf(\DateTimeImmutable::class, $city->getCreatedAt());
     }
 }

--- a/tests/Unit/Entity/GroomerProfileTest.php
+++ b/tests/Unit/Entity/GroomerProfileTest.php
@@ -17,9 +17,9 @@ final class GroomerProfileTest extends TestCase
             ->setEmail('groomer@example.com')
             ->setRoles([User::ROLE_GROOMER])
             ->setPassword('hash');
-        $city = new City('Sofia', 'sofia');
+        $city = new City('Sofia');
 
-        $profile = new GroomerProfile($user, $city, 'Best Groomers', 'best-groomers', 'About us');
+        $profile = new GroomerProfile($user, $city, 'Best Groomers', 'About us', 'best-groomers');
 
         self::assertSame($user, $profile->getUser());
         self::assertSame($city, $profile->getCity());
@@ -34,9 +34,9 @@ final class GroomerProfileTest extends TestCase
             ->setEmail('owner@example.com')
             ->setRoles([User::ROLE_PET_OWNER])
             ->setPassword('hash');
-        $city = new City('Sofia', 'sofia');
+        $city = new City('Sofia');
 
         $this->expectException(\InvalidArgumentException::class);
-        new GroomerProfile($user, $city, 'Biz', 'biz', 'About');
+        new GroomerProfile($user, $city, 'Biz', 'About');
     }
 }

--- a/tests/Unit/Infrastructure/SlugListenerTest.php
+++ b/tests/Unit/Infrastructure/SlugListenerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Infrastructure;
+
+use App\Entity\City;
+use App\Infrastructure\Doctrine\SlugListener;
+use App\Repository\CityRepository;
+use App\Repository\GroomerProfileRepository;
+use App\Repository\ServiceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class SlugListenerTest extends TestCase
+{
+    public function testGeneratesSlugWhenEmpty(): void
+    {
+        $cityRepo = $this->createMock(CityRepository::class);
+        $qb = $this->getMockBuilder(QueryBuilder::class)->disableOriginalConstructor()->getMock();
+        $query = $this->getMockBuilder(Query::class)->disableOriginalConstructor()->getMock();
+        $qb->method('where')->willReturnSelf();
+        $qb->method('setParameter')->willReturnSelf();
+        $qb->method('getQuery')->willReturn($query);
+        $query->method('setMaxResults')->willReturn($query);
+        $query->method('setHint')->willReturn($query);
+        $query->method('getOneOrNullResult')->willReturn(null);
+        $cityRepo->method('createQueryBuilder')->willReturn($qb);
+
+        $listener = new SlugListener($cityRepo, $this->createMock(ServiceRepository::class), $this->createMock(GroomerProfileRepository::class));
+
+        $city = new City('Sofia');
+        $args = new PrePersistEventArgs($city, $this->createMock(EntityManagerInterface::class));
+
+        $listener->prePersist($args);
+
+        self::assertSame('sofia', $city->getSlug());
+    }
+
+    public function testThrowsOnCollision(): void
+    {
+        $existing = new City('Sofia', 'sofia');
+
+        $cityRepo = $this->createMock(CityRepository::class);
+        $qb = $this->getMockBuilder(QueryBuilder::class)->disableOriginalConstructor()->getMock();
+        $query = $this->getMockBuilder(Query::class)->disableOriginalConstructor()->getMock();
+        $qb->method('where')->willReturnSelf();
+        $qb->method('setParameter')->willReturnSelf();
+        $qb->method('getQuery')->willReturn($query);
+        $query->method('setMaxResults')->willReturn($query);
+        $query->method('setHint')->willReturn($query);
+        $query->method('getOneOrNullResult')->willReturn($existing);
+        $cityRepo->method('createQueryBuilder')->willReturn($qb);
+
+        $listener = new SlugListener($cityRepo, $this->createMock(ServiceRepository::class), $this->createMock(GroomerProfileRepository::class));
+
+        $city = new City('Sofia');
+        $args = new PrePersistEventArgs($city, $this->createMock(EntityManagerInterface::class));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $listener->prePersist($args);
+    }
+}


### PR DESCRIPTION
## Summary
- add SluggerTrait for simple slug creation
- introduce Doctrine SlugListener to auto-populate slugs and block duplicates
- test slug collision handling

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6898c0528c3c8322a08372f495fdb8c8