### PR TITLE
feat: add registration with role selection

### DIFF
--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Form\RegistrationFormType;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Annotation\Route;
+
+class RegistrationController extends AbstractController
+{
+    #[Route('/register', name: 'app_register')]
+    public function register(Request $request, UserPasswordHasherInterface $passwordHasher, EntityManagerInterface $entityManager): Response
+    {
+        $user = new User();
+        $form = $this->createForm(RegistrationFormType::class, $user);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $selectedRole = $form->get('role')->getData();
+            if (!\is_string($selectedRole)) {
+                throw $this->createAccessDeniedException('Invalid role');
+            }
+
+            $allowedRoles = ['ROLE_OWNER', User::ROLE_GROOMER];
+            if (!\in_array($selectedRole, $allowedRoles, true)) {
+                throw $this->createAccessDeniedException('Invalid role');
+            }
+
+            $user->setRoles([$selectedRole, 'ROLE_USER']);
+            $plainPassword = $form->get('plainPassword')->getData();
+            if (!\is_string($plainPassword)) {
+                throw new \RuntimeException('Invalid password');
+            }
+
+            $hashedPassword = $passwordHasher->hashPassword($user, $plainPassword);
+            $user->setPassword($hashedPassword);
+
+            $entityManager->persist($user);
+            $entityManager->flush();
+
+            return $this->redirectToRoute('app_homepage');
+        }
+
+        return $this->render('registration/register.html.twig', [
+            'registrationForm' => $form->createView(),
+        ]);
+    }
+}

--- a/src/Form/RegistrationFormType.php
+++ b/src/Form/RegistrationFormType.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use App\Entity\User;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class RegistrationFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('email', EmailType::class)
+            ->add('plainPassword', PasswordType::class, [
+                'mapped' => false,
+            ])
+            ->add('role', ChoiceType::class, [
+                'choices' => [
+                    'Owner' => 'ROLE_OWNER',
+                    'Groomer' => User::ROLE_GROOMER,
+                ],
+                'mapped' => false,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class,
+        ]);
+    }
+}

--- a/templates/registration/register.html.twig
+++ b/templates/registration/register.html.twig
@@ -1,0 +1,12 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Register{% endblock %}
+
+{% block body %}
+    {{ form_start(registrationForm) }}
+        {{ form_row(registrationForm.email) }}
+        {{ form_row(registrationForm.plainPassword) }}
+        {{ form_row(registrationForm.role) }}
+        <button type="submit">Register</button>
+    {{ form_end(registrationForm) }}
+{% endblock %}

--- a/tests/E2E/RegistrationFlowTest.php
+++ b/tests/E2E/RegistrationFlowTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E;
+
+use App\Repository\UserRepository;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class RegistrationFlowTest extends WebTestCase
+{
+    public function testRegisterGroomer(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/register');
+        self::assertResponseIsSuccessful();
+
+        $email = uniqid('user_', true).'@example.com';
+        $form = $crawler->selectButton('Register')->form([
+            'registration_form[email]' => $email,
+            'registration_form[plainPassword]' => 'secret',
+            'registration_form[role]' => 'ROLE_GROOMER',
+        ]);
+
+        $client->submit($form);
+        self::assertResponseRedirects('/');
+
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => $email]);
+        self::assertNotNull($user);
+        self::assertContains('ROLE_GROOMER', $user->getRoles());
+    }
+}

--- a/tests/Form/RegistrationFormTypeTest.php
+++ b/tests/Form/RegistrationFormTypeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Form;
+
+use App\Form\RegistrationFormType;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class RegistrationFormTypeTest extends TypeTestCase
+{
+    public function testRoleChoices(): void
+    {
+        $form = $this->factory->create(RegistrationFormType::class);
+        $choices = $form->get('role')->getConfig()->getOption('choices');
+
+        self::assertSame([
+            'Owner' => 'ROLE_OWNER',
+            'Groomer' => 'ROLE_GROOMER',
+        ], $choices);
+    }
+
+    public function testSubmitValidData(): void
+    {
+        $formData = [
+            'email' => 'user@example.com',
+            'plainPassword' => 'password',
+            'role' => 'ROLE_OWNER',
+        ];
+
+        $form = $this->factory->create(RegistrationFormType::class);
+        $form->submit($formData);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertTrue($form->isValid());
+        self::assertSame('ROLE_OWNER', $form->get('role')->getData());
+    }
+}


### PR DESCRIPTION
## Summary
- add registration form with role selection for owners or groomers
- handle registration route and persist user with chosen role
- cover registration with unit and e2e tests

## Testing
- `composer test`
- `php bin/phpunit --filter=RegistrationFlowTest`


------
https://chatgpt.com/codex/tasks/task_e_689b2af416a48322a1cc3c0447d025ef