### PR TITLE
feat: add accessibility landmarks and skip link

### DIFF
--- a/assets/styles/accessibility.css
+++ b/assets/styles/accessibility.css
@@ -1,0 +1,37 @@
+/* Accessibility helpers */
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    background: #000;
+    color: #fff;
+    padding: 0.5rem 1rem;
+    z-index: 100;
+}
+
+.skip-link:focus,
+.skip-link:active {
+    left: 0;
+    top: 0;
+    width: auto;
+    height: auto;
+    overflow: visible;
+}
+
+.popular-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.popular-card > a {
+    display: block;
+    color: inherit;
+    text-decoration: none;
+    height: 100%;
+}
+

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="UTF-8">
         <title>{% block title %}{{ seo_title|default('CleanWhiskers') }}{% endblock %}</title>
@@ -13,6 +13,7 @@
             <link rel="preconnect" href="https://fonts.googleapis.com">
             <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
             <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;600;700&display=swap" rel="stylesheet">
+            <link rel="stylesheet" href="{{ asset('styles/accessibility.css') }}">
         {% endblock %}
 
         {% block javascripts %}
@@ -20,7 +21,19 @@
         {% endblock %}
     </head>
     <body>
-        {% block body %}{% endblock %}
+        <a href="#main-content" class="skip-link">Skip to main content</a>
+        <header class="site-header">
+            <nav class="main-nav" aria-label="Primary">
+                <ul>
+                    <li><a href="{{ path('app_homepage') }}">Home</a></li>
+                    <li><a href="#about">About</a></li>
+                    <li><a href="#contact">Contact</a></li>
+                </ul>
+            </nav>
+        </header>
+        <main id="main-content" tabindex="-1">
+            {% block body %}{% endblock %}
+        </main>
 
         <footer class="site-footer">
             <nav class="footer-nav">

--- a/templates/home/_featured_groomers.html.twig
+++ b/templates/home/_featured_groomers.html.twig
@@ -1,14 +1,14 @@
 {% if featuredGroomers|length %}
 <section id="featured-groomers" class="featured-carousel">
     <h2 class="featured-carousel__title">Featured Groomers</h2>
-    <div class="carousel" data-carousel>
-        <button class="carousel__button carousel__button--prev" aria-label="Previous" data-carousel-prev>
+    <div class="carousel" data-carousel role="region" aria-roledescription="carousel" aria-label="Featured groomers">
+        <button class="carousel__button carousel__button--prev" aria-label="Previous slide" data-carousel-prev aria-controls="featured-carousel-track">
             &#9664;
         </button>
-        <div class="carousel__track" tabindex="0">
+        <div id="featured-carousel-track" class="carousel__track" tabindex="0" role="list">
             {% for item in featuredGroomers %}
                 {% set g = item.profile %}
-                <article class="carousel__card">
+                <article class="carousel__card" role="listitem">
                     <picture>
                         <source
                             srcset="{{ g.logo|default('https://placehold.co/120x120.avif') }} 120w, {{ g.logo|default('https://placehold.co/160x160.avif') }} 160w"
@@ -35,7 +35,7 @@
                 </article>
             {% endfor %}
         </div>
-        <button class="carousel__button carousel__button--next" aria-label="Next" data-carousel-next>
+        <button class="carousel__button carousel__button--next" aria-label="Next slide" data-carousel-next aria-controls="featured-carousel-track">
             &#9654;
         </button>
     </div>

--- a/templates/home/_popular.html.twig
+++ b/templates/home/_popular.html.twig
@@ -1,45 +1,49 @@
 <section id="popular">
     <h2>Popular Cities</h2>
-    <div class="popular-grid">
+    <ul class="popular-grid" role="list">
         {% for city in popularCities %}
-            <a class="popular-card" href="{{ path('app_city_show', {slug: city.slug}) }}">
-                <span class="popular-card__title">{{ city.name }}</span>
-                <span class="popular-card__overlay">
-                    {% if city.groomerCount is defined and city.groomerCount is not null %}
-                        {{ city.groomerCount }} groomers
-                    {% else %}
-                        Browse
-                    {% endif %}
-                </span>
-            </a>
-        {% else %}
-            <div class="popular-card">City coming soon</div>
-        {% endfor %}
-    </div>
-
-    <h2>Popular Services</h2>
-    <div class="popular-grid">
-        {% set defaultCity = popularCities|first %}
-        {% for service in popularServices %}
-            {% if defaultCity %}
-                <a class="popular-card" href="{{ path('app_groomer_list_by_city_service', {citySlug: defaultCity.slug, serviceSlug: service.slug}) }}">
-                    <span class="popular-card__title">{{ service.name }}</span>
+            <li class="popular-card">
+                <a href="{{ path('app_city_show', {slug: city.slug}) }}">
+                    <span class="popular-card__title">{{ city.name }}</span>
                     <span class="popular-card__overlay">
-                        {% if service.groomerCount is defined and service.groomerCount is not null %}
-                            {{ service.groomerCount }} groomers
+                        {% if city.groomerCount is defined and city.groomerCount is not null %}
+                            {{ city.groomerCount }} groomers
                         {% else %}
                             Browse
                         {% endif %}
                     </span>
                 </a>
+            </li>
+        {% else %}
+            <li class="popular-card">City coming soon</li>
+        {% endfor %}
+    </ul>
+
+    <h2>Popular Services</h2>
+    <ul class="popular-grid" role="list">
+        {% set defaultCity = popularCities|first %}
+        {% for service in popularServices %}
+            {% if defaultCity %}
+                <li class="popular-card">
+                    <a href="{{ path('app_groomer_list_by_city_service', {citySlug: defaultCity.slug, serviceSlug: service.slug}) }}">
+                        <span class="popular-card__title">{{ service.name }}</span>
+                        <span class="popular-card__overlay">
+                            {% if service.groomerCount is defined and service.groomerCount is not null %}
+                                {{ service.groomerCount }} groomers
+                            {% else %}
+                                Browse
+                            {% endif %}
+                        </span>
+                    </a>
+                </li>
             {% else %}
-                <div class="popular-card">
+                <li class="popular-card">
                     <span class="popular-card__title">{{ service.name }}</span>
-                </div>
+                </li>
             {% endif %}
         {% else %}
-            <div class="popular-card">Service coming soon</div>
+            <li class="popular-card">Service coming soon</li>
         {% endfor %}
-    </div>
+    </ul>
 </section>
 

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -18,7 +18,7 @@
 
 {% block body %}
 <div id="sticky-search" class="sticky-search">
-    <form id="sticky-search-form" class="search-form" method="get" action="/search">
+    <form id="sticky-search-form" class="search-form" method="get" action="/search" role="search">
         <label for="sticky-city">City</label>
         <input class="search-form__input search-form__input--city" type="text" id="sticky-city" name="city" placeholder="Where's your pet?" aria-describedby="sticky-city-error" required>
         <span id="sticky-city-error" class="form-error" aria-live="polite"></span>
@@ -40,7 +40,7 @@
         <div class="hero__card">
             <h1>Find trusted pet care</h1>
             <p class="hero__subtext">Book top-rated services near you.</p>
-            <form id="search-form" class="search-form" method="get" action="/search">
+            <form id="search-form" class="search-form" method="get" action="/search" role="search">
                 <label for="city">City</label>
                 <input class="search-form__input search-form__input--city" type="text" id="city" name="city" placeholder="Where's your pet?" aria-describedby="city-error" required>
                 <span id="city-error" class="form-error" aria-live="polite"></span>
@@ -53,7 +53,7 @@
                 <span id="service-error" class="form-error" aria-live="polite"></span>
                 <button class="search-form__button btn btn--accent" type="submit" id="search-submit">{{ ctaLinks.find.label }}</button>
             </form>
-            <button id="hero-video-toggle" class="hero__video-toggle" type="button">Pause</button>
+            <button id="hero-video-toggle" class="hero__video-toggle" type="button" aria-controls="hero-video" aria-pressed="false" aria-label="Pause video">Pause</button>
             <a href="{{ ctaLinks.list.url }}" class="hero__cta-link btn btn--accent">{{ ctaLinks.list.label }}</a>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add header, main landmark and skip link for improved keyboard navigation
- annotate featured carousel controls with ARIA and convert popular sections to lists
- style skip link and list semantics for popular grids

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689e40cc39cc8322a382f7602609107c