### PR TITLE
feat: add idempotent seeder service

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -21,5 +21,8 @@ services:
             - { name: doctrine.event_listener, event: prePersist }
             - { name: doctrine.event_listener, event: preUpdate }
 
+    App\Seed\Seeder:
+        public: true
+
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/Seed/SeedDataset.php
+++ b/src/Seed/SeedDataset.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Seed;
+
+use App\Entity\User;
+
+/**
+ * @psalm-type CityData=array{name:string}
+ * @psalm-type ServiceData=array{name:string}
+ * @psalm-type UserData=array{email:string,password:string,roles:array<int,string>}
+ * @psalm-type GroomerProfileData=array{
+ *     userEmail:string,
+ *     city:string,
+ *     businessName:string,
+ *     about:string,
+ *     services:array<int,string>
+ * }
+ */
+final class SeedDataset
+{
+    /**
+     * @param array<int,CityData>           $cities
+     * @param array<int,ServiceData>        $services
+     * @param array<int,UserData>           $users
+     * @param array<int,GroomerProfileData> $groomerProfiles
+     */
+    public function __construct(
+        public readonly array $cities,
+        public readonly array $services,
+        public readonly array $users,
+        public readonly array $groomerProfiles,
+    ) {
+    }
+
+    public static function default(): self
+    {
+        return new self(
+            cities: [
+                ['name' => 'Sofia'],
+            ],
+            services: [
+                ['name' => 'Mobile Dog Grooming'],
+            ],
+            users: [
+                ['email' => 'groomer@example.com', 'password' => 'hash', 'roles' => [User::ROLE_GROOMER]],
+                ['email' => 'owner@example.com', 'password' => 'hash', 'roles' => [User::ROLE_PET_OWNER]],
+            ],
+            groomerProfiles: [
+                [
+                    'userEmail' => 'groomer@example.com',
+                    'city' => 'Sofia',
+                    'businessName' => 'Sofia Mobile Groomer',
+                    'about' => 'Professional mobile grooming services.',
+                    'services' => ['Mobile Dog Grooming'],
+                ],
+            ],
+        );
+    }
+}

--- a/src/Seed/Seeder.php
+++ b/src/Seed/Seeder.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Seed;
+
+use App\Entity\BookingRequest;
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Review;
+use App\Entity\Service;
+use App\Entity\User;
+use App\Repository\BookingRequestRepository;
+use App\Repository\CityRepository;
+use App\Repository\GroomerProfileRepository;
+use App\Repository\ReviewRepository;
+use App\Repository\ServiceRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+final class Seeder
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly CityRepository $cityRepository,
+        private readonly ServiceRepository $serviceRepository,
+        private readonly UserRepository $userRepository,
+        private readonly GroomerProfileRepository $profileRepository,
+        private readonly ReviewRepository $reviewRepository,
+        private readonly BookingRequestRepository $bookingRequestRepository,
+    ) {
+    }
+
+    public function seed(SeedDataset $dataset, bool $withSamples = false): void
+    {
+        $this->em->wrapInTransaction(function () use ($dataset, $withSamples): void {
+            $cities = [];
+            foreach ($dataset->cities as $cityData) {
+                $slug = $this->slugify($cityData['name']);
+                $city = $this->cityRepository->findOneBySlug($slug);
+                if (null === $city) {
+                    $city = new City($cityData['name']);
+                    $city->refreshSlugFrom($cityData['name']);
+                    $this->em->persist($city);
+                }
+                $cities[$slug] = $city;
+            }
+
+            $services = [];
+            foreach ($dataset->services as $serviceData) {
+                $slug = $this->slugify($serviceData['name']);
+                $service = $this->serviceRepository->findOneBySlug($slug);
+                if (null === $service) {
+                    $service = (new Service())->setName($serviceData['name']);
+                    $service->refreshSlugFrom($serviceData['name']);
+                    $this->em->persist($service);
+                } else {
+                    if ($service->getName() !== $serviceData['name']) {
+                        $service->setName($serviceData['name']);
+                        $service->refreshSlugFrom($serviceData['name']);
+                    }
+                }
+                $services[$slug] = $service;
+            }
+
+            $users = [];
+            foreach ($dataset->users as $userData) {
+                $user = $this->userRepository->findOneBy(['email' => $userData['email']]);
+                if (null === $user) {
+                    $user = (new User())
+                        ->setEmail($userData['email'])
+                        ->setPassword($userData['password'])
+                        ->setRoles($userData['roles']);
+                    $this->em->persist($user);
+                } else {
+                    $user->setPassword($userData['password']);
+                    $user->setRoles($userData['roles']);
+                }
+                $users[$userData['email']] = $user;
+            }
+
+            $profiles = [];
+            foreach ($dataset->groomerProfiles as $profileData) {
+                $user = $users[$profileData['userEmail']] ?? null;
+                $citySlug = $this->slugify($profileData['city']);
+                $city = $cities[$citySlug] ?? null;
+                if (null === $user || null === $city) {
+                    continue; // skip invalid references
+                }
+
+                $slug = $this->slugify($profileData['businessName']);
+                $profile = $this->profileRepository->findOneBySlug($slug);
+                if (null === $profile) {
+                    $profile = new GroomerProfile($user, $city, $profileData['businessName'], $profileData['about']);
+                    $profile->refreshSlugFrom($profileData['businessName']);
+                    foreach ($profileData['services'] as $serviceName) {
+                        $serviceSlug = $this->slugify($serviceName);
+                        if (isset($services[$serviceSlug])) {
+                            $profile->addService($services[$serviceSlug]);
+                        }
+                    }
+                    $this->em->persist($profile);
+                } else {
+                    // ensure services
+                    $desired = [];
+                    foreach ($profileData['services'] as $serviceName) {
+                        $desired[] = $this->slugify($serviceName);
+                    }
+                    foreach ($profile->getServices() as $existingService) {
+                        if (!in_array($existingService->getSlug(), $desired, true)) {
+                            $profile->removeService($existingService);
+                        }
+                    }
+                    foreach ($desired as $serviceSlug) {
+                        if (isset($services[$serviceSlug])) {
+                            $profile->addService($services[$serviceSlug]);
+                        }
+                    }
+                }
+                $profiles[] = $profile;
+            }
+
+            if ($withSamples) {
+                $petOwner = null;
+                foreach ($users as $candidate) {
+                    if (in_array(User::ROLE_PET_OWNER, $candidate->getRoles(), true)) {
+                        $petOwner = $candidate;
+                        break;
+                    }
+                }
+                if (null !== $petOwner) {
+                    foreach ($profiles as $profile) {
+                        $existingReview = $this->reviewRepository->findOneBy([
+                            'groomer' => $profile,
+                            'author' => $petOwner,
+                        ]);
+                        if (null === $existingReview) {
+                            $review = new Review($profile, $petOwner, 5, 'Sample review');
+                            $this->em->persist($review);
+                        }
+
+                        $existingBooking = $this->bookingRequestRepository->findOneBy([
+                            'groomer' => $profile,
+                            'petOwner' => $petOwner,
+                        ]);
+                        if (null === $existingBooking) {
+                            $booking = new BookingRequest($profile, $petOwner);
+                            $service = $profile->getServices()->first();
+                            if ($service instanceof Service) {
+                                $booking->setService($service);
+                            }
+                            $this->em->persist($booking);
+                        }
+                    }
+                }
+            }
+
+            $this->em->flush();
+        });
+    }
+
+    private function slugify(string $source): string
+    {
+        $normalized = preg_replace('/\s+/', ' ', mb_strtolower(trim($source))) ?? '';
+
+        return (new AsciiSlugger())->slug($normalized)->lower()->toString();
+    }
+}

--- a/tests/Unit/Seed/SeedDatasetTest.php
+++ b/tests/Unit/Seed/SeedDatasetTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Seed;
+
+use App\Entity\User;
+use App\Seed\SeedDataset;
+use PHPUnit\Framework\TestCase;
+
+final class SeedDatasetTest extends TestCase
+{
+    public function testDefaultDatasetStructure(): void
+    {
+        $dataset = SeedDataset::default();
+
+        self::assertNotEmpty($dataset->cities);
+        self::assertSame('Sofia', $dataset->cities[0]['name']);
+
+        self::assertNotEmpty($dataset->services);
+        self::assertSame('Mobile Dog Grooming', $dataset->services[0]['name']);
+
+        self::assertCount(2, $dataset->users);
+        self::assertSame('groomer@example.com', $dataset->users[0]['email']);
+        self::assertContains(User::ROLE_GROOMER, $dataset->users[0]['roles']);
+
+        self::assertCount(1, $dataset->groomerProfiles);
+        self::assertSame('Sofia Mobile Groomer', $dataset->groomerProfiles[0]['businessName']);
+    }
+}

--- a/tests/Unit/Seed/SeederIdempotencyTest.php
+++ b/tests/Unit/Seed/SeederIdempotencyTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Seed;
+
+use App\Entity\BookingRequest;
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Review;
+use App\Entity\Service;
+use App\Entity\User;
+use App\Seed\SeedDataset;
+use App\Seed\Seeder;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class SeederIdempotencyTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private Seeder $seeder;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+        $this->em = $container->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $this->seeder = $container->get(Seeder::class);
+    }
+
+    public function testSeedingTwiceDoesNotDuplicateData(): void
+    {
+        $dataset = SeedDataset::default();
+
+        $this->seeder->seed($dataset, true);
+        $this->seeder->seed($dataset, true);
+
+        self::assertSame(1, $this->em->getRepository(City::class)->count([]));
+        self::assertSame(1, $this->em->getRepository(Service::class)->count([]));
+        self::assertSame(2, $this->em->getRepository(User::class)->count([]));
+        self::assertSame(1, $this->em->getRepository(GroomerProfile::class)->count([]));
+        self::assertSame(1, $this->em->getRepository(Review::class)->count([]));
+        self::assertSame(1, $this->em->getRepository(BookingRequest::class)->count([]));
+    }
+}


### PR DESCRIPTION
## Summary
- add `SeedDataset` value object defining core cities, services, users, and groomer profiles
- implement idempotent `Seeder` service with optional sample review and booking data
- expose `Seeder` as a public service and add unit tests for dataset and idempotency

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689a3f8332888322a7dde59e8faafe4e