### PR TITLE
feat: enhance hero with search overlay

### DIFF
--- a/assets/js/home-hero.js
+++ b/assets/js/home-hero.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const city = document.getElementById('city');
+    const submit = document.getElementById('search-submit');
+    if (city && submit) {
+        submit.disabled = city.value.trim() === '';
+        city.addEventListener('input', () => {
+            submit.disabled = city.value.trim() === '';
+        });
+    }
+
+    const video = document.getElementById('hero-video');
+    const toggle = document.getElementById('hero-video-toggle');
+    if (video && toggle) {
+        toggle.addEventListener('click', () => {
+            if (video.paused) {
+                video.play();
+                toggle.textContent = 'Pause';
+            } else {
+                video.pause();
+                toggle.textContent = 'Play';
+            }
+        });
+    }
+});

--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -1,0 +1,72 @@
+.hero {
+    position: relative;
+    min-height: 60vh;
+    overflow: hidden;
+}
+
+.hero__media {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.hero__overlay {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    padding: var(--space-4);
+}
+
+.hero__card {
+    background-color: rgba(253, 250, 245, 0.9);
+    padding: var(--space-4);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+    text-align: center;
+    max-width: 600px;
+    width: 100%;
+}
+
+.hero__subtext {
+    margin-bottom: var(--space-3);
+}
+
+.search-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+}
+
+.search-form__input,
+.search-form__select {
+    padding: var(--space-1);
+}
+
+.search-form__button {
+    align-self: center;
+}
+
+@media (min-width: 600px) {
+    .search-form {
+        flex-direction: row;
+        align-items: flex-end;
+    }
+    .search-form label {
+        flex-basis: 100%;
+        text-align: left;
+    }
+    .search-form__input,
+    .search-form__select {
+        flex: 1;
+    }
+}
+
+.hero__video-toggle {
+    margin-top: var(--space-2);
+}

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -1,31 +1,42 @@
 {% extends 'base.html.twig' %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('styles/home.css') }}">
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    <script type="module" src="{{ asset('js/home-hero.js') }}"></script>
+{% endblock %}
+
 {% block body %}
 <section class="hero">
-    <div class="hero__content">
-        <form id="search-form" class="search-form" method="get" action="/search">
-            <input class="search-form__input" type="text" id="city" name="city" placeholder="Where's your pet?" required>
-            <select class="search-form__select" id="service" name="service">
-                <option value="">Any service</option>
-                <option value="grooming">Grooming</option>
-                <option value="boarding">Boarding</option>
-            </select>
-            <button class="search-form__button btn btn--accent" type="submit" id="search-submit" disabled>{{ ctaLinks.find.label }}</button>
-        </form>
-        <a href="{{ ctaLinks.list.url }}" class="hero__cta-link btn btn--accent">{{ ctaLinks.list.label }}</a>
+    <video id="hero-video" class="hero__media" autoplay muted loop playsinline poster="{{ asset('images/hero-poster.jpg') }}">
+        <source src="{{ asset('media/hero.mp4') }}" type="video/mp4">
+    </video>
+    <div class="hero__overlay">
+        <div class="hero__card">
+            <h1>Find trusted pet care</h1>
+            <p class="hero__subtext">Book top-rated services near you.</p>
+            <form id="search-form" class="search-form" method="get" action="/search">
+                <label for="city">City</label>
+                <input class="search-form__input" type="text" id="city" name="city" placeholder="Where's your pet?" required>
+                <label for="service">Service</label>
+                <select class="search-form__select" id="service" name="service">
+                    <option value="">Any service</option>
+                    <option value="grooming">Grooming</option>
+                    <option value="boarding">Boarding</option>
+                </select>
+                <button class="search-form__button btn btn--accent" type="submit" id="search-submit">{{ ctaLinks.find.label }}</button>
+            </form>
+            <button id="hero-video-toggle" class="hero__video-toggle" type="button">Pause</button>
+            <a href="{{ ctaLinks.list.url }}" class="hero__cta-link btn btn--accent">{{ ctaLinks.list.label }}</a>
+        </div>
     </div>
 </section>
 {% include 'home/_cta_banner.html.twig' %}
 {% include 'home/_how_it_works.html.twig' %}
 {% include 'home/_featured_groomers.html.twig' %}
 {% include 'home/_popular.html.twig' %}
-<script>
-    (function () {
-        const city = document.getElementById('city');
-        const submit = document.getElementById('search-submit');
-        city.addEventListener('input', function () {
-            submit.disabled = city.value.trim() === '';
-        });
-    })();
-</script>
 {% endblock %}

--- a/tests/Controller/SearchControllerTest.php
+++ b/tests/Controller/SearchControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\City;
+use App\Entity\Service;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class SearchControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testSubmittingCityAndServiceRedirects(): void
+    {
+        $city = new City('Sofia');
+        $city->refreshSlugFrom($city->getName());
+        $service = (new Service())->setName('Grooming');
+        $service->refreshSlugFrom($service->getName());
+        $this->em->persist($city);
+        $this->em->persist($service);
+        $this->em->flush();
+
+        $this->client->request('GET', '/search', [
+            'city' => $city->getSlug(),
+            'service' => $service->getSlug(),
+        ]);
+
+        self::assertResponseRedirects('/groomers/'.$city->getSlug().'/'.$service->getSlug());
+    }
+}

--- a/tests/E2E/Homepage/HeroSearchFlowTest.php
+++ b/tests/E2E/Homepage/HeroSearchFlowTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E\Homepage;
+
+use App\Entity\City;
+use App\Entity\Service;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class HeroSearchFlowTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testTypingCityAndServiceRedirectsToListing(): void
+    {
+        $city = new City('Sofia');
+        $city->refreshSlugFrom($city->getName());
+        $service = (new Service())->setName('Grooming');
+        $service->refreshSlugFrom($service->getName());
+        $this->em->persist($city);
+        $this->em->persist($service);
+        $this->em->flush();
+
+        $crawler = $this->client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('#search-form')->form([
+            'city' => $city->getSlug(),
+            'service' => $service->getSlug(),
+        ]);
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/groomers/'.$city->getSlug().'/'.$service->getSlug());
+        $this->client->followRedirect();
+        self::assertResponseIsSuccessful();
+    }
+}


### PR DESCRIPTION
## Summary
- add full-bleed hero video with translucent overlay card and search form
- style hero overlay and video controls
- exercise search redirect via controller and e2e tests

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`
- `./vendor/bin/phpunit --testdox tests/Controller/SearchControllerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_689e2020f6d48322a714610be667fdbe