### PR TITLE
Register local Stimulus controllers in importmap

### DIFF
--- a/assets/controllers.json
+++ b/assets/controllers.json
@@ -9,6 +9,18 @@
                 "enabled": false,
                 "fetch": "eager"
             }
+        },
+        "controllers/autocomplete_controller": {
+            "enabled": true,
+            "fetch": "eager"
+        },
+        "controllers/csrf_protection_controller": {
+            "enabled": true,
+            "fetch": "eager"
+        },
+        "controllers/hello_controller": {
+            "enabled": true,
+            "fetch": "eager"
         }
     },
     "entrypoints": []

--- a/importmap.php
+++ b/importmap.php
@@ -25,4 +25,16 @@ return [
     '@hotwired/turbo' => [
         'version' => '7.3.0',
     ],
+    'controllers' => [
+        'path' => './assets/controllers',
+    ],
+    'controllers/autocomplete_controller' => [
+        'path' => './assets/controllers/autocomplete_controller.js',
+    ],
+    'controllers/csrf_protection_controller' => [
+        'path' => './assets/controllers/csrf_protection_controller.js',
+    ],
+    'controllers/hello_controller' => [
+        'path' => './assets/controllers/hello_controller.js',
+    ],
 ];


### PR DESCRIPTION
## Summary
- enable autocomplete, CSRF protection and hello Stimulus controllers
- map local controllers in importmap

## Testing
- `php bin/console importmap:install`
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Tests: 62, Assertions: 135, Failures: 14)*
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox` *(fails: Tests: 62, Assertions: 135, Failures: 14)*


------
https://chatgpt.com/codex/tasks/task_e_689ce0d8861c8322a51ddd590120e735