### PR TITLE
feat: add illustrated how-it-works cards with reveal animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,10 @@
 ###< phpunit/phpunit ###
 
 ###> symfony/asset-mapper ###
-/public/assets/
+/public/assets/*
 /assets/vendor/
+!/public/assets/illustrations/
+!/public/assets/illustrations/*
 ###< symfony/asset-mapper ###
 
 /node_modules

--- a/assets/js/section-reveal.js
+++ b/assets/js/section-reveal.js
@@ -1,0 +1,25 @@
+const initSectionReveal = () => {
+    const targets = document.querySelectorAll('.reveal-on-scroll');
+    if (!targets.length) {
+        return;
+    }
+
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (prefersReducedMotion) {
+        targets.forEach((el) => el.classList.add('reveal-in'));
+        return;
+    }
+
+    const observer = new IntersectionObserver((entries, obs) => {
+        entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('reveal-in');
+                obs.unobserve(entry.target);
+            }
+        });
+    }, { threshold: 0.1 });
+
+    targets.forEach((el) => observer.observe(el));
+};
+
+document.addEventListener('DOMContentLoaded', initSectionReveal);

--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -115,3 +115,58 @@
         transition: none;
     }
 }
+
+.how-it-works {
+    padding: var(--space-5) var(--space-3);
+    text-align: center;
+}
+
+.how-it-works__cards {
+    display: grid;
+    gap: var(--space-3);
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    margin-top: var(--space-4);
+}
+
+.how-it-works__card {
+    background-color: var(--color-cream);
+    padding: var(--space-3);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.how-it-works__card img {
+    width: 80px;
+    height: 80px;
+    margin-bottom: var(--space-2);
+}
+
+.how-it-works__card:focus,
+.how-it-works__card:hover {
+    outline: none;
+    transform: scale(1.03);
+    box-shadow: var(--shadow-md);
+}
+
+.reveal-on-scroll {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.reveal-in {
+    opacity: 1;
+    transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .how-it-works__card {
+        transition: none;
+    }
+    .reveal-on-scroll {
+        opacity: 1;
+        transform: none;
+        transition: none;
+    }
+}

--- a/public/assets/illustrations/calendar.svg
+++ b/public/assets/illustrations/calendar.svg
@@ -1,0 +1,6 @@
+<svg width="80" height="80" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="10" y="16" width="60" height="54" rx="4"/>
+  <line x1="10" y1="30" x2="70" y2="30"/>
+  <line x1="26" y1="8" x2="26" y2="20"/>
+  <line x1="54" y1="8" x2="54" y2="20"/>
+</svg>

--- a/public/assets/illustrations/paw.svg
+++ b/public/assets/illustrations/paw.svg
@@ -1,0 +1,7 @@
+<svg width="80" height="80" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="40" cy="52" r="14"/>
+  <circle cx="24" cy="34" r="8"/>
+  <circle cx="40" cy="24" r="8"/>
+  <circle cx="56" cy="34" r="8"/>
+  <circle cx="40" cy="40" r="8"/>
+</svg>

--- a/public/assets/illustrations/search.svg
+++ b/public/assets/illustrations/search.svg
@@ -1,0 +1,4 @@
+<svg width="80" height="80" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="34" cy="34" r="20"/>
+  <line x1="48" y1="48" x2="70" y2="70"/>
+</svg>

--- a/templates/home/_how_it_works.html.twig
+++ b/templates/home/_how_it_works.html.twig
@@ -1,37 +1,20 @@
-<section id="how-it-works">
+<section id="how-it-works" class="how-it-works reveal-on-scroll">
     <h2>How It Works</h2>
-    <div class="owner-steps">
-        <h3>For Owners</h3>
-        <ol class="steps">
-            <li>
-                <span class="icon">🔍</span>
-                <p>Find a groomer</p>
-            </li>
-            <li>
-                <span class="icon">📅</span>
-                <p>Book an appointment</p>
-            </li>
-            <li>
-                <span class="icon">🐶</span>
-                <p>Enjoy a clean pet</p>
-            </li>
-        </ol>
-    </div>
-    <div class="groomer-steps">
-        <h3>For Groomers</h3>
-        <ol class="steps">
-            <li>
-                <span class="icon">📝</span>
-                <p>Create your listing</p>
-            </li>
-            <li>
-                <span class="icon">📨</span>
-                <p>Accept bookings</p>
-            </li>
-            <li>
-                <span class="icon">📈</span>
-                <p>Grow your business</p>
-            </li>
-        </ol>
+    <div class="how-it-works__cards">
+        <div class="how-it-works__card" tabindex="0">
+            <img src="{{ asset('assets/illustrations/search.svg') }}" alt="" aria-hidden="true">
+            <h3>Search</h3>
+            <p>Find trusted groomers near you.</p>
+        </div>
+        <div class="how-it-works__card" tabindex="0">
+            <img src="{{ asset('assets/illustrations/calendar.svg') }}" alt="" aria-hidden="true">
+            <h3>Book</h3>
+            <p>Choose a time that works.</p>
+        </div>
+        <div class="how-it-works__card" tabindex="0">
+            <img src="{{ asset('assets/illustrations/paw.svg') }}" alt="" aria-hidden="true">
+            <h3>Relax</h3>
+            <p>Your pet leaves fresh and clean.</p>
+        </div>
     </div>
 </section>

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -9,6 +9,7 @@
     {{ parent() }}
     <script type="module" src="{{ asset('js/home-hero.js') }}"></script>
     <script type="module" src="{{ asset('js/sticky-search.js') }}"></script>
+    <script type="module" src="{{ asset('js/section-reveal.js') }}"></script>
 {% endblock %}
 
 {% block body %}

--- a/tests/E2E/Homepage/HowItWorksAccessibilityTest.php
+++ b/tests/E2E/Homepage/HowItWorksAccessibilityTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E\Homepage;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+
+final class HowItWorksAccessibilityTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testCardsAreFocusableAndReducedMotionStylesPresent(): void
+    {
+        $crawler = $this->client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+
+        $cards = $crawler->filter('#how-it-works .how-it-works__card');
+        self::assertGreaterThanOrEqual(3, $cards->count());
+
+        $cards->each(function (Crawler $card): void {
+            self::assertSame('0', $card->attr('tabindex'));
+        });
+
+        $crawler->filter('#how-it-works img')->each(function (Crawler $img): void {
+            self::assertSame('', $img->attr('alt'));
+            self::assertSame('true', $img->attr('aria-hidden'));
+        });
+
+        $cssPath = static::getContainer()->getParameter('kernel.project_dir').'/assets/styles/home.css';
+        self::assertStringContainsString('@media (prefers-reduced-motion: reduce)', file_get_contents($cssPath));
+    }
+}

--- a/tests/Integration/HowItWorksSectionRenderTest.php
+++ b/tests/Integration/HowItWorksSectionRenderTest.php
@@ -12,10 +12,7 @@ final class HowItWorksSectionRenderTest extends WebTestCase
     {
         $client = static::createClient();
         $client->request('GET', '/');
-
-        self::assertSelectorTextContains('#how-it-works .owner-steps h3', 'For Owners');
-        self::assertSelectorCount(3, '#how-it-works .owner-steps li');
-        self::assertSelectorTextContains('#how-it-works .groomer-steps h3', 'For Groomers');
-        self::assertSelectorCount(3, '#how-it-works .groomer-steps li');
+        self::assertSelectorTextContains('#how-it-works h2', 'How It Works');
+        self::assertSelectorCount(3, '#how-it-works .how-it-works__card');
     }
 }


### PR DESCRIPTION
## Summary
- add illustrated "How It Works" cards and include reveal script
- animate cards on scroll with reduced-motion support
- test accessibility of new section

## Testing
- `composer lint:php`
- `composer stan`
- `composer test`
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689e2420538483229a421395bcc05530