### PR TITLE
perf: optimize home media loading

### DIFF
--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -140,6 +140,7 @@
     width: 80px;
     height: 80px;
     margin-bottom: var(--space-2);
+    aspect-ratio: 1 / 1;
 }
 
 .how-it-works__card:focus,
@@ -186,6 +187,10 @@
     box-shadow: var(--shadow-sm);
     padding: var(--space-3);
     text-align: center;
+}
+
+.carousel__card img {
+    aspect-ratio: 1 / 1;
 }
 
 .carousel__button {
@@ -259,6 +264,9 @@
     color: inherit;
     text-decoration: none;
     overflow: hidden;
+    background-size: cover;
+    background-position: center;
+    aspect-ratio: 16 / 9;
 }
 
 .popular-card__overlay {

--- a/templates/home/_featured_groomers.html.twig
+++ b/templates/home/_featured_groomers.html.twig
@@ -10,9 +10,23 @@
                 {% set g = item.profile %}
                 <article class="carousel__card">
                     <picture>
-                        <source srcset="{{ g.logo|default('https://placehold.co/160x160.avif') }}" type="image/avif">
-                        <source srcset="{{ g.logo|default('https://placehold.co/160x160.webp') }}" type="image/webp">
-                        <img src="{{ g.logo|default('https://placehold.co/160x160.jpg') }}" alt="{{ g.businessName }} logo" loading="lazy" width="160" height="160">
+                        <source
+                            srcset="{{ g.logo|default('https://placehold.co/120x120.avif') }} 120w, {{ g.logo|default('https://placehold.co/160x160.avif') }} 160w"
+                            sizes="(min-width: 600px) 160px, 120px"
+                            type="image/avif">
+                        <source
+                            srcset="{{ g.logo|default('https://placehold.co/120x120.webp') }} 120w, {{ g.logo|default('https://placehold.co/160x160.webp') }} 160w"
+                            sizes="(min-width: 600px) 160px, 120px"
+                            type="image/webp">
+                        <img
+                            src="{{ g.logo|default('https://placehold.co/160x160.jpg') }}"
+                            srcset="{{ g.logo|default('https://placehold.co/120x120.jpg') }} 120w, {{ g.logo|default('https://placehold.co/160x160.jpg') }} 160w"
+                            sizes="(min-width: 600px) 160px, 120px"
+                            alt="{{ g.businessName }} logo"
+                            loading="lazy"
+                            decoding="async"
+                            width="160"
+                            height="160">
                     </picture>
                     <h3 class="carousel__name"><a href="{{ path('app_groomer_show', {slug: g.slug}) }}">{{ g.businessName }}</a></h3>
                     {% set aboutSnippet = g.about|slice(0, 40) %}

--- a/templates/home/_how_it_works.html.twig
+++ b/templates/home/_how_it_works.html.twig
@@ -2,17 +2,17 @@
     <h2>How It Works</h2>
     <div class="how-it-works__cards">
         <div class="how-it-works__card" tabindex="0">
-            <img src="{{ asset('assets/illustrations/search.svg') }}" alt="" aria-hidden="true">
+            <img src="{{ asset('assets/illustrations/search.svg') }}" alt="" aria-hidden="true" width="80" height="80" loading="lazy" decoding="async">
             <h3>Search</h3>
             <p>Find trusted groomers near you.</p>
         </div>
         <div class="how-it-works__card" tabindex="0">
-            <img src="{{ asset('assets/illustrations/calendar.svg') }}" alt="" aria-hidden="true">
+            <img src="{{ asset('assets/illustrations/calendar.svg') }}" alt="" aria-hidden="true" width="80" height="80" loading="lazy" decoding="async">
             <h3>Book</h3>
             <p>Choose a time that works.</p>
         </div>
         <div class="how-it-works__card" tabindex="0">
-            <img src="{{ asset('assets/illustrations/paw.svg') }}" alt="" aria-hidden="true">
+            <img src="{{ asset('assets/illustrations/paw.svg') }}" alt="" aria-hidden="true" width="80" height="80" loading="lazy" decoding="async">
             <h3>Relax</h3>
             <p>Your pet leaves fresh and clean.</p>
         </div>

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -2,16 +2,18 @@
 
 {% block stylesheets %}
     {{ parent() }}
+    <link rel="preload" as="image" href="{{ asset('images/hero-poster.avif') }}" imagesrcset="{{ asset('images/hero-poster.avif') }} 1x, {{ asset('images/hero-poster.webp') }} 1x, {{ asset('images/hero-poster.jpg') }} 1x" imagesizes="100vw">
+    <link rel="preload" as="video" href="{{ asset('media/hero.mp4') }}" type="video/mp4">
     <link rel="stylesheet" href="{{ asset('styles/forms.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/home.css') }}">
 {% endblock %}
 
 {% block javascripts %}
     {{ parent() }}
-    <script type="module" src="{{ asset('js/form-enhance.js') }}"></script>
-    <script type="module" src="{{ asset('js/home-hero.js') }}"></script>
-    <script type="module" src="{{ asset('js/sticky-search.js') }}"></script>
-    <script type="module" src="{{ asset('js/section-reveal.js') }}"></script>
+    <script type="module" src="{{ asset('js/form-enhance.js') }}" defer></script>
+    <script type="module" src="{{ asset('js/home-hero.js') }}" defer></script>
+    <script type="module" src="{{ asset('js/sticky-search.js') }}" defer></script>
+    <script type="module" src="{{ asset('js/section-reveal.js') }}" defer></script>
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
## Summary
- preload hero media and defer home scripts
- add responsive picture tags and async decoding for featured and how-it-works images
- ensure stable media layout with aspect ratios in home styles

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*
- `composer fix:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689e3ef4d4ec83229a88d629f3ee1435