### PR TITLE
feat: enable user reviews

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -4,6 +4,10 @@ security:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
     # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
     providers:
+        app_user_provider:
+            entity:
+                class: App\Entity\User
+                property: email
         users_in_memory: { memory: null }
     firewalls:
         dev:
@@ -11,7 +15,7 @@ security:
             security: false
         main:
             lazy: true
-            provider: users_in_memory
+            provider: app_user_provider
 
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#the-firewall

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -27,6 +27,12 @@
         <testsuite name="integration">
             <directory>tests/Integration</directory>
         </testsuite>
+        <testsuite name="controller">
+            <directory>tests/Controller</directory>
+        </testsuite>
+        <testsuite name="form">
+            <directory>tests/Form</directory>
+        </testsuite>
         <testsuite name="command">
             <directory>tests/Command</directory>
         </testsuite>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,12 @@
         <testsuite name="Integration">
             <directory>tests/Integration</directory>
         </testsuite>
+        <testsuite name="Controller">
+            <directory>tests/Controller</directory>
+        </testsuite>
+        <testsuite name="Form">
+            <directory>tests/Form</directory>
+        </testsuite>
         <testsuite name="Command">
             <directory>tests/Command</directory>
         </testsuite>

--- a/src/Controller/ReviewController.php
+++ b/src/Controller/ReviewController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\Review;
+use App\Entity\User;
+use App\Form\ReviewFormType;
+use App\Repository\GroomerProfileRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class ReviewController extends AbstractController
+{
+    #[Route('/groomers/{slug}/reviews/new', name: 'app_review_new', methods: ['GET', 'POST'], requirements: ['slug' => '[^/]+-[^/]+'])]
+    public function new(
+        string $slug,
+        Request $request,
+        GroomerProfileRepository $groomerRepository,
+        EntityManagerInterface $entityManager,
+    ): Response {
+        $this->denyAccessUnlessGranted('ROLE_USER');
+
+        $groomer = $groomerRepository->findOneBySlug($slug);
+        if (null === $groomer) {
+            throw $this->createNotFoundException();
+        }
+
+        $form = $this->createForm(ReviewFormType::class);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $ratingData = $form->get('rating')->getData();
+            $commentData = $form->get('comment')->getData();
+
+            if (!\is_int($ratingData) || !\is_string($commentData)) {
+                throw new \RuntimeException('Invalid form data');
+            }
+
+            $comment = strip_tags($commentData);
+
+            $user = $this->getUser();
+            if (!$user instanceof User) {
+                throw $this->createAccessDeniedException();
+            }
+
+            $review = new Review($groomer, $user, $ratingData, $comment);
+            $entityManager->persist($review);
+            $entityManager->flush();
+
+            return $this->redirectToRoute('app_groomer_show', ['slug' => $slug]);
+        }
+
+        return $this->render('review/new.html.twig', [
+            'reviewForm' => $form->createView(),
+            'groomer' => $groomer,
+        ]);
+    }
+}

--- a/src/Form/ReviewFormType.php
+++ b/src/Form/ReviewFormType.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Range;
+
+final class ReviewFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('rating', IntegerType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Range(min: 1, max: 5),
+                ],
+            ])
+            ->add('comment', TextareaType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Length(max: 1000),
+                ],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'csrf_protection' => true,
+        ]);
+    }
+}

--- a/templates/review/new.html.twig
+++ b/templates/review/new.html.twig
@@ -1,0 +1,11 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}New Review{% endblock %}
+
+{% block body %}
+    {{ form_start(reviewForm) }}
+        {{ form_row(reviewForm.rating) }}
+        {{ form_row(reviewForm.comment) }}
+        <button type="submit">Submit</button>
+    {{ form_end(reviewForm) }}
+{% endblock %}

--- a/tests/Controller/ReviewControllerTest.php
+++ b/tests/Controller/ReviewControllerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Review;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ReviewControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testAnonymousUserCannotAccessForm(): void
+    {
+        $groomer = $this->persistGroomer();
+
+        $this->client->request('GET', '/groomers/'.$groomer->getSlug().'/reviews/new');
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testLoggedInUserCanSubmitReview(): void
+    {
+        $groomer = $this->persistGroomer();
+
+        $user = (new User())
+            ->setEmail('owner@example.com')
+            ->setPassword('hash');
+        $this->em->persist($user);
+        $this->em->flush();
+
+        $this->client->loginUser($user);
+        $crawler = $this->client->request('GET', '/groomers/'.$groomer->getSlug().'/reviews/new');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->selectButton('Submit')->form([
+            'review_form[rating]' => 5,
+            'review_form[comment]' => '<b>Great service</b>',
+        ]);
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/groomers/'.$groomer->getSlug());
+        $this->client->followRedirect();
+
+        $reviews = $this->em->getRepository(Review::class)->findAll();
+        self::assertCount(1, $reviews);
+        self::assertSame('Great service', $reviews[0]->getComment());
+    }
+
+    private function persistGroomer(): GroomerProfile
+    {
+        $groomerUser = (new User())
+            ->setEmail('groomer@example.com')
+            ->setRoles([User::ROLE_GROOMER])
+            ->setPassword('hash');
+        $city = new City('Sofia');
+        $groomer = new GroomerProfile($groomerUser, $city, 'Best Groomers', 'About');
+        $groomer->refreshSlugFrom($groomer->getBusinessName());
+
+        $this->em->persist($groomerUser);
+        $this->em->persist($city);
+        $this->em->persist($groomer);
+        $this->em->flush();
+
+        return $groomer;
+    }
+}

--- a/tests/Form/ReviewFormTypeTest.php
+++ b/tests/Form/ReviewFormTypeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Form;
+
+use App\Form\ReviewFormType;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Component\Validator\Validation;
+
+final class ReviewFormTypeTest extends TypeTestCase
+{
+    protected function getExtensions(): array
+    {
+        return [
+            new ValidatorExtension(Validation::createValidator()),
+        ];
+    }
+
+    public function testConstraints(): void
+    {
+        $form = $this->factory->create(ReviewFormType::class);
+
+        $ratingConstraints = $form->get('rating')->getConfig()->getOption('constraints');
+        $range = null;
+        foreach ($ratingConstraints as $constraint) {
+            if ($constraint instanceof Range) {
+                $range = $constraint;
+                break;
+            }
+        }
+        self::assertNotNull($range);
+        self::assertSame(1, $range->min);
+        self::assertSame(5, $range->max);
+
+        $commentConstraints = $form->get('comment')->getConfig()->getOption('constraints');
+        $length = null;
+        foreach ($commentConstraints as $constraint) {
+            if ($constraint instanceof Length) {
+                $length = $constraint;
+                break;
+            }
+        }
+        self::assertNotNull($length);
+        self::assertSame(1000, $length->max);
+    }
+
+    public function testSubmitValidData(): void
+    {
+        $form = $this->factory->create(ReviewFormType::class);
+        $formData = ['rating' => 5, 'comment' => 'Great!'];
+        $form->submit($formData);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertTrue($form->isValid());
+    }
+
+    public function testSubmitInvalidData(): void
+    {
+        $form = $this->factory->create(ReviewFormType::class);
+        $formData = ['rating' => 6, 'comment' => str_repeat('a', 1001)];
+        $form->submit($formData);
+
+        self::assertFalse($form->isValid());
+        self::assertSame(6, $form->get('rating')->getData());
+        self::assertSame(str_repeat('a', 1001), $form->get('comment')->getData());
+    }
+}


### PR DESCRIPTION
## Summary
- add ReviewFormType with rating and comment validation
- restrict ReviewController::new to logged-in users and sanitize input
- cover review form and controller with tests

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689e22a80a688322b009bc871d4d56fe