### PR TITLE
feat: add groomer profile page

### DIFF
--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -24,6 +24,9 @@
         <testsuite name="integration">
             <directory>tests/Integration</directory>
         </testsuite>
+        <testsuite name="functional">
+            <directory>tests/Functional</directory>
+        </testsuite>
     </testsuites>
 
     <source ignoreSuppressionOfDeprecations="true"

--- a/src/Controller/GroomerController.php
+++ b/src/Controller/GroomerController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Repository\GroomerProfileRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class GroomerController extends AbstractController
+{
+    #[Route('/groomers/{slug}', name: 'app_groomer_show')]
+    public function show(string $slug, GroomerProfileRepository $repository): Response
+    {
+        $groomer = $repository->findOneBySlug($slug);
+        if (null === $groomer) {
+            throw $this->createNotFoundException();
+        }
+
+        return $this->render('groomer/show.html.twig', [
+            'groomer' => $groomer,
+        ]);
+    }
+}

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -14,4 +14,3 @@ class HomepageController extends AbstractController
         return $this->render('homepage/index.html.twig');
     }
 }
-

--- a/templates/groomer/show.html.twig
+++ b/templates/groomer/show.html.twig
@@ -1,0 +1,12 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ groomer.businessName }}{% endblock %}
+
+{% block body %}
+    <h1>{{ groomer.businessName }}</h1>
+    {% if groomer.city is not null %}
+        <p>{{ groomer.city.name }}</p>
+    {% endif %}
+    <p>{{ groomer.about }}</p>
+    <div id="reviews">Reviews coming soon...</div>
+{% endblock %}

--- a/tests/Functional/Controller/GroomerControllerShowTest.php
+++ b/tests/Functional/Controller/GroomerControllerShowTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\AbstractBrowser;
+
+final class GroomerControllerShowTest extends WebTestCase
+{
+    private AbstractBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = $this->client->getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $metadata = $this->em->getMetadataFactory()->getAllMetadata();
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+    }
+
+    public function testShowReturns200WithBusinessName(): void
+    {
+        $user = (new User())
+            ->setEmail('groomer@example.com')
+            ->setPassword('password')
+            ->setRoles([User::ROLE_GROOMER]);
+        $city = new City('Sofia');
+        $groomer = new GroomerProfile($user, $city, 'Groomer Co', 'We groom pets', 'groomer-co');
+        $this->em->persist($user);
+        $this->em->persist($city);
+        $this->em->persist($groomer);
+        $this->em->flush();
+
+        $this->client->request('GET', '/groomers/groomer-co');
+        $this->assertResponseIsSuccessful();
+        $content = $this->client->getResponse()->getContent();
+        \assert(is_string($content));
+        $this->assertStringContainsString('Groomer Co', $content);
+        $this->assertStringContainsString('Sofia', $content);
+    }
+
+    public function testUnknownSlugReturns404(): void
+    {
+        $this->client->request('GET', '/groomers/unknown');
+        $this->assertResponseStatusCodeSame(404);
+    }
+}


### PR DESCRIPTION
## Summary
- add GroomerController show action for public groomer pages
- render groomer profile with city and about
- cover groomer show with functional tests

## Testing
- `composer lint:php`
- `composer stan`
- `composer test`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6899e54e4a108322bdf1870800bd6c47