### PR TITLE
fix: import utilities stylesheet explicitly

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -6,5 +6,6 @@ import './bootstrap.js';
  * which should already be in your base.html.twig.
  */
 import './styles/app.css';
+import './styles/utilities.css';
 
 console.log('This log comes from assets/app.js - welcome to AssetMapper! 🎉');

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,5 +1,3 @@
-@import './utilities.css';
-
 :root {
     /* Color palette */
     --color-cream: #fdfaf5;


### PR DESCRIPTION
## Summary
- remove unused CSS @import
- load utilities.css from JS entry point

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --testdox`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_689f66ce6ee083228b49023045698c9c