### PR TITLE
feat: add responsive menu with Stimulus

### DIFF
--- a/assets/bootstrap.js
+++ b/assets/bootstrap.js
@@ -1,5 +1,7 @@
-// import { startStimulusApp } from '@symfony/stimulus-bundle';
+import { startStimulusApp } from '@symfony/stimulus-bundle';
 
-// const app = startStimulusApp();
-// // register any custom, 3rd party controllers here
-// // app.register('some_controller_name', SomeImportedController);
+export const app = startStimulusApp(
+    import.meta.glob('./controllers/**/*_controller.js', { eager: true })
+);
+// Register any custom, 3rd party controllers here
+// app.register('some-controller-name', SomeImportedController);

--- a/assets/controllers/menu_controller.js
+++ b/assets/controllers/menu_controller.js
@@ -1,0 +1,57 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['button', 'list'];
+
+    connect() {
+        this.element.classList.add('has-js');
+    }
+
+    toggle() {
+        const isOpen = this.element.classList.toggle('is-open');
+        this.buttonTarget.setAttribute('aria-expanded', String(isOpen));
+
+        if (isOpen) {
+            this.activateFocusTrap();
+            const first = this.focusables[0];
+            first && first.focus();
+        } else {
+            this.deactivateFocusTrap();
+            this.buttonTarget.focus();
+        }
+    }
+
+    activateFocusTrap() {
+        this.focusables = this.getFocusable();
+        this.boundHandleKeydown = this.handleKeydown.bind(this);
+        this.listTarget.addEventListener('keydown', this.boundHandleKeydown);
+    }
+
+    deactivateFocusTrap() {
+        this.listTarget.removeEventListener('keydown', this.boundHandleKeydown);
+        this.boundHandleKeydown = null;
+    }
+
+    handleKeydown(event) {
+        if (event.key !== 'Tab') {
+            return;
+        }
+
+        const first = this.focusables[0];
+        const last = this.focusables[this.focusables.length - 1];
+
+        if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+        }
+    }
+
+    getFocusable() {
+        return Array.from(this.listTarget.querySelectorAll('a, button, input, [tabindex]:not([tabindex="-1"])')).filter(
+            (el) => !el.hasAttribute('disabled')
+        );
+    }
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -77,3 +77,59 @@ footer {
     text-align: center;
     font-size: 0.875rem;
 }
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: var(--spacing-md);
+}
+
+.menu-toggle {
+    display: none;
+    background: none;
+    border: 0;
+    font-size: 1.5rem;
+}
+
+@media (max-width: 480px) {
+    .menu-toggle {
+        display: block;
+    }
+
+    .nav ul {
+        display: block;
+        margin-top: var(--spacing-md);
+    }
+
+    .nav.has-js ul {
+        display: none;
+    }
+
+    .nav.has-js.is-open ul {
+        display: block;
+    }
+
+    .nav ul li {
+        margin: var(--spacing-sm) 0;
+    }
+}

--- a/templates/partials/_header.html.twig
+++ b/templates/partials/_header.html.twig
@@ -1,7 +1,21 @@
 <header>
     <div class="container">
-        <nav class="grid" aria-label="Main navigation">
+        <nav data-controller="menu" class="nav" aria-label="Main navigation">
             <a href="{{ path('app_homepage') }}" class="logo">CleanWhiskers</a>
+            <button
+                class="menu-toggle"
+                type="button"
+                data-menu-target="button"
+                data-action="menu#toggle"
+                aria-controls="primary-menu"
+                aria-expanded="false"
+            >
+                <span class="visually-hidden">Menu</span>
+                &#9776;
+            </button>
+            <ul id="primary-menu" data-menu-target="list">
+                <li><a href="{{ path('app_register') }}">Register</a></li>
+            </ul>
         </nav>
     </div>
 </header>

--- a/tests/E2E/MenuToggleTest.php
+++ b/tests/E2E/MenuToggleTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E;
+
+use Symfony\Component\Panther\PantherTestCase;
+
+class MenuToggleTest extends PantherTestCase
+{
+    public function testMenuAriaExpandedToggles(): void
+    {
+        $client = self::createPantherClient();
+        $crawler = $client->request('GET', '/');
+
+        $button = $crawler->filter('button.menu-toggle');
+        self::assertSame('false', $button->attr('aria-expanded'));
+
+        $button->click();
+        $client->waitForVisibility('#primary-menu');
+        $crawler = $client->getCrawler();
+        $button = $crawler->filter('button.menu-toggle');
+        self::assertSame('true', $button->attr('aria-expanded'));
+
+        $button->click();
+        $client->waitForInvisibility('#primary-menu');
+        $crawler = $client->getCrawler();
+        $button = $crawler->filter('button.menu-toggle');
+        self::assertSame('false', $button->attr('aria-expanded'));
+    }
+}


### PR DESCRIPTION
## Summary
- add Stimulus-powered mobile menu with focus trap
- style header for responsive burger navigation
- add E2E test for aria-expanded toggle

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Class "Symfony\Component\Panther\PantherTestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cb6e93b748322ac659aeaf3ca0323