### PR TITLE
feat: rebuild responsive header navigation

### DIFF
--- a/src/public/css/components/header.css
+++ b/src/public/css/components/header.css
@@ -1,0 +1,68 @@
+.site-header {
+    background: var(--color-pastel);
+    padding: var(--space-2) var(--space-3);
+}
+
+.nav-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.nav-toggle {
+    display: none;
+    background: none;
+    border: 0;
+    font-size: 1.5rem;
+}
+
+.nav-toggle .hamburger {
+    display: block;
+    width: 1.5rem;
+    height: 2px;
+    background: var(--color-text);
+    box-shadow: 0 6px 0 var(--color-text), 0 12px 0 var(--color-text);
+}
+
+.primary-nav ul {
+    list-style: none;
+    display: flex;
+    gap: var(--space-3);
+    margin: 0;
+    padding: 0;
+}
+
+.primary-nav a {
+    text-decoration: none;
+    color: var(--color-text);
+}
+
+.primary-nav a[aria-current="page"] {
+    color: var(--color-accent);
+}
+
+@media (max-width: 768px) {
+    .nav-toggle {
+        display: block;
+    }
+
+    .primary-nav {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        background: var(--color-pastel);
+        transform: translateY(-100%);
+        transition: transform 0.3s ease;
+        padding: var(--space-4) var(--space-3);
+    }
+
+    .primary-nav ul {
+        flex-direction: column;
+        gap: var(--space-2);
+    }
+
+    body[data-menu-open="true"] .primary-nav {
+        transform: translateY(0);
+    }
+}

--- a/src/public/js/nav-toggle.js
+++ b/src/public/js/nav-toggle.js
@@ -1,0 +1,81 @@
+(function (global) {
+  function focusTrap(doc, nav, e) {
+    if (e.key !== 'Tab') {
+      return;
+    }
+    var focusable = nav.querySelectorAll('a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])');
+    if (!focusable.length) {
+      return;
+    }
+    var first = focusable[0];
+    var last = focusable[focusable.length - 1];
+    if (e.shiftKey && doc.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+      doc.activeElement = last;
+    } else if (!e.shiftKey && doc.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+      doc.activeElement = first;
+    }
+  }
+
+  function openMenu(doc, nav, toggle) {
+    doc.body.dataset.menuOpen = 'true';
+    doc.body.style.overflow = 'hidden';
+    toggle.setAttribute('aria-expanded', 'true');
+    var first = nav.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
+    if (first && typeof first.focus === 'function') {
+      first.focus();
+      doc.activeElement = first;
+    }
+  }
+
+  function closeMenu(doc, nav, toggle) {
+    delete doc.body.dataset.menuOpen;
+    doc.body.style.overflow = '';
+    toggle.setAttribute('aria-expanded', 'false');
+  }
+
+  function initNavToggle(doc) {
+    doc = doc || document;
+    var nav = doc.getElementById('primary-nav');
+    var toggle = doc.getElementById('nav-toggle');
+    if (!nav || !toggle) {
+      return;
+    }
+    var onKeyDown = function (e) {
+      if (e.key === 'Escape') {
+        closeMenu(doc, nav, toggle);
+        if (typeof toggle.focus === 'function') {
+          toggle.focus();
+          doc.activeElement = toggle;
+        }
+      } else {
+        focusTrap(doc, nav, e);
+      }
+    };
+    var onClickOutside = function (e) {
+      if (!nav.contains(e.target) && e.target !== toggle) {
+        closeMenu(doc, nav, toggle);
+      }
+    };
+    toggle.addEventListener('click', function () {
+      if (doc.body.dataset.menuOpen === 'true') {
+        closeMenu(doc, nav, toggle);
+      } else {
+        openMenu(doc, nav, toggle);
+      }
+    });
+    doc.addEventListener('keydown', onKeyDown);
+    doc.addEventListener('click', onClickOutside);
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { initNavToggle: initNavToggle, openMenu: openMenu, closeMenu: closeMenu, focusTrap: focusTrap };
+  } else {
+    document.addEventListener('DOMContentLoaded', function () {
+      initNavToggle(document);
+    });
+  }
+})(this);

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -12,23 +12,17 @@
             <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
             <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;600;700&display=swap" rel="stylesheet">
             <link rel="stylesheet" href="{{ asset('styles/accessibility.css') }}">
+            <link rel="stylesheet" href="{{ asset('css/components/header.css') }}">
         {% endblock %}
 
         {% block javascripts %}
             {% block importmap %}{{ importmap('app') }}{% endblock %}
+            <script src="{{ asset('js/nav-toggle.js') }}" defer></script>
         {% endblock %}
     </head>
-    <body>
+    <body data-route="{{ app.request.attributes.get('_route') }}">
         <a href="#main-content" class="skip-link">Skip to main content</a>
-        <header class="site-header">
-            <nav class="main-nav" aria-label="Primary">
-                <ul>
-                    <li><a href="{{ path('app_homepage') }}">Home</a></li>
-                    <li><a href="#about">About</a></li>
-                    <li><a href="#contact">Contact</a></li>
-                </ul>
-            </nav>
-        </header>
+        {% include 'partials/_header.html.twig' %}
         <main id="main-content" tabindex="-1">
             {% block body %}{% endblock %}
         </main>

--- a/templates/partials/_header.html.twig
+++ b/templates/partials/_header.html.twig
@@ -1,0 +1,19 @@
+{% set currentRoute = app.request.attributes.get('_route') %}
+<header class="site-header">
+  <div class="nav-container">
+    <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+      <span class="sr-only">Menu</span>
+      <span class="hamburger" aria-hidden="true"></span>
+    </button>
+    <nav id="primary-nav" class="primary-nav" aria-label="Primary">
+      <ul>
+        <li><a href="#about">About</a></li>
+        <li><a href="#contact">Contact</a></li>
+        <li><a href="#faq">FAQ</a></li>
+        <li><a href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>Blog</a></li>
+        <li><a href="#terms">Terms</a></li>
+        <li><a href="#privacy">Privacy</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/tests/Frontend/E2E/header.e2e.md
+++ b/tests/Frontend/E2E/header.e2e.md
@@ -1,0 +1,14 @@
+# Header Navigation E2E
+
+## Desktop
+1. Visit the home page on a viewport wider than 768px.
+2. Verify the navigation menu displays "About", "Contact", "FAQ", "Blog", "Terms", "Privacy" horizontally.
+3. Navigate to Blog and ensure the link has `aria-current="page"`.
+
+## Mobile
+1. Set viewport to 375px wide.
+2. Activate the hamburger button.
+3. Ensure body has `data-menu-open="true"` and scrolling is disabled.
+4. Tab through links; focus cycles within the menu.
+5. Press `Escape` to close the menu and verify body no longer has `data-menu-open`.
+6. Click outside the menu and ensure it closes.

--- a/tests/Frontend/Unit/NavToggleTest.js
+++ b/tests/Frontend/Unit/NavToggleTest.js
@@ -1,0 +1,68 @@
+const assert = require('assert');
+const path = require('path');
+const navToggle = require(path.join(__dirname, '../../../src/public/js/nav-toggle.js'));
+
+function createDocument() {
+  const doc = {
+    body: { dataset: {}, style: {} },
+    activeElement: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  return doc;
+}
+
+function createLink(doc) {
+  return {
+    focusCalled: false,
+    focus: function () {
+      this.focusCalled = true;
+      doc.activeElement = this;
+    },
+  };
+}
+
+(function testToggle() {
+  const doc = createDocument();
+  const first = createLink(doc);
+  const last = createLink(doc);
+  const nav = {
+    querySelector: () => first,
+    querySelectorAll: () => [first, last],
+    contains: () => false,
+  };
+  const toggle = {
+    setAttribute: () => {},
+    addEventListener: () => {},
+  };
+
+  navToggle.openMenu(doc, nav, toggle);
+  assert.strictEqual(doc.body.dataset.menuOpen, 'true', 'menu opens');
+  assert.strictEqual(first.focusCalled, true, 'first element focused');
+
+  navToggle.closeMenu(doc, nav, toggle);
+  assert.ok(!('menuOpen' in doc.body.dataset), 'menu closes');
+})();
+
+(function testFocusTrap() {
+  const doc = createDocument();
+  const first = createLink(doc);
+  const last = createLink(doc);
+  const nav = {
+    querySelectorAll: () => [first, last],
+  };
+
+  doc.activeElement = first;
+  const backward = { key: 'Tab', shiftKey: true, preventDefault: function () { this.called = true; }, called: false };
+  navToggle.focusTrap(doc, nav, backward);
+  assert.strictEqual(doc.activeElement, last, 'shift+tab cycles to last');
+  assert.strictEqual(backward.called, true, 'default prevented');
+
+  doc.activeElement = last;
+  const forward = { key: 'Tab', shiftKey: false, preventDefault: function () { this.called = true; }, called: false };
+  navToggle.focusTrap(doc, nav, forward);
+  assert.strictEqual(doc.activeElement, first, 'tab cycles to first');
+  assert.strictEqual(forward.called, true, 'default prevented');
+})();
+
+console.log('NavToggle tests passed');


### PR DESCRIPTION
## Summary
- add accessible header partial with desktop and mobile navigation
- wire new CSS and JS assets in base layout
- create vanilla nav toggle with focus trap and tests

## Testing
- `node tests/Frontend/Unit/NavToggleTest.js`
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689f6e3b94688322ad8bc102d7b46942