### PR TITLE
fix: include hero svg for build

### DIFF
--- a/assets/images/hero.svg
+++ b/assets/images/hero.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4e54c8"/>
+      <stop offset="100%" stop-color="#8f94fb"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#g)"/>
+</svg>

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -41,7 +41,7 @@ body {
 
 .hero {
     position: relative;
-    background: url('/images/hero.svg') center/cover no-repeat;
+    background: url('../images/hero.svg') center/cover no-repeat;
     color: #fff;
     padding: 8rem 1rem 4rem;
     text-align: center;


### PR DESCRIPTION
## Summary
- add hero SVG to asset pipeline
- reference hero background image relatively in CSS

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --testdox`
- `yarn build` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_689e2ee032cc8322acff20ef20b0b6cd