### PR TITLE
Improve homepage SEO semantics

### DIFF
--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -48,6 +48,8 @@ class HomepageController extends AbstractController
             'popularCities' => $popularCities,
             'popularServices' => $popularServices,
             'featuredGroomers' => $featuredGroomers,
+            'seo_title' => 'Book local pet care | CleanWhiskers',
+            'seo_description' => 'Discover trusted groomers and pet boarding near you. CleanWhiskers makes booking easy.',
         ]);
     }
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -2,11 +2,9 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8">
-        <title>{% block title %}{{ seo_title|default('CleanWhiskers') }}{% endblock %}</title>
+        <title>{% block title %}{{ seo_title|default('Find trusted pet care | CleanWhiskers') }}{% endblock %}</title>
         {% block meta_description %}
-            {% if seo_description is defined %}
-                <meta name="description" content="{{ seo_description }}">
-            {% endif %}
+            <meta name="description" content="{{ seo_description|default('Book top-rated grooming and boarding services near you with CleanWhiskers.') }}">
         {% endblock %}
         <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
         {% block stylesheets %}

--- a/templates/home/_cta_banner.html.twig
+++ b/templates/home/_cta_banner.html.twig
@@ -1,4 +1,5 @@
 <section class="cta-banner">
+    <h2 class="cta-banner__heading">Get started</h2>
     <a href="#search-form" class="cta-banner__link cta-banner__link--owners btn btn--accent">Find a Groomer</a>
     <a href="/register?role=groomer" class="cta-banner__link cta-banner__link--groomers btn btn--accent">Join as Groomer</a>
 </section>

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -40,6 +40,7 @@
         <div class="hero__card">
             <h1>Find trusted pet care</h1>
             <p class="hero__subtext">Book top-rated services near you.</p>
+            <a href="{{ ctaLinks.list.url }}" class="hero__cta-link btn btn--accent">{{ ctaLinks.list.label }}</a>
             <form id="search-form" class="search-form" method="get" action="/search" role="search">
                 <label for="city">City</label>
                 <input class="search-form__input search-form__input--city" type="text" id="city" name="city" placeholder="Where's your pet?" aria-describedby="city-error" required>
@@ -54,7 +55,6 @@
                 <button class="search-form__button btn btn--accent" type="submit" id="search-submit">{{ ctaLinks.find.label }}</button>
             </form>
             <button id="hero-video-toggle" class="hero__video-toggle" type="button" aria-controls="hero-video" aria-pressed="false" aria-label="Pause video">Pause</button>
-            <a href="{{ ctaLinks.list.url }}" class="hero__cta-link btn btn--accent">{{ ctaLinks.list.label }}</a>
         </div>
     </div>
 </section>

--- a/tests/Controller/HomepageMetaTest.php
+++ b/tests/Controller/HomepageMetaTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class HomepageMetaTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testHomePageRendersMetaTags(): void
+    {
+        $crawler = $this->client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+
+        self::assertSelectorTextContains('title', 'Book local pet care | CleanWhiskers');
+        $description = $crawler->filter('meta[name="description"]')->attr('content');
+        self::assertSame(
+            'Discover trusted groomers and pet boarding near you. CleanWhiskers makes booking easy.',
+            $description
+        );
+    }
+}

--- a/tests/E2E/Homepage/HeadingStructureTest.php
+++ b/tests/E2E/Homepage/HeadingStructureTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E\Homepage;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class HeadingStructureTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testHeadingOutlineIsLogical(): void
+    {
+        $crawler = $this->client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+
+        $main = $crawler->filter('main');
+        self::assertSame(1, $main->filter('h1')->count());
+
+        $headings = $main->filter('h1, h2, h3, h4, h5, h6');
+        $prevLevel = 1;
+        foreach ($headings as $index => $node) {
+            $level = (int) substr($node->nodeName, 1);
+            if (0 === $index) {
+                self::assertSame(1, $level);
+            } else {
+                self::assertLessThanOrEqual($prevLevel + 1, $level);
+            }
+            $prevLevel = $level;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add server-rendered meta title and description for homepage
- ensure heading structure uses one H1 and logical H2/H3 tree
- keep primary CTA visible in hero

## Testing
- ⚠️ `make setup` *(No rule to make target 'setup')*
- ✅ `composer fix:php`
- ✅ `composer stan`
- ⚠️ `composer test` *(Allowed memory size exhausted)*
- ✅ `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --testdox`
- ⚠️ `make test -k` *(No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689e4313b3c08322b6c11a9a32a90886