### PR TITLE
feat: add static blog module

### DIFF
--- a/src/Controller/BlogController.php
+++ b/src/Controller/BlogController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class BlogController extends AbstractController
+{
+    #[Route('/blog', name: 'app_blog_index', methods: ['GET'])]
+    public function index(): Response
+    {
+        $posts = $this->getPosts();
+
+        return $this->render('blog/index.html.twig', [
+            'posts' => $posts,
+            'seo_title' => 'Blog – CleanWhiskers',
+            'seo_description' => 'Insights and updates from the CleanWhiskers team.',
+        ]);
+    }
+
+    #[Route('/blog/{slug}', name: 'app_blog_show', methods: ['GET'])]
+    public function show(string $slug): Response
+    {
+        $posts = $this->getPosts();
+        $post = $posts[$slug] ?? null;
+        if (null === $post) {
+            throw $this->createNotFoundException();
+        }
+
+        return $this->render('blog/show.html.twig', [
+            'post' => $post,
+            'seo_title' => $post['seo_title'],
+            'seo_description' => $post['seo_description'],
+        ]);
+    }
+
+    /**
+     * @return array<string, array{title: string, excerpt: string, template: string, seo_title: string, seo_description: string}>
+     */
+    private function getPosts(): array
+    {
+        return [
+            'welcome-to-cleanwhiskers' => [
+                'title' => 'Welcome to CleanWhiskers',
+                'excerpt' => 'Discover tips for grooming your beloved pets.',
+                'template' => 'blog/posts/welcome.html.twig',
+                'seo_title' => 'Welcome to CleanWhiskers Blog – CleanWhiskers',
+                'seo_description' => 'Learn about our mission and how we help pet owners.',
+            ],
+            'healthy-grooming-habits' => [
+                'title' => 'Healthy Grooming Habits',
+                'excerpt' => 'Simple routines to keep your pet feeling great.',
+                'template' => 'blog/posts/grooming-habits.html.twig',
+                'seo_title' => 'Healthy Grooming Habits for Pets – CleanWhiskers',
+                'seo_description' => 'Establish routines for a clean, happy pet.',
+            ],
+        ];
+    }
+}

--- a/templates/blog/index.html.twig
+++ b/templates/blog/index.html.twig
@@ -1,0 +1,14 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+<h1>Blog</h1>
+<ul class="blog-list">
+    {% for slug, post in posts %}
+        <li class="post">
+            <h2><a href="{{ path('app_blog_show', {slug: slug}) }}">{{ post.title }}</a></h2>
+            <p>{{ post.excerpt }}</p>
+            <a href="{{ path('app_blog_show', {slug: slug}) }}">Read more</a>
+        </li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/blog/posts/grooming-habits.html.twig
+++ b/templates/blog/posts/grooming-habits.html.twig
@@ -1,0 +1,1 @@
+<p>Keeping your pet's coat healthy is easy with these simple grooming habits. Regular brushing and bathing go a long way.</p>

--- a/templates/blog/posts/welcome.html.twig
+++ b/templates/blog/posts/welcome.html.twig
@@ -1,0 +1,1 @@
+<p>Welcome to the CleanWhiskers blog! We share grooming tips and platform updates.</p>

--- a/templates/blog/show.html.twig
+++ b/templates/blog/show.html.twig
@@ -1,0 +1,8 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+<article>
+    <h1>{{ post.title }}</h1>
+    {% include post.template %}
+</article>
+{% endblock %}

--- a/tests/Integration/BlogControllerTest.php
+++ b/tests/Integration/BlogControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class BlogControllerTest extends WebTestCase
+{
+    public function testBlogIndexListsPosts(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/blog');
+
+        self::assertResponseIsSuccessful();
+        self::assertSame(2, $crawler->filter('li.post')->count());
+        self::assertSelectorTextContains('h1', 'Blog');
+    }
+
+    public function testBlogShowDisplaysPostWithSeo(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/blog/welcome-to-cleanwhiskers');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h1', 'Welcome to CleanWhiskers');
+        $content = $client->getResponse()->getContent();
+        self::assertStringContainsString('<title>Welcome to CleanWhiskers Blog – CleanWhiskers</title>', $content);
+        self::assertStringContainsString('<meta name="description" content="Learn about our mission and how we help pet owners.">', $content);
+    }
+}


### PR DESCRIPTION
## Summary
- add `BlogController` with routes for listing and showing static posts
- create Twig templates for blog index and post pages
- cover blog controller with integration tests

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_689e2d57e6748322af7002c158b817b5