### PR TITLE
feat: add reusable SEO head partial

### DIFF
--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -33,6 +33,9 @@
         <testsuite name="e2e">
             <directory>tests/E2E</directory>
         </testsuite>
+        <testsuite name="twig">
+            <directory>tests/Twig</directory>
+        </testsuite>
     </testsuites>
 
     <source ignoreSuppressionOfDeprecations="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,9 @@
         <testsuite name="e2e">
             <directory>tests/E2E</directory>
         </testsuite>
+        <testsuite name="Twig">
+            <directory>tests/Twig</directory>
+        </testsuite>
     </testsuites>
 
     <source>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,8 +1,9 @@
+{% use 'partials/_seo_head.html.twig' %}
 <!DOCTYPE html>
 <html>
     <head>
         <meta charset="UTF-8">
-        <title>{% block title %}Welcome!{% endblock %}</title>
+        {{ block('seo_head') }}
         <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
         {% block stylesheets %}
         {% endblock %}

--- a/templates/partials/_seo_head.html.twig
+++ b/templates/partials/_seo_head.html.twig
@@ -1,0 +1,12 @@
+{% block seo_head %}
+    {% set default_title = 'CleanWhiskers' %}
+    {% set default_description = 'Find the best pet groomers near you.' %}
+    <title>{% block title %}{{ default_title }}{% endblock %}</title>
+    <meta name="description" content="{% block meta_description %}{{ default_description }}{% endblock %}">
+    <link rel="canonical" href="{% block canonical %}{{ app.request.uri }}{% endblock %}">
+    <meta property="og:title" content="{% block og_title %}{{ block('title') }}{% endblock %}">
+    <meta property="og:description" content="{% block og_description %}{{ block('meta_description') }}{% endblock %}">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{% block twitter_title %}{{ block('og_title') }}{% endblock %}">
+    <meta name="twitter:description" content="{% block twitter_description %}{{ block('og_description') }}{% endblock %}">
+{% endblock %}

--- a/tests/Twig/SeoHeadPartialTest.php
+++ b/tests/Twig/SeoHeadPartialTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Twig;
+
+use App\Entity\City;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class SeoHeadPartialTest extends WebTestCase
+{
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testHomePageHasCanonicalAndOgTags(): void
+    {
+        $this->client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+        $content = $this->client->getResponse()->getContent();
+        self::assertStringContainsString('<link rel="canonical" href="', $content);
+        self::assertMatchesRegularExpression('/<meta property="og:title" content="[^"]+"/', $content);
+        self::assertMatchesRegularExpression('/<meta property="og:description" content="[^"]+"/', $content);
+    }
+
+    public function testCityPageHasCanonicalAndOgTags(): void
+    {
+        $city = new City('Testopolis');
+        $city->refreshSlugFrom('Testopolis');
+        $this->em->persist($city);
+        $this->em->flush();
+
+        $this->client->request('GET', '/cities/'.$city->getSlug());
+        self::assertResponseIsSuccessful();
+        $content = $this->client->getResponse()->getContent();
+        self::assertStringContainsString('<link rel="canonical" href="', $content);
+        self::assertMatchesRegularExpression('/<meta property="og:title" content="[^"]+"/', $content);
+        self::assertMatchesRegularExpression('/<meta property="og:description" content="[^"]+"/', $content);
+    }
+}


### PR DESCRIPTION
## Summary
- centralize SEO, Open Graph, and Twitter meta tags in a shared Twig partial
- include canonical and social preview tags in base layout
- cover canonical and OG tags with Twig test suite

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689caf5e42dc8322bcf94e0df9a44ff0