### PR TITLE
feat: redesign homepage hero and navigation

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,21 +1,70 @@
 body {
-    background-color: skyblue;
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background-color: #f5f5f5;
 }
+
+.site-header {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 10;
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.main-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 2rem;
+}
+
+.main-nav ul {
+    list-style: none;
+    display: flex;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+}
+
+.main-nav a {
+    color: #fff;
+    text-decoration: none;
+    padding: 0.5rem 1rem;
+}
+
+.main-nav .nav-cta a {
+    background: #ff5a5f;
+    border-radius: 4px;
+}
+
 .hero {
-    background: #eee no-repeat center/cover;
-    padding: 4rem 1rem;
+    position: relative;
+    background: url('/images/hero.svg') center/cover no-repeat;
+    color: #fff;
+    padding: 8rem 1rem 4rem;
+    text-align: center;
+}
+
+.hero-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
 }
 
 .hero-content {
-    max-width: 600px;
+    position: relative;
+    z-index: 1;
+    max-width: 800px;
     margin: 0 auto;
-    text-align: center;
 }
 
 .search-form {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    margin-top: 1rem;
 }
 
 @media (min-width: 600px) {
@@ -27,6 +76,26 @@ body {
     .search-form select {
         flex: 1;
     }
+}
+
+.hero-menu {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+    margin: 1rem 0;
+    padding: 0;
+}
+
+.hero-menu a {
+    display: block;
+    padding: 0.5rem 1rem;
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 20px;
+    color: #fff;
+    text-decoration: none;
+    font-size: 0.875rem;
 }
 
 .cta-banner {

--- a/public/images/hero.svg
+++ b/public/images/hero.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4e54c8"/>
+      <stop offset="100%" stop-color="#8f94fb"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#g)"/>
+</svg>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -12,6 +12,19 @@
         {% endblock %}
     </head>
     <body>
+        <header class="site-header">
+            <nav class="main-nav">
+                <a href="{{ path('app_homepage') }}" class="logo">CleanWhiskers</a>
+                <ul>
+                    <li><a href="{{ path('app_homepage') }}">Home</a></li>
+                    <li><a href="#listings">Listings</a></li>
+                    <li><a href="#blog">Blog</a></li>
+                    <li><a href="#contact">Contact</a></li>
+                    <li class="nav-cta"><a href="{{ path('app_register', {role: 'groomer'}) }}">Add Listing</a></li>
+                </ul>
+            </nav>
+        </header>
+
         {% block body %}{% endblock %}
 
         <footer class="site-footer">

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -2,16 +2,24 @@
 
 {% block body %}
 <section class="hero">
+    <div class="hero-overlay"></div>
     <div class="hero-content">
+        <h1>Find the Best for Your Pet</h1>
+        <p>Search local groomers and services near you</p>
         <form id="search-form" class="search-form" method="get" action="/search">
-            <input type="text" id="city" name="city" placeholder="Where's your pet?" required>
+            <input type="text" id="city" name="city" placeholder="City" required>
             <select id="service" name="service">
-                <option value="">Any service</option>
+                <option value="">Select Service</option>
                 <option value="grooming">Grooming</option>
                 <option value="boarding">Boarding</option>
             </select>
             <button type="submit" id="search-submit" disabled>{{ ctaLinks.find.label }}</button>
         </form>
+        <ul class="hero-menu">
+            {% for service in popularServices %}
+                <li><a href="#">{{ service.name }}</a></li>
+            {% endfor %}
+        </ul>
         <a href="{{ ctaLinks.list.url }}" class="cta-list">{{ ctaLinks.list.label }}</a>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- add top navigation menu with call-to-action link
- overhaul hero section with heading, search form, and service menu
- style header and hero and include gradient background asset

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_689e2caefe3883228b988c842fe96df0