### PR TITLE
feat: import groomers from CSV

### DIFF
--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -27,6 +27,9 @@
         <testsuite name="integration">
             <directory>tests/Integration</directory>
         </testsuite>
+        <testsuite name="command">
+            <directory>tests/Command</directory>
+        </testsuite>
         <testsuite name="e2e">
             <directory>tests/E2E</directory>
         </testsuite>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,9 @@
         <testsuite name="Integration">
             <directory>tests/Integration</directory>
         </testsuite>
+        <testsuite name="Command">
+            <directory>tests/Command</directory>
+        </testsuite>
         <testsuite name="e2e">
             <directory>tests/E2E</directory>
         </testsuite>

--- a/src/Command/ImportGroomersCsvCommand.php
+++ b/src/Command/ImportGroomersCsvCommand.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Repository\CityRepository;
+use App\Repository\GroomerProfileRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+#[AsCommand(name: 'app:groomers:import-csv', description: 'Import unclaimed groomers from a CSV file')]
+final class ImportGroomersCsvCommand extends Command
+{
+    public function __construct(
+        private readonly CityRepository $cityRepository,
+        private readonly GroomerProfileRepository $groomerRepository,
+        private readonly EntityManagerInterface $em,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('csv', InputArgument::REQUIRED, 'Path to CSV file');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $path = $input->getArgument('csv');
+        if (!is_string($path) || !is_readable($path)) {
+            $output->writeln('<error>CSV file not readable.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $file = new \SplFileObject($path);
+        $file->setFlags(\SplFileObject::READ_CSV | \SplFileObject::SKIP_EMPTY);
+
+        $inserted = 0;
+        $updated = 0;
+        $skipped = 0;
+        $rowNum = 0;
+
+        foreach ($file as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            // Skip header
+            if (0 === $rowNum++) {
+                continue;
+            }
+
+            [$name, $citySlug, $phone, $serviceArea, $servicesOffered, $priceRange] = array_pad($row, 6, null);
+
+            if (!is_string($name) || !is_string($citySlug)) {
+                ++$skipped;
+
+                continue;
+            }
+
+            $phone = is_string($phone) ? $phone : null;
+            $serviceArea = is_string($serviceArea) ? $serviceArea : null;
+            $servicesOffered = is_string($servicesOffered) ? $servicesOffered : null;
+            $priceRange = is_string($priceRange) ? $priceRange : null;
+
+            $city = $this->cityRepository->findOneBySlug($citySlug);
+            if (!$city instanceof City) {
+                ++$skipped;
+
+                continue;
+            }
+
+            $existing = $this->findExisting($name, $city);
+
+            if (null !== $existing) {
+                $this->applyDetails($existing, $phone, $serviceArea, $servicesOffered, $priceRange);
+                $this->em->flush();
+                ++$updated;
+
+                continue;
+            }
+
+            $profile = new GroomerProfile(null, $city, $name, '');
+            $profile->refreshSlugFrom($name);
+
+            $suffix = 1;
+            while ($this->groomerRepository->existsBySlug($profile->getSlug())) {
+                $profile->refreshSlugFrom(sprintf('%s-%d', $name, $suffix));
+                ++$suffix;
+            }
+
+            $this->applyDetails($profile, $phone, $serviceArea, $servicesOffered, $priceRange);
+
+            $this->em->persist($profile);
+            $this->em->flush();
+            ++$inserted;
+        }
+
+        $output->writeln(sprintf('Inserted: %d', $inserted));
+        $output->writeln(sprintf('Updated: %d', $updated));
+        $output->writeln(sprintf('Skipped: %d', $skipped));
+
+        return Command::SUCCESS;
+    }
+
+    private function findExisting(string $name, City $city): ?GroomerProfile
+    {
+        $slug = $this->slugify($name);
+        $existing = $this->groomerRepository->findOneBySlug($slug);
+        if (null !== $existing) {
+            return $existing;
+        }
+
+        return $this->groomerRepository->findOneBy([
+            'businessName' => $name,
+            'city' => $city,
+        ]);
+    }
+
+    private function applyDetails(
+        GroomerProfile $profile,
+        ?string $phone,
+        ?string $serviceArea,
+        ?string $servicesOffered,
+        ?string $priceRange,
+    ): void {
+        $profile->setPhone($this->nullOrTrim($phone));
+        $profile->setServiceArea($this->nullOrTrim($serviceArea));
+        $profile->setServicesOffered($this->nullOrTrim($servicesOffered));
+        $profile->setPriceRange($this->nullOrTrim($priceRange));
+    }
+
+    private function nullOrTrim(?string $value): ?string
+    {
+        $trimmed = null === $value ? null : trim($value);
+
+        return '' === $trimmed ? null : $trimmed;
+    }
+
+    private function slugify(string $source): string
+    {
+        $normalized = preg_replace('/\s+/', ' ', mb_strtolower(trim($source))) ?? '';
+
+        return (new AsciiSlugger())->slug($normalized)->lower()->toString();
+    }
+}

--- a/src/Entity/GroomerProfile.php
+++ b/src/Entity/GroomerProfile.php
@@ -23,8 +23,8 @@ class GroomerProfile
     private ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
-    #[ORM\JoinColumn(nullable: false)]
-    private User $user;
+    #[ORM\JoinColumn(nullable: true)]
+    private ?User $user = null;
 
     #[ORM\ManyToOne(targetEntity: City::class)]
     #[ORM\JoinColumn(nullable: false)]
@@ -53,9 +53,9 @@ class GroomerProfile
     #[ORM\JoinTable(name: 'groomer_profile_service')]
     private Collection $services;
 
-    public function __construct(User $user, City $city, string $businessName, string $about, string $slug = '')
+    public function __construct(?User $user, City $city, string $businessName, string $about, string $slug = '')
     {
-        if (!in_array(User::ROLE_GROOMER, $user->getRoles(), true)) {
+        if (null !== $user && !in_array(User::ROLE_GROOMER, $user->getRoles(), true)) {
             throw new \InvalidArgumentException('User must have groomer role.');
         }
 
@@ -72,7 +72,7 @@ class GroomerProfile
         return $this->id;
     }
 
-    public function getUser(): User
+    public function getUser(): ?User
     {
         return $this->user;
     }

--- a/tests/Command/GroomerImportCsvTest.php
+++ b/tests/Command/GroomerImportCsvTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\ImportGroomersCsvCommand;
+use App\Entity\City;
+use App\Repository\GroomerProfileRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class GroomerImportCsvTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private GroomerProfileRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $container = static::getContainer();
+        $this->em = $container->get('doctrine')->getManager();
+        $this->repository = $container->get(GroomerProfileRepository::class);
+
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+
+        $city = new City('Sofia');
+        $city->refreshSlugFrom('sofia');
+        $this->em->persist($city);
+        $this->em->flush();
+    }
+
+    public function testImportIsIdempotent(): void
+    {
+        $csv = <<<CSV
+name,city_slug,phone,service_area,services_offered,price_range
+Paw Parlour,sofia,12345,Downtown,Full service,"$$"
+Other,unknown,999,,,
+CSV;
+        $path = sys_get_temp_dir().'/groomers.csv';
+        file_put_contents($path, $csv);
+
+        $command = static::getContainer()->get(ImportGroomersCsvCommand::class);
+        $tester = new CommandTester($command);
+
+        $status1 = $tester->execute(['csv' => $path]);
+        self::assertSame(ImportGroomersCsvCommand::SUCCESS, $status1);
+        $display1 = $tester->getDisplay();
+        self::assertStringContainsString('Inserted: 1', $display1);
+        self::assertStringContainsString('Updated: 0', $display1);
+        self::assertStringContainsString('Skipped: 1', $display1);
+        self::assertCount(1, $this->repository->findAll());
+
+        $status2 = $tester->execute(['csv' => $path]);
+        self::assertSame(ImportGroomersCsvCommand::SUCCESS, $status2);
+        $display2 = $tester->getDisplay();
+        self::assertStringContainsString('Inserted: 0', $display2);
+        self::assertStringContainsString('Updated: 1', $display2);
+        self::assertStringContainsString('Skipped: 1', $display2);
+        self::assertCount(1, $this->repository->findAll());
+    }
+}


### PR DESCRIPTION
## Summary
- add command to import unclaimed groomers from CSV
- allow GroomerProfile without a user for unclaimed entries
- test groomer CSV import and wire into PHPUnit suites

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`
- `./vendor/bin/phpunit tests/Command/GroomerImportCsvTest.php --testdox`


------
https://chatgpt.com/codex/tasks/task_e_689b2b5b31c08322af9624781d5d845f