### PR TITLE
feat: add sticky search bar on homepage

### DIFF
--- a/assets/js/sticky-search.js
+++ b/assets/js/sticky-search.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const sticky = document.getElementById('sticky-search');
+    const hero = document.querySelector('.hero');
+    if (!sticky || !hero) {
+        return;
+    }
+
+    const observer = new IntersectionObserver(([entry]) => {
+        if (entry.isIntersecting) {
+            sticky.classList.remove('is-sticky');
+        } else {
+            sticky.classList.add('is-sticky');
+        }
+    });
+
+    observer.observe(hero);
+});

--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -70,3 +70,48 @@
 .hero__video-toggle {
     margin-top: var(--space-2);
 }
+
+.sticky-search {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    background-color: rgba(253, 250, 245, 0.9);
+    padding: var(--space-2);
+    box-shadow: var(--shadow-md);
+    transform: translateY(-100%);
+    transition: transform 0.3s ease-in-out;
+}
+
+.sticky-search.is-sticky {
+    transform: translateY(0);
+}
+
+.sticky-search .search-form {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-2);
+    margin: 0;
+}
+
+.sticky-search .search-form label {
+    display: none;
+}
+
+.sticky-search .search-form__input,
+.sticky-search .search-form__select,
+.sticky-search .search-form__button {
+    flex: 1;
+    min-height: 44px;
+}
+
+.sticky-search .search-form__button {
+    flex: 0 0 auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .sticky-search {
+        transition: none;
+    }
+}

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -8,9 +8,23 @@
 {% block javascripts %}
     {{ parent() }}
     <script type="module" src="{{ asset('js/home-hero.js') }}"></script>
+    <script type="module" src="{{ asset('js/sticky-search.js') }}"></script>
 {% endblock %}
 
 {% block body %}
+<div id="sticky-search" class="sticky-search">
+    <form id="sticky-search-form" class="search-form" method="get" action="/search">
+        <label for="sticky-city">City</label>
+        <input class="search-form__input" type="text" id="sticky-city" name="city" placeholder="Where's your pet?" required>
+        <label for="sticky-service">Service</label>
+        <select class="search-form__select" id="sticky-service" name="service">
+            <option value="">Any service</option>
+            <option value="grooming">Grooming</option>
+            <option value="boarding">Boarding</option>
+        </select>
+        <button class="search-form__button btn btn--accent" type="submit">{{ ctaLinks.find.label }}</button>
+    </form>
+</div>
 <section class="hero">
     <video id="hero-video" class="hero__media" autoplay muted loop playsinline poster="{{ asset('images/hero-poster.jpg') }}">
         <source src="{{ asset('media/hero.mp4') }}" type="video/mp4">

--- a/tests/E2E/Homepage/StickySearchTest.php
+++ b/tests/E2E/Homepage/StickySearchTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E\Homepage;
+
+use App\Entity\City;
+use App\Entity\Service;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class StickySearchTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testStickySearchFormSubmits(): void
+    {
+        $city = new City('Sofia');
+        $city->refreshSlugFrom($city->getName());
+        $service = (new Service())->setName('Grooming');
+        $service->refreshSlugFrom($service->getName());
+        $this->em->persist($city);
+        $this->em->persist($service);
+        $this->em->flush();
+
+        $crawler = $this->client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+
+        self::assertSelectorExists('#sticky-search');
+
+        $form = $crawler->filter('#sticky-search-form')->form([
+            'city' => $city->getSlug(),
+            'service' => $service->getSlug(),
+        ]);
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/groomers/'.$city->getSlug().'/'.$service->getSlug());
+        $this->client->followRedirect();
+        self::assertResponseIsSuccessful();
+    }
+}


### PR DESCRIPTION
## Summary
- add JS intersection observer to toggle sticky search bar
- style sticky search and handle reduced-motion preferences
- include sticky search markup and tests

## Testing
- `make setup` (failed: No rule to make target 'setup')
- `make test -k` (failed: No rule to make target 'test')
- `composer lint:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689e22981d888322bcf7594f2fc6e442