### PR TITLE
Fix missing seed packs configuration parameter

### DIFF
--- a/config/packages/seed.yaml
+++ b/config/packages/seed.yaml
@@ -1,11 +1,10 @@
 parameters:
-  seed:
-    packs:
-      staging:
-        entities:
-          - default
-        withSamples: true
-      production:
-        entities:
-          - default
-        withSamples: false
+  seed.packs:
+    staging:
+      entities:
+        - default
+      withSamples: true
+    production:
+      entities:
+        - default
+      withSamples: false


### PR DESCRIPTION
## Summary
- define `seed.packs` parameter in configuration so seed services can resolve correctly

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`
- `php bin/console lint:container`


------
https://chatgpt.com/codex/tasks/task_e_689a49c10b48832285d2638429e87807