### PR TITLE
feat: add safe bootstrap seeding command

### DIFF
--- a/src/Command/SeedBootstrapCommand.php
+++ b/src/Command/SeedBootstrapCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Seed\SeedDataset;
+use App\Seed\Seeder;
+use App\Seed\SeedPackProvider;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+#[AsCommand(name: 'app:seed:bootstrap', description: 'Seed baseline data using a seed pack')]
+final class SeedBootstrapCommand extends Command
+{
+    private string $appEnv;
+
+    public function __construct(
+        private readonly SeedPackProvider $packProvider,
+        private readonly Seeder $seeder,
+        KernelInterface $kernel,
+    ) {
+        $this->appEnv = $kernel->getEnvironment();
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('env-pack', null, InputOption::VALUE_REQUIRED, 'Seed pack to use (staging|production)')
+            ->addOption('dry-run', null, InputOption::VALUE_NEGATABLE, 'Simulate without database writes')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Required to run in production');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $envPack = $input->getOption('env-pack');
+        if (!is_string($envPack) || '' === $envPack) {
+            $output->writeln('<error>The --env-pack option is required.</error>');
+
+            return Command::INVALID;
+        }
+
+        if ('prod' === $this->appEnv && !$input->getOption('force')) {
+            $output->writeln('<error>Refusing to run without --force in production.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $dryRunOption = $input->getOption('dry-run');
+        $dryRun = null === $dryRunOption ? ('prod' === $this->appEnv) : (bool) $dryRunOption;
+
+        $pack = $this->packProvider->get($envPack);
+
+        $dataset = SeedDataset::default();
+
+        if ($dryRun) {
+            $output->writeln('<info>Dry run - no changes will be written.</info>');
+            $output->writeln(sprintf('Cities: %d', count($dataset->cities)));
+            $output->writeln(sprintf('Services: %d', count($dataset->services)));
+            $output->writeln(sprintf('Users: %d', count($dataset->users)));
+            $output->writeln(sprintf('Groomer profiles: %d', count($dataset->groomerProfiles)));
+
+            return Command::SUCCESS;
+        }
+
+        $this->seeder->seed($dataset, $pack['withSamples']);
+        $output->writeln('<info>Seeding completed.</info>');
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Unit/Command/SeedBootstrapCommandOptionsTest.php
+++ b/tests/Unit/Command/SeedBootstrapCommandOptionsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\SeedBootstrapCommand;
+use App\Repository\BookingRequestRepository;
+use App\Repository\CityRepository;
+use App\Repository\GroomerProfileRepository;
+use App\Repository\ReviewRepository;
+use App\Repository\ServiceRepository;
+use App\Repository\UserRepository;
+use App\Seed\Seeder;
+use App\Seed\SeedPackProvider;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+final class SeedBootstrapCommandOptionsTest extends TestCase
+{
+    public function testFailsWithoutForceInProd(): void
+    {
+        $provider = new SeedPackProvider(new ParameterBag([
+            'seed.packs' => [
+                'production' => ['entities' => ['default'], 'withSamples' => false],
+            ],
+        ]));
+
+        $seeder = new Seeder(
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(CityRepository::class),
+            $this->createMock(ServiceRepository::class),
+            $this->createMock(UserRepository::class),
+            $this->createMock(GroomerProfileRepository::class),
+            $this->createMock(ReviewRepository::class),
+            $this->createMock(BookingRequestRepository::class),
+        );
+
+        $command = new SeedBootstrapCommand($provider, $seeder, $this->kernelMock('prod'));
+
+        $tester = new CommandTester($command);
+        $status = $tester->execute(['--env-pack' => 'production']);
+
+        self::assertSame(SeedBootstrapCommand::FAILURE, $status);
+        self::assertStringContainsString('Refusing to run', $tester->getDisplay());
+    }
+
+    public function testDryRunByDefaultInProd(): void
+    {
+        $provider = new SeedPackProvider(new ParameterBag([
+            'seed.packs' => [
+                'production' => ['entities' => ['default'], 'withSamples' => false],
+            ],
+        ]));
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::never())->method('wrapInTransaction');
+
+        $seeder = new Seeder(
+            $em,
+            $this->createMock(CityRepository::class),
+            $this->createMock(ServiceRepository::class),
+            $this->createMock(UserRepository::class),
+            $this->createMock(GroomerProfileRepository::class),
+            $this->createMock(ReviewRepository::class),
+            $this->createMock(BookingRequestRepository::class),
+        );
+
+        $command = new SeedBootstrapCommand($provider, $seeder, $this->kernelMock('prod'));
+        $tester = new CommandTester($command);
+        $status = $tester->execute([
+            '--env-pack' => 'production',
+            '--force' => true,
+        ]);
+
+        self::assertSame(SeedBootstrapCommand::SUCCESS, $status);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Dry run', $display);
+        self::assertStringContainsString('Cities: 1', $display);
+    }
+
+    private function kernelMock(string $env): KernelInterface
+    {
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->method('getEnvironment')->willReturn($env);
+
+        return $kernel;
+    }
+}


### PR DESCRIPTION
## Summary
- add app:seed:bootstrap command with dry-run and force protections
- cover command option behavior in unit tests

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_689a456e07ac8322ad5abfbc9653fd3e