### PR TITLE
feat: add role helpers to User

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -66,7 +66,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function getRoles(): array
     {
-        return $this->roles;
+        $roles = $this->roles;
+        $roles[] = 'ROLE_USER';
+
+        return array_values(array_unique($roles));
     }
 
     /**
@@ -75,6 +78,29 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setRoles(array $roles): self
     {
         $this->roles = $roles;
+
+        return $this;
+    }
+
+    public function isGroomer(): bool
+    {
+        return \in_array(self::ROLE_GROOMER, $this->roles, true);
+    }
+
+    public function isOwner(): bool
+    {
+        if (\in_array(self::ROLE_PET_OWNER, $this->roles, true)) {
+            return true;
+        }
+
+        return !\in_array(self::ROLE_GROOMER, $this->roles, true);
+    }
+
+    public function withGroomerRole(): self
+    {
+        if (!$this->isGroomer()) {
+            $this->roles[] = self::ROLE_GROOMER;
+        }
 
         return $this;
     }

--- a/tests/Entity/UserRolesTest.php
+++ b/tests/Entity/UserRolesTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+class UserRolesTest extends TestCase
+{
+    public function testGetRolesAlwaysIncludesRoleUser(): void
+    {
+        $user = new User();
+        self::assertSame(['ROLE_USER'], $user->getRoles());
+
+        $user->setRoles([User::ROLE_GROOMER]);
+        self::assertSame(['ROLE_GROOMER', 'ROLE_USER'], $user->getRoles());
+    }
+
+    public function testIsGroomerReturnsTrueWhenRolePresent(): void
+    {
+        $user = (new User())->withGroomerRole();
+        self::assertTrue($user->isGroomer());
+    }
+
+    public function testIsOwnerReturnsTrueForDefaultUser(): void
+    {
+        $user = new User();
+        self::assertTrue($user->isOwner());
+    }
+
+    public function testIsOwnerReturnsTrueWhenOwnerRoleSet(): void
+    {
+        $user = (new User())->setRoles([User::ROLE_PET_OWNER]);
+        self::assertTrue($user->isOwner());
+    }
+
+    public function testIsOwnerReturnsFalseWhenOnlyGroomerRoleSet(): void
+    {
+        $user = (new User())->setRoles([User::ROLE_GROOMER]);
+        self::assertFalse($user->isOwner());
+    }
+
+    public function testWithGroomerRoleAddsRole(): void
+    {
+        $user = new User();
+        $user->withGroomerRole();
+        self::assertContains(User::ROLE_GROOMER, $user->getRoles());
+    }
+}

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -9,10 +9,10 @@ use PHPUnit\Framework\TestCase;
 
 class UserTest extends TestCase
 {
-    public function testNewUserHasEmptyRoles(): void
+    public function testNewUserHasDefaultUserRole(): void
     {
         $user = new User();
-        self::assertSame([], $user->getRoles());
+        self::assertSame(['ROLE_USER'], $user->getRoles());
     }
 
     public function testCreatedAtIsInitialized(): void


### PR DESCRIPTION
## Summary
- add role helper methods to `User` entity
- ensure roles always include ROLE_USER
- add tests for role helpers

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`
- `php bin/phpunit --filter=UserRolesTest tests/Entity/UserRolesTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689b012d3274832281b57a7cb5f531f4