### PR TITLE
chore(ci): compile assets before staging deploy

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -63,10 +63,10 @@ jobs:
         run: yarn install
           # If you need to unblock temporarily, swap to:
           # run: yarn install --ignore-engines
-  
 
-      - name: Build Frontend Assets
-        run: yarn build
+
+      - name: Compile Asset Map
+        run: php bin/console asset-map:compile
 
       - name: Deploy to Staging Server
         run: |


### PR DESCRIPTION
## Summary
- compile Symfony asset map before staging deploy
- drop unused `yarn build` step

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted...)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_689e33a3d5bc8322a6bb87664e1f1da7