### PR TITLE
feat: list groomers by city and service

### DIFF
--- a/src/Controller/GroomerController.php
+++ b/src/Controller/GroomerController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Repository\CityRepository;
+use App\Repository\GroomerProfileRepository;
+use App\Repository\ServiceRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class GroomerController extends AbstractController
+{
+    #[Route('/groomers/{citySlug}/{serviceSlug}', name: 'app_groomer_list_by_city_service', methods: ['GET'])]
+    public function listByCityService(
+        string $citySlug,
+        string $serviceSlug,
+        Request $request,
+        CityRepository $cityRepository,
+        ServiceRepository $serviceRepository,
+        GroomerProfileRepository $groomerProfileRepository,
+    ): Response {
+        $city = $cityRepository->findOneBySlug($citySlug);
+        if (null === $city) {
+            throw $this->createNotFoundException();
+        }
+
+        $service = $serviceRepository->findOneBySlug($serviceSlug);
+        if (null === $service) {
+            throw $this->createNotFoundException();
+        }
+
+        $offset = max(0, $request->query->getInt('offset', 0));
+        $groomers = $groomerProfileRepository->findByCityAndService($city, $service, 20, $offset);
+
+        return $this->render('groomer/list.html.twig', [
+            'groomers' => $groomers,
+            'city' => $city,
+            'service' => $service,
+        ]);
+    }
+}

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -14,4 +14,3 @@ class HomepageController extends AbstractController
         return $this->render('homepage/index.html.twig');
     }
 }
-

--- a/src/Repository/GroomerProfileRepository.php
+++ b/src/Repository/GroomerProfileRepository.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\City;
 use App\Entity\GroomerProfile;
+use App\Entity\Service;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -31,5 +33,26 @@ class GroomerProfileRepository extends ServiceEntityRepository
             ->setParameter('slug', $slug)
             ->getQuery()
             ->getOneOrNullResult();
+    }
+
+    /**
+     * @return array<int, GroomerProfile>
+     */
+    public function findByCityAndService(City $city, Service $service, int $limit = 20, int $offset = 0): array
+    {
+        $query = $this->createQueryBuilder('g')
+            ->innerJoin('g.services', 's')
+            ->where('g.city = :city')
+            ->andWhere('s = :service')
+            ->setParameter('city', $city)
+            ->setParameter('service', $service)
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->getQuery();
+
+        /** @var array<int, GroomerProfile> $result */
+        $result = $query->getResult();
+
+        return $result;
     }
 }

--- a/templates/groomer/list.html.twig
+++ b/templates/groomer/list.html.twig
@@ -1,0 +1,16 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Groomers in {{ city.name }} for {{ service.name }}{% endblock %}
+
+{% block body %}
+    <h1>Groomers in {{ city.name }} for {{ service.name }}</h1>
+    {% if groomers %}
+        <ul>
+        {% for groomer in groomers %}
+            <li><a href="/groomers/{{ groomer.slug }}">{{ groomer.businessName }}</a></li>
+        {% endfor %}
+        </ul>
+    {% else %}
+        <p>No results yet.</p>
+    {% endif %}
+{% endblock %}

--- a/tests/Functional/Controller/GroomerControllerListTest.php
+++ b/tests/Functional/Controller/GroomerControllerListTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Service;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class GroomerControllerListTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testListByCityAndServiceDisplaysGroomer(): void
+    {
+        $user = (new User())
+            ->setEmail('groomer@example.com')
+            ->setRoles([User::ROLE_GROOMER])
+            ->setPassword('hash');
+        $city = new City('Sofia');
+        $city->refreshSlugFrom($city->getName());
+        $service = (new Service())->setName('Bath');
+        $service->refreshSlugFrom($service->getName());
+        $profile = new GroomerProfile($user, $city, 'Best Groomers', 'About us');
+        $profile->addService($service);
+        $profile->refreshSlugFrom($profile->getBusinessName());
+
+        $this->em->persist($user);
+        $this->em->persist($city);
+        $this->em->persist($service);
+        $this->em->persist($profile);
+        $this->em->flush();
+
+        $this->client->request('GET', '/groomers/'.$city->getSlug().'/'.$service->getSlug());
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Best Groomers', (string) $this->client->getResponse()->getContent());
+    }
+
+    public function testUnknownCityReturns404(): void
+    {
+        $service = (new Service())->setName('Bath');
+        $service->refreshSlugFrom($service->getName());
+        $this->em->persist($service);
+        $this->em->flush();
+
+        $this->client->request('GET', '/groomers/unknown-city/'.$service->getSlug());
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testUnknownServiceReturns404(): void
+    {
+        $city = new City('Sofia');
+        $city->refreshSlugFrom($city->getName());
+        $this->em->persist($city);
+        $this->em->flush();
+
+        $this->client->request('GET', '/groomers/'.$city->getSlug().'/unknown-service');
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## Summary
- add groomer listing by city and service
- basic twig template for groomer listings
- cover listing behavior with functional tests

## Testing
- `composer lint:php`
- `composer stan`
- `composer test`
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: ./vendor/bin/phpunit --testdox --bootstrap tests/bootstrap.php tests/Functional/Controller/GroomerControllerListTest.php`
- `composer audit` *(fails: curl error 56 while downloading https://packagist.org/api/security-advisories/: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899e561d4188322b698b612a2dc7b76