### PR TITLE
feat: extend groomer profile details

### DIFF
--- a/migrations/Version20250810160700.php
+++ b/migrations/Version20250810160700.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250810160700 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add service area, phone, services offered, price range to groomer_profile';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('groomer_profile');
+        $table->addColumn('service_area', Types::STRING, ['length' => 120, 'notnull' => false]);
+        $table->addColumn('phone', Types::STRING, ['length' => 32, 'notnull' => false]);
+        $table->addColumn('services_offered', Types::TEXT, ['notnull' => false]);
+        $table->addColumn('price_range', Types::STRING, ['length' => 64, 'notnull' => false]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('groomer_profile');
+        $table->dropColumn('service_area');
+        $table->dropColumn('phone');
+        $table->dropColumn('services_offered');
+        $table->dropColumn('price_range');
+    }
+}

--- a/src/Entity/GroomerProfile.php
+++ b/src/Entity/GroomerProfile.php
@@ -36,6 +36,18 @@ class GroomerProfile
     #[ORM\Column(type: 'text')]
     private string $about;
 
+    #[ORM\Column(name: 'service_area', length: 120, nullable: true)]
+    private ?string $serviceArea = null;
+
+    #[ORM\Column(length: 32, nullable: true)]
+    private ?string $phone = null;
+
+    #[ORM\Column(name: 'services_offered', type: 'text', nullable: true)]
+    private ?string $servicesOffered = null;
+
+    #[ORM\Column(name: 'price_range', length: 64, nullable: true)]
+    private ?string $priceRange = null;
+
     /** @var Collection<int, Service> */
     #[ORM\ManyToMany(targetEntity: Service::class)]
     #[ORM\JoinTable(name: 'groomer_profile_service')]
@@ -78,6 +90,54 @@ class GroomerProfile
     public function getAbout(): string
     {
         return $this->about;
+    }
+
+    public function getServiceArea(): ?string
+    {
+        return $this->serviceArea;
+    }
+
+    public function setServiceArea(?string $serviceArea): self
+    {
+        $this->serviceArea = $serviceArea;
+
+        return $this;
+    }
+
+    public function getPhone(): ?string
+    {
+        return $this->phone;
+    }
+
+    public function setPhone(?string $phone): self
+    {
+        $this->phone = $phone;
+
+        return $this;
+    }
+
+    public function getServicesOffered(): ?string
+    {
+        return $this->servicesOffered;
+    }
+
+    public function setServicesOffered(?string $servicesOffered): self
+    {
+        $this->servicesOffered = $servicesOffered;
+
+        return $this;
+    }
+
+    public function getPriceRange(): ?string
+    {
+        return $this->priceRange;
+    }
+
+    public function setPriceRange(?string $priceRange): self
+    {
+        $this->priceRange = $priceRange;
+
+        return $this;
     }
 
     /**

--- a/templates/groomer/show.html.twig
+++ b/templates/groomer/show.html.twig
@@ -9,6 +9,19 @@
     {% endif %}
     <p>{{ groomer.about }}</p>
 
+    {% if groomer.serviceArea %}
+        <p>Service area: {{ groomer.serviceArea }}</p>
+    {% endif %}
+    {% if groomer.phone %}
+        <p>Phone: {{ groomer.phone }}</p>
+    {% endif %}
+    {% if groomer.servicesOffered %}
+        <p>Services offered: {{ groomer.servicesOffered }}</p>
+    {% endif %}
+    {% if groomer.priceRange %}
+        <p>Price range: {{ groomer.priceRange }}</p>
+    {% endif %}
+
     <h2>Reviews</h2>
     <p>Reviews coming soon.</p>
 {% endblock %}

--- a/tests/Functional/Controller/GroomerDetailRenderTest.php
+++ b/tests/Functional/Controller/GroomerDetailRenderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class GroomerDetailRenderTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testDetailShowsOptionalFields(): void
+    {
+        $user = (new User())
+            ->setEmail('groomer@example.com')
+            ->setRoles([User::ROLE_GROOMER])
+            ->setPassword('hash');
+        $city = new City('Sofia');
+        $city->refreshSlugFrom($city->getName());
+        $profile = new GroomerProfile($user, $city, 'Best Groomers', 'About us');
+        $profile->refreshSlugFrom($profile->getBusinessName());
+        $profile->setServiceArea('Downtown');
+        $profile->setPhone('123-456');
+        $profile->setServicesOffered('Bathing');
+        $profile->setPriceRange('$$');
+
+        $this->em->persist($user);
+        $this->em->persist($city);
+        $this->em->persist($profile);
+        $this->em->flush();
+
+        $this->client->request('GET', '/groomers/'.$profile->getSlug());
+        self::assertResponseIsSuccessful();
+        $content = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('Downtown', $content);
+        self::assertStringContainsString('123-456', $content);
+        self::assertStringContainsString('Bathing', $content);
+        self::assertStringContainsString('$$', $content);
+    }
+}

--- a/tests/Unit/Entity/GroomerProfileFieldsTest.php
+++ b/tests/Unit/Entity/GroomerProfileFieldsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+final class GroomerProfileFieldsTest extends TestCase
+{
+    public function testOptionalFieldsDefaultToNullAndCanBeSet(): void
+    {
+        $user = (new User())
+            ->setEmail('groomer@example.com')
+            ->setRoles([User::ROLE_GROOMER])
+            ->setPassword('hash');
+        $city = new City('Sofia');
+        $profile = new GroomerProfile($user, $city, 'Best Groomers', 'About us');
+
+        self::assertNull($profile->getServiceArea());
+        self::assertNull($profile->getPhone());
+        self::assertNull($profile->getServicesOffered());
+        self::assertNull($profile->getPriceRange());
+
+        $profile->setServiceArea('Downtown');
+        $profile->setPhone('123-456');
+        $profile->setServicesOffered('Bathing');
+        $profile->setPriceRange('$$');
+
+        self::assertSame('Downtown', $profile->getServiceArea());
+        self::assertSame('123-456', $profile->getPhone());
+        self::assertSame('Bathing', $profile->getServicesOffered());
+        self::assertSame('$$', $profile->getPriceRange());
+    }
+}


### PR DESCRIPTION
## Summary
- add service area, phone, services offered, and price range to groomer profile
- render optional groomer details on profile page
- test grooming profile optional fields and detail rendering

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`
- `php bin/phpunit --filter=GroomerDetailRenderTest`
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689b013e098c8322a7948e76a98e97b2