### PR TITLE
feat: add environment-aware seed packs

### DIFF
--- a/config/packages/seed.yaml
+++ b/config/packages/seed.yaml
@@ -1,0 +1,11 @@
+parameters:
+  seed:
+    packs:
+      staging:
+        entities:
+          - default
+        withSamples: true
+      production:
+        entities:
+          - default
+        withSamples: false

--- a/src/Seed/SeedPackProvider.php
+++ b/src/Seed/SeedPackProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Seed;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+/**
+ * Provides access to configured seed packs.
+ */
+final class SeedPackProvider
+{
+    public function __construct(private ParameterBagInterface $parameters)
+    {
+    }
+
+    /**
+     * @return array{entities: array<int, string>, withSamples: bool}
+     */
+    public function get(string $name): array
+    {
+        /** @var array<string, array{entities: array<int, string>, withSamples: bool}> $packs */
+        $packs = $this->parameters->get('seed.packs');
+
+        if (!isset($packs[$name])) {
+            throw new \InvalidArgumentException(sprintf('Seed pack "%s" is not defined.', $name));
+        }
+
+        return $packs[$name];
+    }
+}

--- a/tests/Unit/Seed/SeedPackProviderTest.php
+++ b/tests/Unit/Seed/SeedPackProviderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Seed;
+
+use App\Seed\SeedPackProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+final class SeedPackProviderTest extends TestCase
+{
+    public function testReturnsPackConfig(): void
+    {
+        $bag = new ParameterBag([
+            'seed.packs' => [
+                'staging' => [
+                    'entities' => ['default'],
+                    'withSamples' => true,
+                ],
+                'production' => [
+                    'entities' => ['default'],
+                    'withSamples' => false,
+                ],
+            ],
+        ]);
+        $provider = new SeedPackProvider($bag);
+
+        $pack = $provider->get('staging');
+
+        self::assertSame(
+            ['entities' => ['default'], 'withSamples' => true],
+            $pack
+        );
+    }
+
+    public function testThrowsWhenPackMissing(): void
+    {
+        $bag = new ParameterBag(['seed.packs' => []]);
+        $provider = new SeedPackProvider($bag);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $provider->get('unknown');
+    }
+}


### PR DESCRIPTION
## Summary
- add seed pack configuration for staging and production
- introduce SeedPackProvider for retrieving configured packs
- cover seed pack lookup and error handling with unit tests

## Testing
- `composer lint:php`
- `composer stan`
- `composer test`
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689a4319e40c83228b39de1c905bd03e