### PR TITLE
feat: add loading spinner for search forms

### DIFF
--- a/assets/js/loading.js
+++ b/assets/js/loading.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const forms = document.querySelectorAll('.search-form');
+    forms.forEach((form) => {
+        form.addEventListener('submit', () => {
+            const button = form.querySelector('button[type="submit"]');
+            if (button) {
+                const spinner = button.querySelector('.spinner');
+                if (spinner) {
+                    spinner.hidden = false;
+                }
+            }
+        });
+    });
+});

--- a/assets/styles/components/loading.css
+++ b/assets/styles/components/loading.css
@@ -1,0 +1,17 @@
+.spinner {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    border: 2px solid currentColor;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: spin 0.75s linear infinite;
+    margin-left: var(--space-1);
+    vertical-align: middle;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -6,6 +6,7 @@
     <link rel="preload" as="video" href="{{ asset('media/hero.mp4') }}" type="video/mp4">
     <link rel="stylesheet" href="{{ asset('styles/forms.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/home.css') }}">
+    <link rel="stylesheet" href="{{ asset('styles/components/loading.css') }}">
 {% endblock %}
 
 {% block javascripts %}
@@ -14,6 +15,7 @@
     <script type="module" src="{{ asset('js/home-hero.js') }}" defer></script>
     <script type="module" src="{{ asset('js/sticky-search.js') }}" defer></script>
     <script type="module" src="{{ asset('js/section-reveal.js') }}" defer></script>
+    <script type="module" src="{{ asset('js/loading.js') }}" defer></script>
 {% endblock %}
 
 {% block body %}
@@ -29,7 +31,10 @@
             <option value="boarding">Boarding</option>
         </select>
         <span id="sticky-service-error" class="form-error" aria-live="polite"></span>
-        <button class="search-form__button btn btn--accent" type="submit">{{ ctaLinks.find.label }}</button>
+        <button class="search-form__button btn btn--accent" type="submit">
+            {{ ctaLinks.find.label }}
+            <span class="spinner" hidden role="status" aria-live="polite" aria-label="Loading"></span>
+        </button>
     </form>
 </div>
 <section class="hero">
@@ -52,7 +57,10 @@
                     <option value="boarding">Boarding</option>
                 </select>
                 <span id="service-error" class="form-error" aria-live="polite"></span>
-                <button class="search-form__button btn btn--accent" type="submit" id="search-submit">{{ ctaLinks.find.label }}</button>
+                <button class="search-form__button btn btn--accent" type="submit" id="search-submit">
+                    {{ ctaLinks.find.label }}
+                    <span class="spinner" hidden role="status" aria-live="polite" aria-label="Loading"></span>
+                </button>
             </form>
             <button id="hero-video-toggle" class="hero__video-toggle" type="button" aria-controls="hero-video" aria-pressed="false" aria-label="Pause video">Pause</button>
         </div>

--- a/tests/E2E/Homepage/LoadingStateTest.php
+++ b/tests/E2E/Homepage/LoadingStateTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E\Homepage;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class LoadingStateTest extends WebTestCase
+{
+    private KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+    }
+
+    public function testSearchButtonsIncludeHiddenAccessibleSpinner(): void
+    {
+        $crawler = $this->client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+
+        $spinners = $crawler->filter('.search-form__button .spinner[role="status"][aria-live="polite"][hidden]');
+        self::assertCount(2, $spinners);
+    }
+}


### PR DESCRIPTION
## Summary
- add CSS/JS spinner component for search forms
- inject spinner markup and assets into home template
- cover spinner markup with E2E test

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_689e45602d508322ac4a63325a53874f