### PR TITLE
feat: add global layout and design tokens

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,3 +1,79 @@
+/* Design tokens */
+:root {
+    --color-bg: #fdfdfd;
+    --color-text: #1a1a1a;
+    --color-primary: #0d6efd;
+    --spacing-xs: 0.25rem;
+    --spacing-sm: 0.5rem;
+    --spacing-md: 1rem;
+    --spacing-lg: 2rem;
+    --font-size-base: 16px;
+    --max-width: 70rem;
+}
+
+/* Base styles */
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
 body {
-    background-color: skyblue;
+    margin: 0;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+    background: var(--color-bg);
+    color: var(--color-text);
+    line-height: 1.5;
+    font-size: var(--font-size-base);
+}
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+.skip-link:focus {
+    left: 0;
+    top: 0;
+    width: auto;
+    height: auto;
+    padding: var(--spacing-sm);
+    background: var(--color-primary);
+    color: #fff;
+    z-index: 1000;
+}
+
+/* Layout utilities */
+.container {
+    width: 100%;
+    max-width: var(--max-width);
+    margin-inline: auto;
+    padding-inline: var(--spacing-md);
+}
+
+.grid {
+    display: grid;
+    gap: var(--spacing-md);
+}
+
+.btn {
+    display: inline-block;
+    padding: var(--spacing-sm) var(--spacing-md);
+    background: var(--color-primary);
+    color: #fff;
+    text-decoration: none;
+    border-radius: 4px;
+}
+
+header,
+footer {
+    background: #fff;
+    padding-block: var(--spacing-md);
+}
+
+footer {
+    text-align: center;
+    font-size: 0.875rem;
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,17 +1,22 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title>{% block title %}Welcome!{% endblock %}</title>
-        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
-        {% block stylesheets %}
-        {% endblock %}
-
-        {% block javascripts %}
-            {% block importmap %}{{ importmap('app') }}{% endblock %}
-        {% endblock %}
-    </head>
-    <body>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}CleanWhiskers{% endblock %}</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
+    <link rel="stylesheet" href="{{ asset('styles/app.css') }}">
+    {% block stylesheets %}{% endblock %}
+    {% block javascripts %}
+        {% block importmap %}{{ importmap('app') }}{% endblock %}
+    {% endblock %}
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    {% include 'partials/_header.html.twig' %}
+    <main id="main" class="container">
         {% block body %}{% endblock %}
-    </body>
+    </main>
+    {% include 'partials/_footer.html.twig' %}
+</body>
 </html>

--- a/templates/partials/_footer.html.twig
+++ b/templates/partials/_footer.html.twig
@@ -1,0 +1,5 @@
+<footer>
+    <div class="container">
+        <p>&copy; {{ "now"|date("Y") }} CleanWhiskers</p>
+    </div>
+</footer>

--- a/templates/partials/_header.html.twig
+++ b/templates/partials/_header.html.twig
@@ -1,0 +1,7 @@
+<header>
+    <div class="container">
+        <nav class="grid" aria-label="Main navigation">
+            <a href="{{ path('app_homepage') }}" class="logo">CleanWhiskers</a>
+        </nav>
+    </div>
+</header>

--- a/tests/E2E/LayoutElementsTest.php
+++ b/tests/E2E/LayoutElementsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class LayoutElementsTest extends WebTestCase
+{
+    public function testHeaderMainFooterPresent(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, $crawler->filter('header'));
+        self::assertCount(1, $crawler->filter('main'));
+        self::assertCount(1, $crawler->filter('footer'));
+    }
+}

--- a/tests/Integration/CitySeoIntroRenderTest.php
+++ b/tests/Integration/CitySeoIntroRenderTest.php
@@ -31,11 +31,11 @@ final class CitySeoIntroRenderTest extends WebTestCase
         $this->em->persist($city);
         $this->em->flush();
 
-        $this->client->request('GET', '/cities/'.$city->getSlug());
+        $crawler = $this->client->request('GET', '/cities/'.$city->getSlug());
         self::assertResponseIsSuccessful();
         $content = $this->client->getResponse()->getContent();
         $this->assertStringContainsString('Amazing place for pets.', $content);
-        $this->assertSame(2, substr_count($content, '<p>'));
+        $this->assertSame(2, $crawler->filter('main p')->count());
     }
 
     public function testNoSeoIntroRendersNothing(): void
@@ -45,9 +45,8 @@ final class CitySeoIntroRenderTest extends WebTestCase
         $this->em->persist($city);
         $this->em->flush();
 
-        $this->client->request('GET', '/cities/'.$city->getSlug());
+        $crawler = $this->client->request('GET', '/cities/'.$city->getSlug());
         self::assertResponseIsSuccessful();
-        $content = $this->client->getResponse()->getContent();
-        $this->assertSame(1, substr_count($content, '<p>'));
+        $this->assertSame(1, $crawler->filter('main p')->count());
     }
 }

--- a/tests/Twig/BaseLayoutTest.php
+++ b/tests/Twig/BaseLayoutTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Twig;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Twig\Environment;
+
+class BaseLayoutTest extends KernelTestCase
+{
+    public function testBaseTemplateRenders(): void
+    {
+        self::bootKernel();
+        $twig = static::getContainer()->get(Environment::class);
+        $html = $twig->render('base.html.twig');
+        self::assertStringContainsString('<main', $html);
+    }
+}


### PR DESCRIPTION
## Summary
- add header and footer partials with skip link and container layout
- introduce design tokens and utility classes in global CSS
- test base layout rendering and structural elements

## Testing
- `make setup && make test -k` *(fails: No rule to make target 'setup')*
- `composer fix:php`
- `composer stan`
- `composer test`
- `./vendor/bin/phpunit`
- `php bin/phpunit --testsuite=e2e`


------
https://chatgpt.com/codex/tasks/task_e_689caf53cc448322a69f7015e547b750