### PR TITLE
fix: add symfony ux-turbo dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@babel/core": "^7.28.0",
     "@babel/preset-env": "^7.28.0",
     "@hotwired/stimulus": "^3.2.2",
+    "@symfony/ux-turbo": "file:vendor/symfony/ux-turbo/assets",
     "@symfony/stimulus-bridge": "^4.0.1",
     "@symfony/webpack-encore": "^4.0.0",
     "babel-loader": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4320,3 +4320,7 @@ yocto-queue@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.1.tgz#36d7c4739f775b3cbc28e6136e21aa057adec418"
   integrity sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==
+
+"@symfony/ux-turbo@file:vendor/symfony/ux-turbo/assets":
+  version "2.29.0"
+  resolved "file:vendor/symfony/ux-turbo/assets"


### PR DESCRIPTION
## Summary
- add `@symfony/ux-turbo` to devDependencies so webpack can resolve Stimulus controllers
- update yarn.lock to include `@symfony/ux-turbo`

## Testing
- `composer lint:php`
- `composer stan`
- `composer test`
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*


------
https://chatgpt.com/codex/tasks/task_e_689cec0196ac83228014a13844531948