### PR TITLE
feat: add featured groomers section to homepage

### DIFF
--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Repository\CityRepository;
+use App\Repository\GroomerProfileRepository;
 use App\Repository\ServiceRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
@@ -15,6 +16,7 @@ class HomepageController extends AbstractController
     public function __construct(
         private readonly CityRepository $cityRepository,
         private readonly ServiceRepository $serviceRepository,
+        private readonly GroomerProfileRepository $groomerProfileRepository,
     ) {
     }
 
@@ -37,6 +39,7 @@ class HomepageController extends AbstractController
 
         $popularCities = $this->cityRepository->findTop(6);
         $popularServices = $this->serviceRepository->findTop(6);
+        $featuredGroomers = $this->groomerProfileRepository->findFeatured(4);
 
         return $this->render('home/index.html.twig', [
             'ctaLinks' => $ctaLinks,
@@ -44,6 +47,7 @@ class HomepageController extends AbstractController
             'footerServices' => $footerServices,
             'popularCities' => $popularCities,
             'popularServices' => $popularServices,
+            'featuredGroomers' => $featuredGroomers,
         ]);
     }
 }

--- a/templates/home/_featured_groomers.html.twig
+++ b/templates/home/_featured_groomers.html.twig
@@ -1,0 +1,20 @@
+{% if featuredGroomers|length %}
+<section id="featured-groomers">
+    <h2>Featured Groomers</h2>
+    <div class="featured-groomers-grid">
+        {% for item in featuredGroomers %}
+            {% set g = item.profile %}
+            <div class="featured-groomer-card">
+                <img src="{{ g.logo ?? 'https://via.placeholder.com/64' }}" alt="{{ g.businessName }} logo">
+                <h3><a href="{{ path('app_groomer_show', {slug: g.slug}) }}">{{ g.businessName }}</a></h3>
+                <p class="city">{{ g.city.name }}</p>
+                <p class="rating">{{ item.rating|number_format(1) }} ({{ item.reviewCount }})</p>
+                {% if g.priceRange %}
+                    <p class="price">{{ g.priceRange }}</p>
+                {% endif %}
+                <a href="{{ path('app_groomer_show', {slug: g.slug}) }}">View Profile</a>
+            </div>
+        {% endfor %}
+    </div>
+</section>
+{% endif %}

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -17,6 +17,7 @@
 </section>
 {% include 'home/_cta_banner.html.twig' %}
 {% include 'home/_how_it_works.html.twig' %}
+{% include 'home/_featured_groomers.html.twig' %}
 {% include 'home/_popular.html.twig' %}
 <script>
     (function () {

--- a/tests/Integration/HomepageFeaturedGroomersTest.php
+++ b/tests/Integration/HomepageFeaturedGroomersTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Review;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class HomepageFeaturedGroomersTest extends WebTestCase
+{
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testFeaturedGroomersSectionRendersProfiles(): void
+    {
+        $city = new City('Sofia');
+        $groomerUser = (new User())
+            ->setEmail('g@example.com')
+            ->setPassword('hash')
+            ->setRoles([User::ROLE_GROOMER]);
+        $author = (new User())
+            ->setEmail('a@example.com')
+            ->setPassword('hash');
+        $profile = new GroomerProfile($groomerUser, $city, 'Fancy Groomers', 'About');
+        $profile->setPriceRange('$$');
+
+        $this->em->persist($city);
+        $this->em->persist($groomerUser);
+        $this->em->persist($author);
+        $this->em->persist($profile);
+        $this->em->persist(new Review($profile, $author, 5, 'Great'));
+        $this->em->flush();
+
+        $slug = $profile->getSlug();
+        $crawler = $this->client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists(sprintf('#featured-groomers a[href="/groomers/%s"]', $slug));
+        self::assertSelectorTextContains('#featured-groomers', 'Fancy Groomers');
+    }
+}

--- a/tests/Integration/Repository/GroomerProfileRepositoryTest.php
+++ b/tests/Integration/Repository/GroomerProfileRepositoryTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Repository;
 
 use App\Entity\City;
 use App\Entity\GroomerProfile;
+use App\Entity\Review;
 use App\Entity\User;
 use App\Repository\GroomerProfileRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -48,5 +49,54 @@ final class GroomerProfileRepositoryTest extends KernelTestCase
         $found = $this->repository->findOneBySlug('best-groomers');
         self::assertNotNull($found);
         self::assertSame('Best Groomers', $found->getBusinessName());
+    }
+
+    public function testFindFeaturedReturnsClaimedProfilesOrderedByRatingAndVolume(): void
+    {
+        $city = new City('Sofia');
+        $author = (new User())
+            ->setEmail('author@example.com')
+            ->setPassword('hash');
+
+        $profiles = [];
+        foreach (['Alpha', 'Beta', 'Gamma'] as $i => $name) {
+            $user = (new User())
+                ->setEmail(sprintf('groomer%d@example.com', $i))
+                ->setPassword('hash')
+                ->setRoles([User::ROLE_GROOMER]);
+            $profile = new GroomerProfile($user, $city, $name, 'About');
+            $profiles[$name] = $profile;
+            $this->em->persist($user);
+            $this->em->persist($profile);
+        }
+        $unclaimed = new GroomerProfile(null, $city, 'Delta', 'About');
+        $this->em->persist($city);
+        $this->em->persist($author);
+        $this->em->persist($unclaimed);
+        $this->em->flush();
+
+        // Alpha: rating 5 with 3 reviews
+        for ($i = 0; $i < 3; ++$i) {
+            $this->em->persist(new Review($profiles['Alpha'], $author, 5, 'Great'));
+        }
+        // Beta: rating 4 with 5 reviews
+        for ($i = 0; $i < 5; ++$i) {
+            $this->em->persist(new Review($profiles['Beta'], $author, 4, 'Good'));
+        }
+        // Gamma: rating 4 with 2 reviews
+        for ($i = 0; $i < 2; ++$i) {
+            $this->em->persist(new Review($profiles['Gamma'], $author, 4, 'Okay'));
+        }
+        // Unclaimed profile reviews should be ignored
+        $this->em->persist(new Review($unclaimed, $author, 5, 'Ignored'));
+        $this->em->flush();
+
+        $result = $this->repository->findFeatured(2);
+
+        self::assertCount(2, $result);
+        self::assertSame('Alpha', $result[0]['profile']->getBusinessName());
+        self::assertSame(5.0, $result[0]['rating']);
+        self::assertSame('Beta', $result[1]['profile']->getBusinessName());
+        self::assertSame(5, $result[1]['reviewCount']);
     }
 }


### PR DESCRIPTION
## Summary
- showcase top-rated claimed groomers on the homepage
- compute featured groomers by average rating and review count
- test repository query and featured section rendering

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689cd5c481a88322800875a3ad6b4ca3