### PR TITLE
feat: add city and service autocomplete

### DIFF
--- a/assets/js/autocomplete.js
+++ b/assets/js/autocomplete.js
@@ -1,0 +1,119 @@
+const endpoints = {
+    city: '/api/autocomplete/cities',
+    service: '/api/autocomplete/services',
+};
+
+function initAutocomplete(input) {
+    const type = input.dataset.autocomplete;
+    const hidden = document.getElementById(type + 'Slug');
+    const list = document.createElement('ul');
+    list.className = 'autocomplete-list';
+    list.style.position = 'absolute';
+    list.style.zIndex = '1000';
+    list.hidden = true;
+    input.parentNode.appendChild(list);
+
+    let index = -1;
+    let items = [];
+    let debounce;
+
+    input.addEventListener('input', () => {
+        hidden.value = '';
+        const q = input.value.trim().toLowerCase();
+        if (q.length < 2) {
+            list.hidden = true;
+            return;
+        }
+        clearTimeout(debounce);
+        debounce = setTimeout(async () => {
+            try {
+                const response = await fetch(`${endpoints[type]}?q=${encodeURIComponent(q)}`);
+                if (!response.ok) throw new Error('Network');
+                items = await response.json();
+            } catch {
+                items = [];
+            }
+            render();
+        }, 250);
+    });
+
+    input.addEventListener('keydown', (e) => {
+        if (list.hidden) {
+            return;
+        }
+        switch (e.key) {
+            case 'ArrowDown':
+                e.preventDefault();
+                index = Math.min(index + 1, list.children.length - 1);
+                highlight();
+                break;
+            case 'ArrowUp':
+                e.preventDefault();
+                index = Math.max(index - 1, 0);
+                highlight();
+                break;
+            case 'Enter':
+                if (index >= 0) {
+                    e.preventDefault();
+                    select(list.children[index]);
+                }
+                break;
+            case 'Escape':
+                list.hidden = true;
+                break;
+            default:
+        }
+    });
+
+    list.addEventListener('mousedown', (e) => {
+        if (e.target.tagName === 'LI') {
+            select(e.target);
+        }
+    });
+
+    document.addEventListener('click', (e) => {
+        if (!list.contains(e.target) && e.target !== input) {
+            list.hidden = true;
+        }
+    });
+
+    function render() {
+        list.innerHTML = '';
+        index = -1;
+        if (items.length === 0) {
+            const li = document.createElement('li');
+            li.textContent = 'No matches';
+            list.appendChild(li);
+        } else {
+            items.forEach((item) => {
+                const li = document.createElement('li');
+                li.textContent = item.name;
+                li.dataset.slug = item.slug;
+                list.appendChild(li);
+            });
+        }
+        const rect = input.getBoundingClientRect();
+        list.style.left = rect.left + window.scrollX + 'px';
+        list.style.top = rect.bottom + window.scrollY + 'px';
+        list.style.width = rect.width + 'px';
+        list.hidden = false;
+    }
+
+    function highlight() {
+        Array.from(list.children).forEach((li, i) => {
+            li.classList.toggle('selected', i === index);
+        });
+    }
+
+    function select(li) {
+        if (li.dataset.slug) {
+            input.value = li.textContent;
+            hidden.value = li.dataset.slug;
+        }
+        list.hidden = true;
+    }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-autocomplete]').forEach(initAutocomplete);
+});

--- a/src/Controller/AutocompleteController.php
+++ b/src/Controller/AutocompleteController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Repository\CityRepository;
+use App\Repository\ServiceRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/autocomplete', name: 'app_autocomplete_')]
+final class AutocompleteController extends AbstractController
+{
+    public function __construct(
+        private readonly CityRepository $cityRepository,
+        private readonly ServiceRepository $serviceRepository,
+    ) {
+    }
+
+    #[Route('/cities', name: 'cities', methods: ['GET'])]
+    public function cities(Request $request): JsonResponse
+    {
+        $q = trim(mb_strtolower($request->query->getString('q')));
+        if (mb_strlen($q) < 2) {
+            return $this->json([]);
+        }
+
+        return $this->json($this->cityRepository->findByNameLike($q));
+    }
+
+    #[Route('/services', name: 'services', methods: ['GET'])]
+    public function services(Request $request): JsonResponse
+    {
+        $q = trim(mb_strtolower($request->query->getString('q')));
+        if (mb_strlen($q) < 2) {
+            return $this->json([]);
+        }
+
+        return $this->json($this->serviceRepository->findByNameLike($q));
+    }
+}

--- a/src/Repository/CityRepository.php
+++ b/src/Repository/CityRepository.php
@@ -48,4 +48,27 @@ class CityRepository extends ServiceEntityRepository
 
         return $cities;
     }
+
+    /**
+     * @return array<int, array{name: string, slug: string}>
+     */
+    public function findByNameLike(string $q, int $limit = 8): array
+    {
+        $q = trim(mb_strtolower($q));
+        if ('' === $q) {
+            return [];
+        }
+
+        /** @var array<int, array{name: string, slug: string}> $rows */
+        $rows = $this->createQueryBuilder('c')
+            ->select('c.name', 'c.slug')
+            ->where('LOWER(c.name) LIKE :q')
+            ->setParameter('q', '%'.$q.'%')
+            ->orderBy('c.name', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getArrayResult();
+
+        return $rows;
+    }
 }

--- a/src/Repository/ServiceRepository.php
+++ b/src/Repository/ServiceRepository.php
@@ -48,4 +48,27 @@ class ServiceRepository extends ServiceEntityRepository
 
         return $services;
     }
+
+    /**
+     * @return array<int, array{name: string, slug: string}>
+     */
+    public function findByNameLike(string $q, int $limit = 8): array
+    {
+        $q = trim(mb_strtolower($q));
+        if ('' === $q) {
+            return [];
+        }
+
+        /** @var array<int, array{name: string, slug: string}> $rows */
+        $rows = $this->createQueryBuilder('s')
+            ->select('s.name', 's.slug')
+            ->where('LOWER(s.name) LIKE :q')
+            ->setParameter('q', '%'.$q.'%')
+            ->orderBy('s.name', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getArrayResult();
+
+        return $rows;
+    }
 }

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -4,12 +4,15 @@
 <section class="hero">
     <div class="hero-content">
         <form id="search-form" class="search-form" method="get" action="/search">
-            <input type="text" id="city" name="city" placeholder="Where's your pet?" required>
-            <select id="service" name="service">
-                <option value="">Any service</option>
-                <option value="grooming">Grooming</option>
-                <option value="boarding">Boarding</option>
-            </select>
+            <input type="text" id="city-input" name="city" placeholder="Where's your pet?" required data-autocomplete="city" list="city-datalist">
+            <input type="hidden" id="citySlug" name="citySlug">
+            <datalist id="city-datalist">
+                {% for city in popularCities %}
+                    <option value="{{ city.name }}"></option>
+                {% endfor %}
+            </datalist>
+            <input type="text" id="service-input" name="service" placeholder="Any service" data-autocomplete="service">
+            <input type="hidden" id="serviceSlug" name="serviceSlug">
             <button type="submit" id="search-submit" disabled>{{ ctaLinks.find.label }}</button>
         </form>
         <a href="{{ ctaLinks.list.url }}" class="cta-list">{{ ctaLinks.list.label }}</a>
@@ -21,11 +24,12 @@
 {% include 'home/_popular.html.twig' %}
 <script>
     (function () {
-        const city = document.getElementById('city');
+        const city = document.getElementById('city-input');
         const submit = document.getElementById('search-submit');
         city.addEventListener('input', function () {
             submit.disabled = city.value.trim() === '';
         });
     })();
 </script>
+<script type="module" src="{{ asset('js/autocomplete.js') }}"></script>
 {% endblock %}

--- a/tests/Controller/AutocompleteEndpointsTest.php
+++ b/tests/Controller/AutocompleteEndpointsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\City;
+use App\Entity\Service;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class AutocompleteEndpointsTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testCitiesEndpointReturnsMatchesAndEnforcesRules(): void
+    {
+        $ruse = new City('Ruse');
+        $ruse->refreshSlugFrom($ruse->getName());
+        $this->em->persist($ruse);
+        for ($i = 1; $i <= 9; ++$i) {
+            $city = new City('City'.$i);
+            $city->refreshSlugFrom($city->getName());
+            $this->em->persist($city);
+        }
+        $this->em->flush();
+
+        $this->client->request('GET', '/api/autocomplete/cities?q=ru');
+        self::assertResponseIsSuccessful();
+        self::assertJsonStringEqualsJsonString('[{"name":"Ruse","slug":"ruse"}]', (string) $this->client->getResponse()->getContent());
+
+        $this->client->request('GET', '/api/autocomplete/cities?q=r');
+        self::assertSame('[]', $this->client->getResponse()->getContent());
+
+        $this->client->request('GET', '/api/autocomplete/cities?q=city');
+        $data = json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertCount(8, $data);
+    }
+
+    public function testServicesEndpointReturnsMatches(): void
+    {
+        $dog = (new Service())->setName('Dog Grooming');
+        $dog->refreshSlugFrom($dog->getName());
+        $this->em->persist($dog);
+        $this->em->flush();
+
+        $this->client->request('GET', '/api/autocomplete/services?q=dog');
+        self::assertResponseIsSuccessful();
+        self::assertJsonStringEqualsJsonString('[{"name":"Dog Grooming","slug":"dog-grooming"}]', (string) $this->client->getResponse()->getContent());
+    }
+}

--- a/tests/Controller/HomepageFlowTest.php
+++ b/tests/Controller/HomepageFlowTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class HomepageFlowTest extends WebTestCase
+{
+    public function testSearchFormHasAutocompleteFields(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+        $content = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('id="city-input"', $content);
+        self::assertStringContainsString('id="service-input"', $content);
+        self::assertStringContainsString('js/autocomplete.js', $content);
+    }
+}

--- a/tests/Integration/HomePageLoadsTest.php
+++ b/tests/Integration/HomePageLoadsTest.php
@@ -14,8 +14,8 @@ final class HomePageLoadsTest extends WebTestCase
         $client->request('GET', '/');
 
         self::assertResponseIsSuccessful();
-        self::assertSelectorExists('input#city');
-        self::assertSelectorExists('select#service');
+        self::assertSelectorExists('input#city-input');
+        self::assertSelectorExists('input#service-input');
         self::assertSelectorTextContains('button#search-submit', 'Find a Groomer');
         self::assertSelectorTextContains('a.cta-list', 'List Your Business');
     }

--- a/tests/Repository/CityRepositoryTest.php
+++ b/tests/Repository/CityRepositoryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Entity\City;
+use App\Repository\CityRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class CityRepositoryTest extends KernelTestCase
+{
+    private CityRepository $repository;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+        $this->repository = $container->get(CityRepository::class);
+        $this->em = $container->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testFindByNameLikeReturnsExpectedItems(): void
+    {
+        $ruse = new City('Ruse');
+        $ruse->refreshSlugFrom($ruse->getName());
+        $sofia = new City('Sofia');
+        $sofia->refreshSlugFrom($sofia->getName());
+        $this->em->persist($ruse);
+        $this->em->persist($sofia);
+        $this->em->flush();
+
+        $results = $this->repository->findByNameLike(' Ru ');
+
+        self::assertSame([
+            ['name' => 'Ruse', 'slug' => 'ruse'],
+        ], $results);
+    }
+
+    public function testFindByNameLikeRespectsLimit(): void
+    {
+        for ($i = 1; $i <= 10; ++$i) {
+            $city = new City('City '.$i);
+            $city->refreshSlugFrom($city->getName());
+            $this->em->persist($city);
+        }
+        $this->em->flush();
+
+        $results = $this->repository->findByNameLike('city', 3);
+
+        self::assertCount(3, $results);
+    }
+}

--- a/tests/Repository/ServiceRepositoryTest.php
+++ b/tests/Repository/ServiceRepositoryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Entity\Service;
+use App\Repository\ServiceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class ServiceRepositoryTest extends KernelTestCase
+{
+    private ServiceRepository $repository;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+        $this->repository = $container->get(ServiceRepository::class);
+        $this->em = $container->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testFindByNameLikeReturnsExpectedItems(): void
+    {
+        $dog = (new Service())->setName('Dog Grooming');
+        $dog->refreshSlugFrom($dog->getName());
+        $cat = (new Service())->setName('Cat Grooming');
+        $cat->refreshSlugFrom($cat->getName());
+        $this->em->persist($dog);
+        $this->em->persist($cat);
+        $this->em->flush();
+
+        $results = $this->repository->findByNameLike(' dog ');
+
+        self::assertSame([
+            ['name' => 'Dog Grooming', 'slug' => 'dog-grooming'],
+        ], $results);
+    }
+
+    public function testFindByNameLikeRespectsLimit(): void
+    {
+        for ($i = 1; $i <= 10; ++$i) {
+            $service = (new Service())->setName('Service '.$i);
+            $service->refreshSlugFrom($service->getName());
+            $this->em->persist($service);
+        }
+        $this->em->flush();
+
+        $results = $this->repository->findByNameLike('service', 5);
+
+        self::assertCount(5, $results);
+    }
+}


### PR DESCRIPTION
## Summary
- add autocomplete JSON endpoints for cities and services
- expose repository search helpers for city and service
- enhance homepage with JS autocomplete and datalist fallback

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689cf6e513a08322a04d9a97c5a4f73c