### PR TITLE
feat: add popular cities and services section

### DIFF
--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -35,10 +35,15 @@ class HomepageController extends AbstractController
         $footerCities = $this->cityRepository->findBy([], ['name' => 'ASC'], 5);
         $footerServices = $this->serviceRepository->findBy([], ['name' => 'ASC'], 5);
 
+        $popularCities = $this->cityRepository->findTop(6);
+        $popularServices = $this->serviceRepository->findTop(6);
+
         return $this->render('home/index.html.twig', [
             'ctaLinks' => $ctaLinks,
             'footerCities' => $footerCities,
             'footerServices' => $footerServices,
+            'popularCities' => $popularCities,
+            'popularServices' => $popularServices,
         ]);
     }
 }

--- a/src/Repository/CityRepository.php
+++ b/src/Repository/CityRepository.php
@@ -32,4 +32,20 @@ class CityRepository extends ServiceEntityRepository
             ->getQuery()
             ->getOneOrNullResult();
     }
+
+    /**
+     * @return City[]
+     */
+    public function findTop(int $limit = 6): array
+    {
+        /** @var City[] $cities */
+        $cities = $this->createQueryBuilder('c')
+            ->select('partial c.{id, name, slug, seoIntro}')
+            ->orderBy('c.name', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        return $cities;
+    }
 }

--- a/src/Repository/ServiceRepository.php
+++ b/src/Repository/ServiceRepository.php
@@ -32,4 +32,20 @@ class ServiceRepository extends ServiceEntityRepository
             ->getQuery()
             ->getOneOrNullResult();
     }
+
+    /**
+     * @return Service[]
+     */
+    public function findTop(int $limit = 6): array
+    {
+        /** @var Service[] $services */
+        $services = $this->createQueryBuilder('s')
+            ->select('partial s.{id, name, slug}')
+            ->orderBy('s.name', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        return $services;
+    }
 }

--- a/templates/home/_popular.html.twig
+++ b/templates/home/_popular.html.twig
@@ -1,0 +1,43 @@
+<section id="popular">
+    <h2>Popular Cities</h2>
+    <div class="popular-grid">
+        {% for city in popularCities %}
+            <div class="popular-item">
+                <a href="{{ path('app_city_show', {slug: city.slug}) }}">{{ city.name }}</a>
+                {% if city.seoIntro %}
+                    <p>{{ city.seoIntro }}</p>
+                {% endif %}
+            </div>
+        {% else %}
+            <div class="popular-item">City coming soon</div>
+        {% endfor %}
+    </div>
+
+    <h2>Popular Services</h2>
+    <div class="popular-grid">
+        {% set defaultCity = popularCities|first %}
+        {% for service in popularServices %}
+            <div class="popular-item">
+                {% if defaultCity %}
+                    <a href="{{ path('app_groomer_list_by_city_service', {citySlug: defaultCity.slug, serviceSlug: service.slug}) }}">{{ service.name }} in {{ defaultCity.name }}</a>
+                {% else %}
+                    {{ service.name }}
+                {% endif %}
+            </div>
+        {% else %}
+            <div class="popular-item">Service coming soon</div>
+        {% endfor %}
+    </div>
+</section>
+<style>
+#popular .popular-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 1rem;
+}
+#popular .popular-item {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+}
+</style>
+

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -17,6 +17,7 @@
 </section>
 {% include 'home/_cta_banner.html.twig' %}
 {% include 'home/_how_it_works.html.twig' %}
+{% include 'home/_popular.html.twig' %}
 <script>
     (function () {
         const city = document.getElementById('city');

--- a/tests/Integration/HomepagePopularSectionTest.php
+++ b/tests/Integration/HomepagePopularSectionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use App\Entity\City;
+use App\Entity\Service;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class HomepagePopularSectionTest extends WebTestCase
+{
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testPopularSectionLinksAreRendered(): void
+    {
+        foreach (['Bucharest', 'Ruse', 'Sofia'] as $name) {
+            $city = new City($name);
+            $city->setSeoIntro('Visit '.$name);
+            $this->em->persist($city);
+        }
+
+        foreach (['Dog', 'Cat', 'Mobile'] as $name) {
+            $service = (new Service())->setName($name);
+            $this->em->persist($service);
+        }
+
+        $this->em->flush();
+
+        $crawler = $this->client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+
+        foreach (['bucharest', 'ruse', 'sofia'] as $slug) {
+            self::assertSelectorExists(sprintf('#popular a[href="/cities/%s"]', $slug));
+        }
+
+        $firstCitySlug = 'bucharest';
+        foreach (['dog', 'cat', 'mobile'] as $serviceSlug) {
+            self::assertSelectorExists(sprintf('#popular a[href="/groomers/%s/%s"]', $firstCitySlug, $serviceSlug));
+        }
+    }
+}

--- a/tests/Integration/Repository/CityRepositoryTest.php
+++ b/tests/Integration/Repository/CityRepositoryTest.php
@@ -43,4 +43,19 @@ class CityRepositoryTest extends KernelTestCase
         self::assertNotNull($found);
         self::assertSame('Sofia', $found->getName());
     }
+
+    public function testFindTopReturnsLimitedNumberOfCities(): void
+    {
+        for ($i = 1; $i <= 8; ++$i) {
+            $city = new City('City '.$i);
+            $city->refreshSlugFrom('City '.$i);
+            $this->em->persist($city);
+        }
+
+        $this->em->flush();
+
+        $cities = $this->repository->findTop(6);
+
+        self::assertCount(6, $cities);
+    }
 }

--- a/tests/Integration/Repository/ServiceRepositoryTest.php
+++ b/tests/Integration/Repository/ServiceRepositoryTest.php
@@ -40,4 +40,20 @@ final class ServiceRepositoryTest extends KernelTestCase
         self::assertNotNull($found);
         self::assertSame('Grooming', $found->getName());
     }
+
+    public function testFindTopReturnsLimitedNumberOfServices(): void
+    {
+        for ($i = 1; $i <= 8; ++$i) {
+            $service = (new Service())
+                ->setName('Service '.$i);
+            $service->refreshSlugFrom('Service '.$i);
+            $this->em->persist($service);
+        }
+
+        $this->em->flush();
+
+        $services = $this->repository->findTop(6);
+
+        self::assertCount(6, $services);
+    }
 }


### PR DESCRIPTION
## Summary
- fetch top cities and services for homepage
- render Popular Cities & Services grid with SEO snippets and links
- cover repositories and homepage with tests

## Testing
- `composer stan`
- `composer test`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689cd3b9aea883229258245706c2b072