### PR TITLE
feat: add popular navigation grid with hover stats

### DIFF
--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -232,3 +232,53 @@
         transition: none;
     }
 }
+
+#popular {
+    padding: var(--space-5) var(--space-3);
+}
+
+.popular-grid {
+    column-gap: var(--space-3);
+    column-count: 2;
+}
+
+@media (min-width: 600px) {
+    .popular-grid {
+        column-count: 3;
+    }
+}
+
+.popular-card {
+    display: block;
+    position: relative;
+    break-inside: avoid;
+    margin-bottom: var(--space-3);
+    background-color: var(--color-cream);
+    border-radius: var(--radius-md);
+    padding: var(--space-3);
+    color: inherit;
+    text-decoration: none;
+    overflow: hidden;
+}
+
+.popular-card__overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.popular-card:hover .popular-card__overlay,
+.popular-card:focus .popular-card__overlay {
+    opacity: 1;
+}
+
+.popular-card:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}

--- a/templates/home/_popular.html.twig
+++ b/templates/home/_popular.html.twig
@@ -2,14 +2,18 @@
     <h2>Popular Cities</h2>
     <div class="popular-grid">
         {% for city in popularCities %}
-            <div class="popular-item">
-                <a href="{{ path('app_city_show', {slug: city.slug}) }}">{{ city.name }}</a>
-                {% if city.seoIntro %}
-                    <p>{{ city.seoIntro }}</p>
-                {% endif %}
-            </div>
+            <a class="popular-card" href="{{ path('app_city_show', {slug: city.slug}) }}">
+                <span class="popular-card__title">{{ city.name }}</span>
+                <span class="popular-card__overlay">
+                    {% if city.groomerCount is defined and city.groomerCount is not null %}
+                        {{ city.groomerCount }} groomers
+                    {% else %}
+                        Browse
+                    {% endif %}
+                </span>
+            </a>
         {% else %}
-            <div class="popular-item">City coming soon</div>
+            <div class="popular-card">City coming soon</div>
         {% endfor %}
     </div>
 
@@ -17,27 +21,25 @@
     <div class="popular-grid">
         {% set defaultCity = popularCities|first %}
         {% for service in popularServices %}
-            <div class="popular-item">
-                {% if defaultCity %}
-                    <a href="{{ path('app_groomer_list_by_city_service', {citySlug: defaultCity.slug, serviceSlug: service.slug}) }}">{{ service.name }} in {{ defaultCity.name }}</a>
-                {% else %}
-                    {{ service.name }}
-                {% endif %}
-            </div>
+            {% if defaultCity %}
+                <a class="popular-card" href="{{ path('app_groomer_list_by_city_service', {citySlug: defaultCity.slug, serviceSlug: service.slug}) }}">
+                    <span class="popular-card__title">{{ service.name }}</span>
+                    <span class="popular-card__overlay">
+                        {% if service.groomerCount is defined and service.groomerCount is not null %}
+                            {{ service.groomerCount }} groomers
+                        {% else %}
+                            Browse
+                        {% endif %}
+                    </span>
+                </a>
+            {% else %}
+                <div class="popular-card">
+                    <span class="popular-card__title">{{ service.name }}</span>
+                </div>
+            {% endif %}
         {% else %}
-            <div class="popular-item">Service coming soon</div>
+            <div class="popular-card">Service coming soon</div>
         {% endfor %}
     </div>
 </section>
-<style>
-#popular .popular-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-    gap: 1rem;
-}
-#popular .popular-item {
-    border: 1px solid #ccc;
-    padding: 0.5rem;
-}
-</style>
 

--- a/tests/E2E/Homepage/PopularNavTest.php
+++ b/tests/E2E/Homepage/PopularNavTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E\Homepage;
+
+use App\Entity\City;
+use App\Entity\Service;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class PopularNavTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testLinksResolveAndFocusStylesPresent(): void
+    {
+        foreach (['Bucharest', 'Ruse', 'Sofia'] as $name) {
+            $city = new City($name);
+            $this->em->persist($city);
+        }
+
+        foreach (['Dog', 'Cat', 'Mobile'] as $name) {
+            $service = (new Service())->setName($name);
+            $this->em->persist($service);
+        }
+
+        $this->em->flush();
+
+        $crawler = $this->client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+
+        $citySlugs = ['bucharest', 'ruse', 'sofia'];
+        foreach ($citySlugs as $slug) {
+            $link = sprintf('#popular a[href="/cities/%s"]', $slug);
+            self::assertSame(1, $crawler->filter($link)->count());
+        }
+
+        foreach ($citySlugs as $slug) {
+            $this->client->request('GET', '/cities/'.$slug);
+            self::assertResponseIsSuccessful();
+        }
+
+        $firstCity = 'bucharest';
+        $serviceSlugs = ['dog', 'cat', 'mobile'];
+        foreach ($serviceSlugs as $serviceSlug) {
+            $href = sprintf('/groomers/%s/%s', $firstCity, $serviceSlug);
+            self::assertSame(1, $crawler->filter(sprintf('#popular a[href="%s"]', $href))->count());
+        }
+
+        foreach ($serviceSlugs as $serviceSlug) {
+            $href = sprintf('/groomers/%s/%s', $firstCity, $serviceSlug);
+            $this->client->request('GET', $href);
+            self::assertResponseIsSuccessful();
+        }
+
+        $cssPath = static::getContainer()->getParameter('kernel.project_dir').'/assets/styles/home.css';
+        $css = file_get_contents($cssPath);
+        self::assertStringContainsString('.popular-card:focus', $css);
+    }
+}


### PR DESCRIPTION
## Summary
- add masonry-style popular cities and services grid with hover/focus stats overlays
- style grid and cards with responsive columns and accessible focus states
- cover navigation and CSS presence via PopularNav E2E test

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_689e3bde99b8832281cb9db3373814f1