### PR TITLE
feat: lazy-load groomer images

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -96,3 +96,11 @@ footer {
     padding: var(--spacing-sm);
     font-size: 1rem;
 }
+
+/* Groomer card images */
+.groomer-card__image {
+    width: 100%;
+    height: auto;
+    object-fit: cover;
+    display: block;
+}

--- a/templates/groomer/_card.html.twig
+++ b/templates/groomer/_card.html.twig
@@ -1,0 +1,14 @@
+{% set placeholder = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'%3E%3Crect width='200' height='200' fill='%23e5e5e5'/%3E%3C/svg%3E" %}
+<li class="groomer-card">
+    <img
+        src="{{ groomer.imageUrl is defined and groomer.imageUrl ? groomer.imageUrl : placeholder }}"
+        alt="{{ groomer.businessName }}"
+        class="groomer-card__image"
+        loading="lazy"
+        decoding="async"
+        width="200"
+        height="200"
+        sizes="(max-width: 600px) 50vw, 200px"
+    >
+    <a href="/groomers/{{ groomer.slug }}">{{ groomer.businessName }}</a>
+</li>


### PR DESCRIPTION
## Summary
- lazy-load groomer card images with width/height and responsive sizes
- style card images with object-fit cover

## Testing
- `make setup && make test -k` *(fails: No rule to make target 'setup')*
- `composer lint:php`
- `composer stan`
- `composer test`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689cbc65f6d08322bf73f0d67492766f