### PR TITLE
feat: add responsive mobile menu

### DIFF
--- a/assets/bootstrap.js
+++ b/assets/bootstrap.js
@@ -1,5 +1,8 @@
-// import { startStimulusApp } from '@symfony/stimulus-bundle';
+import { startStimulusApp } from '@symfony/stimulus-bundle';
 
-// const app = startStimulusApp();
-// // register any custom, 3rd party controllers here
-// // app.register('some_controller_name', SomeImportedController);
+const app = startStimulusApp(
+    import.meta.glob('./controllers/**/*_controller.js', { eager: true })
+);
+
+// register any custom, 3rd party controllers here
+// app.register('some_controller_name', SomeImportedController);

--- a/assets/controllers/menu_controller.js
+++ b/assets/controllers/menu_controller.js
@@ -1,0 +1,62 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['menu'];
+
+    connect() {
+        this.isOpen = false;
+        this.menuTarget.classList.add('is-ready');
+        this.close();
+    }
+
+    toggle() {
+        this.isOpen ? this.close() : this.open();
+    }
+
+    open() {
+        this.menuTarget.classList.add('is-open');
+        this.element.setAttribute('aria-expanded', 'true');
+        this.isOpen = true;
+        this.focusable = this.menuTarget.querySelectorAll('a, button, [tabindex]:not([tabindex="-1"])');
+        if (this.focusable.length > 0) {
+            this.focusable[0].focus();
+        }
+        this.boundTrap = this.trap.bind(this);
+        document.addEventListener('keydown', this.boundTrap);
+    }
+
+    close() {
+        this.menuTarget.classList.remove('is-open');
+        this.element.setAttribute('aria-expanded', 'false');
+        this.isOpen = false;
+        document.removeEventListener('keydown', this.boundTrap);
+    }
+
+    trap(event) {
+        if (!this.isOpen) {
+            return;
+        }
+
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            this.close();
+            this.element.focus();
+            return;
+        }
+
+        if (event.key !== 'Tab') {
+            return;
+        }
+
+        const first = this.focusable[0];
+        const last = this.focusable[this.focusable.length - 1];
+
+        if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+        }
+    }
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,3 +1,57 @@
 body {
     background-color: skyblue;
 }
+
+.topbar {
+    position: sticky;
+    top: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: #fff;
+    padding: 0.5rem 1rem;
+}
+
+.topbar__burger {
+    background: none;
+    border: 0;
+    font-size: 1.5rem;
+}
+
+.topbar__nav {
+    display: flex;
+    gap: 1rem;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 480px) {
+    .topbar__burger {
+        display: block;
+    }
+
+    .topbar__nav.is-ready {
+        display: none;
+        flex-direction: column;
+    }
+
+    .topbar__nav.is-ready.is-open {
+        display: flex;
+    }
+}
+
+@media (min-width: 481px) {
+    .topbar__burger {
+        display: none;
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -12,6 +12,7 @@
         {% endblock %}
     </head>
     <body>
+        {% include 'partials/_header.html.twig' %}
         {% block body %}{% endblock %}
     </body>
 </html>

--- a/templates/partials/_header.html.twig
+++ b/templates/partials/_header.html.twig
@@ -1,0 +1,11 @@
+<header class="topbar">
+    <a href="{{ path('app_homepage') }}" class="topbar__logo">CleanWhiskers</a>
+    <button class="topbar__burger" type="button" data-controller="menu" data-action="click->menu#toggle" aria-expanded="false" aria-controls="main-nav">
+        <span class="sr-only">Menu</span>
+        ☰
+    </button>
+    <nav id="main-nav" class="topbar__nav" data-menu-target="menu">
+        <a href="{{ path('app_homepage') }}">Home</a>
+        <a href="{{ path('app_register') }}">Register</a>
+    </nav>
+</header>

--- a/tests/E2E/MenuTest.php
+++ b/tests/E2E/MenuTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E;
+
+use PHPUnit\Framework\TestCase;
+
+class MenuTest extends TestCase
+{
+    public function testMenuToggles(): void
+    {
+        if (!class_exists(\Symfony\Component\Panther\PantherTestCase::class)) {
+            $this->markTestSkipped('Panther not installed');
+            return;
+        }
+
+        $client = \Symfony\Component\Panther\PantherTestCase::createPantherClient();
+        $crawler = $client->request('GET', '/');
+        $button = $crawler->filter('.topbar__burger');
+        self::assertSame('false', $button->attr('aria-expanded'));
+        $button->click();
+        self::assertSame('true', $button->attr('aria-expanded'));
+    }
+}


### PR DESCRIPTION
## Summary
- add Stimulus controller with focus trap for mobile menu
- style and include responsive header partial
- add integration test (skipped if Panther unavailable)

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*
- `composer lint:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689caf733c0883228f07e6e4bb586b03