### PR TITLE
feat: add staging seed command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+setup:
+	composer install
+
+test:
+	composer test
+
+seed-staging:
+	APP_ENV=staging bin/console app:seed-staging

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -15,5 +15,5 @@ return [
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
     Nelmio\CorsBundle\NelmioCorsBundle::class => ['all' => true],
     ApiPlatform\Symfony\Bundle\ApiPlatformBundle::class => ['all' => true],
-    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
+    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true, 'staging' => true],
 ];

--- a/src/Command/SeedStagingCommand.php
+++ b/src/Command/SeedStagingCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+#[AsCommand(name: 'app:seed-staging', description: 'Seed staging data')]
+final class SeedStagingCommand extends Command
+{
+    public function __construct(
+        private readonly KernelInterface $kernel,
+        private readonly EntityManagerInterface $em,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('force', null, InputOption::VALUE_NONE, 'Force run outside staging env');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $env = $this->kernel->getEnvironment();
+        if ('staging' !== $env && !$input->getOption('force')) {
+            $output->writeln('<error>Refusing to seed in non-staging environment. Use --force to override.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $app = $this->getApplication();
+        if (null === $app) {
+            throw new \RuntimeException('Application not available');
+        }
+        $app->setAutoExit(false);
+
+        $app->run(new ArrayInput([
+            'command' => 'doctrine:migrations:migrate',
+            '--no-interaction' => true,
+        ]), $output);
+
+        $app->run(new ArrayInput([
+            'command' => 'doctrine:fixtures:load',
+            '--group' => ['staging'],
+            '--no-interaction' => true,
+        ]), $output);
+
+        $counts = [
+            'cities' => $this->em->getRepository(\App\Entity\City::class)->count([]),
+            'services' => $this->em->getRepository(\App\Entity\Service::class)->count([]),
+            'groomers' => $this->em->getRepository(\App\Entity\GroomerProfile::class)->count([]),
+            'reviews' => $this->em->getRepository(\App\Entity\Review::class)->count([]),
+            'bookings' => $this->em->getRepository(\App\Entity\BookingRequest::class)->count([]),
+        ];
+
+        $output->writeln(sprintf(
+            'Seeded %d cities, %d services, %d groomers, %d reviews, %d bookings.',
+            $counts['cities'],
+            $counts['services'],
+            $counts['groomers'],
+            $counts['reviews'],
+            $counts['bookings']
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -11,9 +11,10 @@ use App\Entity\Review;
 use App\Entity\Service;
 use App\Entity\User;
 use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class AppFixtures extends Fixture
+class AppFixtures extends Fixture implements FixtureGroupInterface
 {
     public function load(ObjectManager $manager): void
     {
@@ -53,5 +54,10 @@ class AppFixtures extends Fixture
         $manager->persist($booking);
 
         $manager->flush();
+    }
+
+    public static function getGroups(): array
+    {
+        return ['test'];
     }
 }

--- a/src/DataFixtures/StagingFixtures.php
+++ b/src/DataFixtures/StagingFixtures.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use App\Entity\BookingRequest;
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Review;
+use App\Entity\Service;
+use App\Entity\User;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
+use Doctrine\Persistence\ObjectManager;
+
+final class StagingFixtures extends Fixture implements FixtureGroupInterface
+{
+    public static function getGroups(): array
+    {
+        return ['staging'];
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $cities = [];
+        foreach (['Sofia', 'Plovdiv', 'Varna'] as $name) {
+            $city = new City($name);
+            $manager->persist($city);
+            $cities[] = $city;
+        }
+
+        $services = [];
+        foreach ([
+            'Mobile Dog Grooming',
+            'Cat Grooming',
+            'Nail Trimming',
+            'Full Groom',
+        ] as $name) {
+            $service = (new Service())->setName($name);
+            $manager->persist($service);
+            $services[] = $service;
+        }
+
+        $groomers = [];
+        for ($i = 1; $i <= 5; ++$i) {
+            $user = (new User())
+                ->setEmail("groomer{$i}@example.com")
+                ->setPassword('password')
+                ->setRoles([User::ROLE_GROOMER]);
+            $manager->persist($user);
+            $groomers[] = $user;
+        }
+
+        $owners = [];
+        for ($i = 1; $i <= 3; ++$i) {
+            $user = (new User())
+                ->setEmail("owner{$i}@example.com")
+                ->setPassword('password')
+                ->setRoles([User::ROLE_PET_OWNER]);
+            $manager->persist($user);
+            $owners[] = $user;
+        }
+
+        $profiles = [];
+        for ($i = 0; $i < 5; ++$i) {
+            $profile = new GroomerProfile(
+                $groomers[$i],
+                $cities[$i % count($cities)],
+                "Groomer {$i} Biz",
+                "About groomer {$i}",
+            );
+            $indexes = array_rand($services, random_int(1, 3));
+            foreach ((array) $indexes as $idx) {
+                $profile->addService($services[$idx]);
+            }
+            $manager->persist($profile);
+            $profiles[] = $profile;
+        }
+
+        $reviewCount = random_int(6, 10);
+        for ($i = 0; $i < $reviewCount; ++$i) {
+            $review = new Review(
+                $profiles[$i % count($profiles)],
+                $owners[$i % count($owners)],
+                random_int(3, 5),
+                "Review {$i}",
+            );
+            $manager->persist($review);
+        }
+
+        $statuses = [
+            BookingRequest::STATUS_PENDING,
+            BookingRequest::STATUS_ACCEPTED,
+            BookingRequest::STATUS_DECLINED,
+        ];
+        for ($i = 0; $i < 5; ++$i) {
+            $booking = new BookingRequest(
+                $profiles[$i % count($profiles)],
+                $owners[$i % count($owners)],
+            );
+            $booking->setService($services[$i % count($services)]);
+            $booking->setStatus($statuses[$i % count($statuses)]);
+            $manager->persist($booking);
+        }
+
+        $manager->flush();
+    }
+}

--- a/tests/E2E/FixturesSmokeTest.php
+++ b/tests/E2E/FixturesSmokeTest.php
@@ -19,6 +19,8 @@ class FixturesSmokeTest extends WebTestCase
         $application->run(new ArrayInput([
             'command' => 'doctrine:fixtures:load',
             '--no-interaction' => true,
+            '--group' => ['test'],
+            '--purge-with-truncate' => true,
         ]));
         $client->request('GET', '/cities/sofia');
         self::assertResponseIsSuccessful();

--- a/tests/Functional/Command/SeedStagingCommandTest.php
+++ b/tests/Functional/Command/SeedStagingCommandTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpFoundation\Request;
+
+final class SeedStagingCommandTest extends KernelTestCase
+{
+    private function initDbEnv(): void
+    {
+        self::ensureKernelShutdown();
+        $db = __DIR__.'/../../../var/test.db';
+        if (file_exists($db)) {
+            unlink($db);
+        }
+        $dsn = 'sqlite:///'.$db;
+        putenv('DATABASE_URL='.$dsn);
+        $_ENV['DATABASE_URL'] = $dsn;
+        $_SERVER['DATABASE_URL'] = $dsn;
+    }
+
+    public function testSeedsInStaging(): void
+    {
+        $this->initDbEnv();
+        self::bootKernel(['environment' => 'staging']);
+        $application = new Application(self::$kernel);
+        $command = $application->find('app:seed-staging');
+        $tester = new CommandTester($command);
+        self::assertSame(0, $tester->execute([]));
+
+        self::ensureKernelShutdown();
+        self::bootKernel(['environment' => 'staging']);
+        $slug = 'groomer-0-biz';
+
+        $response = self::$kernel->handle(Request::create('/cities/sofia'));
+        self::assertSame(200, $response->getStatusCode());
+
+        $response = self::$kernel->handle(Request::create('/groomers/'.$slug));
+        self::assertSame(200, $response->getStatusCode());
+
+        $response = self::$kernel->handle(Request::create('/groomers/sofia/mobile-dog-grooming'));
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testRequiresForceOutsideStaging(): void
+    {
+        $this->initDbEnv();
+        self::bootKernel(['environment' => 'dev']);
+        $application = new Application(self::$kernel);
+        $command = $application->find('app:seed-staging');
+
+        $tester = new CommandTester($command);
+        self::assertSame(Command::FAILURE, $tester->execute([]));
+
+        $tester = new CommandTester($command);
+        self::assertSame(Command::SUCCESS, $tester->execute(['--force' => true]));
+    }
+}


### PR DESCRIPTION
## Summary
- add app:seed-staging console command to migrate and seed staging data
- provide staging fixtures for sample cities, services, users, profiles, reviews and bookings
- enable DoctrineFixturesBundle in staging and add make seed-staging target
- cover seeding command with functional tests

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: City slug already exists)*
- `make test -k` *(fails: City slug already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6899f7e7348c8322b8ebc5332a28f05f