### PR TITLE
fix: configure Stimulus bridge

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ Encore
   .setOutputPath('public/build/')
   .setPublicPath('/build')
   .addEntry('main', './assets/app.js') // <- make sure this exists
+  .enableStimulusBridge('./assets/controllers.json')
   .splitEntryChunks()
   .enableSingleRuntimeChunk()
   .cleanupOutputBeforeBuild()


### PR DESCRIPTION
## Summary
- enable Stimulus Bridge in webpack so controllers.json is resolved

## Testing
- `composer lint:php`
- `composer stan`
- `composer test`
- ⚠️ `yarn build` *(fails: cleanwhiskers@workspace:.: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_689ceacfc044832293aa88e683c882b4