### PR TITLE
fix: update stimulus import

### DIFF
--- a/assets/bootstrap.js
+++ b/assets/bootstrap.js
@@ -1,4 +1,4 @@
-import { startStimulusApp } from '@symfony/stimulus-bundle';
+import { startStimulusApp } from '@symfony/stimulus-bridge';
 
 const app = startStimulusApp();
 // register any custom, 3rd party controllers here


### PR DESCRIPTION
## Summary
- fix stimulus import to use `@symfony/stimulus-bridge`

## Testing
- `composer fix:php`
- `composer stan -- --no-progress`
- `composer test`
- `./vendor/bin/phpunit`
- `yarn install` *(fails: RequestError: Bad response: 403)*
- `yarn build` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_689ce907eb648322bf6668bb0e882b76