### PR TITLE
feat: add city SEO intro

### DIFF
--- a/migrations/Version20250810170000.php
+++ b/migrations/Version20250810170000.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250810170000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add seo_intro column to city table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $schema->getTable('city')->addColumn('seo_intro', Types::TEXT, ['notnull' => false]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->getTable('city')->dropColumn('seo_intro');
+    }
+}

--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -24,6 +24,9 @@ class City
     #[ORM\Column(length: 255)]
     private string $name;
 
+    #[ORM\Column(name: 'seo_intro', type: Types::TEXT, nullable: true)]
+    private ?string $seoIntro = null;
+
     #[ORM\Column(name: 'created_at', type: Types::DATETIME_IMMUTABLE)]
     private \DateTimeImmutable $createdAt;
 
@@ -41,6 +44,16 @@ class City
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getSeoIntro(): ?string
+    {
+        return $this->seoIntro;
+    }
+
+    public function setSeoIntro(?string $seoIntro): void
+    {
+        $this->seoIntro = $seoIntro;
     }
 
     public function getCreatedAt(): \DateTimeImmutable

--- a/templates/city/show.html.twig
+++ b/templates/city/show.html.twig
@@ -4,6 +4,9 @@
 
 {% block body %}
     <h1>{{ city.name }}</h1>
+    {% if city.seoIntro %}
+        <p>{{ city.seoIntro|split(' ')|slice(0,200)|join(' ') }}</p>
+    {% endif %}
     <p>Grooming options coming soon.</p>
 {% endblock %}
 

--- a/tests/Entity/CitySeoIntroTest.php
+++ b/tests/Entity/CitySeoIntroTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\City;
+use PHPUnit\Framework\TestCase;
+
+final class CitySeoIntroTest extends TestCase
+{
+    public function testSeoIntroGetterAndSetter(): void
+    {
+        $city = new City('Sofia');
+        self::assertNull($city->getSeoIntro());
+
+        $intro = 'Welcome to Sofia, the city of cats.';
+        $city->setSeoIntro($intro);
+        self::assertSame($intro, $city->getSeoIntro());
+    }
+}

--- a/tests/Integration/CitySeoIntroRenderTest.php
+++ b/tests/Integration/CitySeoIntroRenderTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use App\Entity\City;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class CitySeoIntroRenderTest extends WebTestCase
+{
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testSeoIntroRendersWhenSet(): void
+    {
+        $city = new City('Testopolis');
+        $city->refreshSlugFrom('Testopolis');
+        $city->setSeoIntro('Amazing place for pets.');
+        $this->em->persist($city);
+        $this->em->flush();
+
+        $this->client->request('GET', '/cities/'.$city->getSlug());
+        self::assertResponseIsSuccessful();
+        $content = $this->client->getResponse()->getContent();
+        $this->assertStringContainsString('Amazing place for pets.', $content);
+        $this->assertSame(2, substr_count($content, '<p>'));
+    }
+
+    public function testNoSeoIntroRendersNothing(): void
+    {
+        $city = new City('Plainville');
+        $city->refreshSlugFrom('Plainville');
+        $this->em->persist($city);
+        $this->em->flush();
+
+        $this->client->request('GET', '/cities/'.$city->getSlug());
+        self::assertResponseIsSuccessful();
+        $content = $this->client->getResponse()->getContent();
+        $this->assertSame(1, substr_count($content, '<p>'));
+    }
+}


### PR DESCRIPTION
## Summary
- allow storing a short SEO intro for cities
- show SEO intro beneath city title with 200-word cap
- cover SEO intro with unit and integration tests

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*
- `composer fix:php`
- `composer stan`
- `composer test`
- `php bin/phpunit --filter=CitySeoIntroRenderTest`


------
https://chatgpt.com/codex/tasks/task_e_689b0151d96c8322a37aa63cf3295772