### PR TITLE
feat: add groomer listing by city

### DIFF
--- a/src/Controller/GroomerController.php
+++ b/src/Controller/GroomerController.php
@@ -43,7 +43,33 @@ final class GroomerController extends AbstractController
         ]);
     }
 
-    #[Route('/groomers/{slug}', name: 'app_groomer_show', methods: ['GET'])]
+    #[Route(
+        '/groomers/{citySlug}',
+        name: 'app_groomer_list_by_city',
+        methods: ['GET'],
+        requirements: ['citySlug' => '[a-z0-9]+']
+    )]
+    public function listByCity(
+        string $citySlug,
+        Request $request,
+        CityRepository $cityRepository,
+        GroomerProfileRepository $groomerProfileRepository,
+    ): Response {
+        $city = $cityRepository->findOneBySlug($citySlug);
+        if (null === $city) {
+            throw $this->createNotFoundException();
+        }
+
+        $page = max(1, $request->query->getInt('page', 1));
+        $groomers = $groomerProfileRepository->findByCitySlug($citySlug, $page);
+
+        return $this->render('groomer/list_by_city.html.twig', [
+            'groomers' => $groomers,
+            'city' => $city,
+        ]);
+    }
+
+    #[Route('/groomers/{slug}', name: 'app_groomer_show', methods: ['GET'], requirements: ['slug' => '[^/]+-[^/]+'])]
     public function show(string $slug, GroomerProfileRepository $groomerProfileRepository): Response
     {
         $groomer = $groomerProfileRepository->findOneBySlug($slug);
@@ -54,5 +80,11 @@ final class GroomerController extends AbstractController
         return $this->render('groomer/show.html.twig', [
             'groomer' => $groomer,
         ]);
+    }
+
+    #[Route('/groomers/{slug}/', name: 'app_groomer_show_trailing', methods: ['GET'], requirements: ['slug' => '[^/]+-[^/]+'])]
+    public function showTrailingSlash(string $slug): Response
+    {
+        return $this->redirectToRoute('app_groomer_show', ['slug' => $slug], Response::HTTP_MOVED_PERMANENTLY);
     }
 }

--- a/src/Repository/GroomerProfileRepository.php
+++ b/src/Repository/GroomerProfileRepository.php
@@ -8,6 +8,7 @@ use App\Entity\City;
 use App\Entity\GroomerProfile;
 use App\Entity\Service;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -54,5 +55,27 @@ class GroomerProfileRepository extends ServiceEntityRepository
         $result = $query->getResult();
 
         return $result;
+    }
+
+    /**
+     * @return Paginator<GroomerProfile>
+     */
+    public function findByCitySlug(string $slug, int $page = 1): Paginator
+    {
+        $limit = 20;
+        $offset = max(0, ($page - 1) * $limit);
+
+        $query = $this->createQueryBuilder('g')
+            ->innerJoin('g.city', 'c')
+            ->where('c.slug = :slug')
+            ->setParameter('slug', $slug)
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->getQuery();
+
+        /** @var Paginator<GroomerProfile> $paginator */
+        $paginator = new Paginator($query);
+
+        return $paginator;
     }
 }

--- a/templates/groomer/list_by_city.html.twig
+++ b/templates/groomer/list_by_city.html.twig
@@ -1,0 +1,21 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Groomers in {{ city.name }}{% endblock %}
+
+{% block body %}
+    <h1>Groomers in {{ city.name }}</h1>
+    {% if groomers|length %}
+        <ul>
+        {% for groomer in groomers %}
+            <li>
+                <a href="/groomers/{{ groomer.slug }}">{{ groomer.businessName }}</a><br>
+                <span>Service area: {{ groomer.serviceArea ?? '' }}</span><br>
+                <span>Phone: {{ groomer.phone ?? '' }}</span><br>
+                <span>Price range: {{ groomer.priceRange ?? '' }}</span>
+            </li>
+        {% endfor %}
+        </ul>
+    {% else %}
+        <p>No results yet.</p>
+    {% endif %}
+{% endblock %}

--- a/tests/Controller/GroomerListByCityTest.php
+++ b/tests/Controller/GroomerListByCityTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class GroomerListByCityTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testListByCityShowsPaginatedProfiles(): void
+    {
+        $city = new City('Sofia');
+        $city->refreshSlugFrom($city->getName());
+        $otherCity = new City('Plovdiv');
+        $otherCity->refreshSlugFrom($otherCity->getName());
+        $this->em->persist($city);
+        $this->em->persist($otherCity);
+
+        $firstProfile = null;
+        for ($i = 1; $i <= 25; ++$i) {
+            $user = (new User())
+                ->setEmail('groomer'.$i.'@example.com')
+                ->setRoles([User::ROLE_GROOMER])
+                ->setPassword('hash');
+            $profile = new GroomerProfile($user, $city, 'Groomer '.$i, 'About');
+            $profile->refreshSlugFrom($profile->getBusinessName());
+            if (null === $firstProfile) {
+                $firstProfile = $profile;
+            }
+            $this->em->persist($user);
+            $this->em->persist($profile);
+        }
+
+        $otherUser = (new User())
+            ->setEmail('other@example.com')
+            ->setRoles([User::ROLE_GROOMER])
+            ->setPassword('hash');
+        $otherProfile = new GroomerProfile($otherUser, $otherCity, 'Other', 'About');
+        $otherProfile->refreshSlugFrom($otherProfile->getBusinessName());
+        $this->em->persist($otherUser);
+        $this->em->persist($otherProfile);
+
+        $this->em->flush();
+
+        $this->client->request('GET', '/groomers/'.$city->getSlug());
+        self::assertResponseIsSuccessful();
+        $content = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('Groomer 1', $content);
+        self::assertStringNotContainsString('Other', $content);
+        self::assertStringContainsString('/groomers/'.$firstProfile->getSlug(), $content);
+
+        $this->client->request('GET', '/groomers/'.$city->getSlug().'?page=2');
+        self::assertResponseIsSuccessful();
+        $content = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('Groomer 25', $content);
+        self::assertStringNotContainsString('Groomer 1', $content);
+    }
+
+    public function testUnknownCityReturns404(): void
+    {
+        $this->client->request('GET', '/groomers/unknown-city');
+        self::assertResponseStatusCodeSame(404);
+    }
+}


### PR DESCRIPTION
## Summary
- add route to list groomers by city with pagination
- implement repository lookup by city slug
- render city listing cards with contact info
- cover city listing with integration tests

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`
- `php bin/phpunit tests/Controller/GroomerListByCityTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689b2b37288c83229b49d44ddb505108