### PR TITLE
feat: add dynamic SEO metadata for listings

### DIFF
--- a/src/Controller/CityController.php
+++ b/src/Controller/CityController.php
@@ -23,8 +23,20 @@ class CityController extends AbstractController
             throw $this->createNotFoundException();
         }
 
+        $seoTitle = sprintf('Mobile Dog Groomers in %s – CleanWhiskers', $city->getName());
+        $seoDescription = $this->truncate(
+            sprintf('Explore top mobile dog groomers in %s. Book trusted pros on CleanWhiskers.', $city->getName())
+        );
+
         return $this->render('city/show.html.twig', [
             'city' => $city,
+            'seo_title' => $seoTitle,
+            'seo_description' => $seoDescription,
         ]);
+    }
+
+    private function truncate(string $text, int $max = 160): string
+    {
+        return mb_strlen($text) > $max ? mb_substr($text, 0, $max - 3).'...' : $text;
     }
 }

--- a/src/Controller/GroomerController.php
+++ b/src/Controller/GroomerController.php
@@ -43,6 +43,19 @@ final class GroomerController extends AbstractController
         $nextOffset = count($groomers) === $limit ? $offset + $limit : null;
         $previousOffset = $offset > 0 ? max(0, $offset - $limit) : null;
 
+        $seoTitle = sprintf(
+            'Mobile Dog Groomers in %s for %s – CleanWhiskers',
+            $city->getName(),
+            $service->getName()
+        );
+        $seoDescription = $this->truncate(
+            sprintf(
+                'Find mobile dog groomers in %s for %s. Book experienced groomers on CleanWhiskers.',
+                $city->getName(),
+                $service->getName()
+            )
+        );
+
         return $this->render('groomer/list.html.twig', [
             'groomers' => $groomers,
             'city' => $city,
@@ -50,6 +63,8 @@ final class GroomerController extends AbstractController
             'rating' => $minRating,
             'nextOffset' => $nextOffset,
             'previousOffset' => $previousOffset,
+            'seo_title' => $seoTitle,
+            'seo_description' => $seoDescription,
         ]);
     }
 
@@ -73,9 +88,19 @@ final class GroomerController extends AbstractController
         $page = max(1, $request->query->getInt('page', 1));
         $groomers = $groomerProfileRepository->findByCitySlug($citySlug, $page);
 
+        $seoTitle = sprintf('Mobile Dog Groomers in %s – CleanWhiskers', $city->getName());
+        $seoDescription = $this->truncate(
+            sprintf(
+                'Browse mobile dog groomers serving %s. Read reviews and schedule your pet\'s groom today.',
+                $city->getName()
+            )
+        );
+
         return $this->render('groomer/list_by_city.html.twig', [
             'groomers' => $groomers,
             'city' => $city,
+            'seo_title' => $seoTitle,
+            'seo_description' => $seoDescription,
         ]);
     }
 
@@ -99,5 +124,10 @@ final class GroomerController extends AbstractController
     public function profileTrailingSlash(string $slug): Response
     {
         return $this->redirectToRoute('app_groomer_show', ['slug' => $slug], Response::HTTP_MOVED_PERMANENTLY);
+    }
+
+    private function truncate(string $text, int $max = 160): string
+    {
+        return mb_strlen($text) > $max ? mb_substr($text, 0, $max - 3).'...' : $text;
     }
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -2,7 +2,12 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title>{% block title %}Welcome!{% endblock %}</title>
+        <title>{% block title %}{{ seo_title|default('CleanWhiskers') }}{% endblock %}</title>
+        {% block meta_description %}
+            {% if seo_description is defined %}
+                <meta name="description" content="{{ seo_description }}">
+            {% endif %}
+        {% endblock %}
         <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
         {% block stylesheets %}
         {% endblock %}

--- a/templates/city/show.html.twig
+++ b/templates/city/show.html.twig
@@ -1,7 +1,5 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}{{ city.name }}{% endblock %}
-
 {% block body %}
     <h1>{{ city.name }}</h1>
     {% if city.seoIntro %}

--- a/templates/groomer/list.html.twig
+++ b/templates/groomer/list.html.twig
@@ -1,7 +1,5 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Groomers in {{ city.name }} for {{ service.name }}{% endblock %}
-
 {% block body %}
     <h1>Groomers in {{ city.name }} for {{ service.name }}</h1>
     <form method="get">

--- a/templates/groomer/list_by_city.html.twig
+++ b/templates/groomer/list_by_city.html.twig
@@ -1,7 +1,5 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Groomers in {{ city.name }}{% endblock %}
-
 {% block body %}
     <h1>Groomers in {{ city.name }}</h1>
     {% if groomers|length %}

--- a/tests/Integration/SeoMetaTagsRenderTest.php
+++ b/tests/Integration/SeoMetaTagsRenderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use App\Entity\City;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class SeoMetaTagsRenderTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testCityPageHasSeoMetadata(): void
+    {
+        $city = new City('Testopolis');
+        $city->refreshSlugFrom($city->getName());
+        $this->em->persist($city);
+        $this->em->flush();
+
+        $this->client->request('GET', '/cities/'.$city->getSlug());
+        self::assertResponseIsSuccessful();
+        $content = $this->client->getResponse()->getContent();
+
+        $expectedTitle = sprintf('<title>Mobile Dog Groomers in %s – CleanWhiskers</title>', $city->getName());
+        $expectedDescription = sprintf(
+            '<meta name="description" content="%s">',
+            htmlspecialchars(
+                sprintf('Explore top mobile dog groomers in %s. Book trusted pros on CleanWhiskers.', $city->getName()),
+                ENT_QUOTES
+            )
+        );
+
+        $this->assertStringContainsString($expectedTitle, $content);
+        $this->assertStringContainsString($expectedDescription, $content);
+    }
+
+    public function testGroomerListingHasSeoMetadata(): void
+    {
+        $city = new City('Gotham');
+        $city->refreshSlugFrom($city->getName());
+        $this->em->persist($city);
+        $this->em->flush();
+
+        $this->client->request('GET', '/groomers/'.$city->getSlug());
+        self::assertResponseIsSuccessful();
+        $content = $this->client->getResponse()->getContent();
+
+        $expectedTitle = sprintf('<title>Mobile Dog Groomers in %s – CleanWhiskers</title>', $city->getName());
+        $expectedDescription = sprintf(
+            '<meta name="description" content="%s">',
+            htmlspecialchars(
+                sprintf('Browse mobile dog groomers serving %s. Read reviews and schedule your pet\'s groom today.', $city->getName()),
+                ENT_QUOTES
+            )
+        );
+
+        $this->assertStringContainsString($expectedTitle, $content);
+        $this->assertStringContainsString($expectedDescription, $content);
+    }
+}


### PR DESCRIPTION
## Summary
- add dynamic title and meta description blocks to base template
- generate per-page SEO metadata in city and groomer listing controllers
- verify SEO tags via integration tests

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `composer audit` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689e2ab41e4083229ac2527e22fbafa2