### PR TITLE
fix: debounce CTA spinner

### DIFF
--- a/src/public/css/components/button.css
+++ b/src/public/css/components/button.css
@@ -1,0 +1,27 @@
+.btn.is-loading {
+    position: relative;
+}
+
+.btn.is-loading::after {
+    content: "";
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    margin-left: var(--space-1, 0.5rem);
+    border: 2px solid currentColor;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: spin 0.75s linear infinite;
+    vertical-align: middle;
+}
+
+.btn[aria-disabled="true"] {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/src/public/js/cta-button.js
+++ b/src/public/js/cta-button.js
@@ -1,0 +1,62 @@
+(function (global) {
+  function initCtaButton(doc, fetchFn, win) {
+    doc = doc || document;
+    fetchFn = fetchFn || (typeof fetch !== 'undefined' ? fetch.bind(global) : null);
+    win = win || global;
+    var button = doc.querySelector('.cta-banner__link--owners');
+    if (!button) {
+      return;
+    }
+    var spinner = button.querySelector('.spinner');
+    if (!spinner) {
+      spinner = doc.createElement('span');
+      spinner.className = 'spinner';
+      spinner.hidden = true;
+      button.appendChild(spinner);
+    }
+    var errorEl = doc.createElement('span');
+    errorEl.className = 'cta-button__error';
+    errorEl.setAttribute('role', 'status');
+    errorEl.setAttribute('aria-live', 'polite');
+    errorEl.hidden = true;
+    button.after(errorEl);
+    button.classList.remove('is-loading');
+    button.removeAttribute('aria-disabled');
+    spinner.hidden = true;
+    var pending = false;
+    button.addEventListener('click', function (e) {
+      if (pending) {
+        if (e && typeof e.preventDefault === 'function') {
+          e.preventDefault();
+        }
+        return;
+      }
+      pending = true;
+      button.classList.add('is-loading');
+      button.setAttribute('aria-disabled', 'true');
+      spinner.hidden = false;
+      var href = button.getAttribute('href');
+      if (fetchFn) {
+        fetchFn(href, { method: 'HEAD' })
+          .then(function () {
+            win.location.href = href;
+          })
+          .catch(function () {
+            pending = false;
+            button.classList.remove('is-loading');
+            button.removeAttribute('aria-disabled');
+            spinner.hidden = true;
+            errorEl.textContent = 'Please try again';
+            errorEl.hidden = false;
+          });
+      }
+    });
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { initCtaButton: initCtaButton };
+  } else {
+    document.addEventListener('DOMContentLoaded', function () {
+      initCtaButton(document);
+    });
+  }
+})(this);

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{{ asset('styles/forms.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/home.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/components/loading.css') }}">
+    <link rel="stylesheet" href="{{ asset('styles/components/button.css') }}">
 {% endblock %}
 
 {% block javascripts %}
@@ -16,6 +17,7 @@
     <script type="module" src="{{ asset('js/sticky-search.js') }}" defer></script>
     <script type="module" src="{{ asset('js/section-reveal.js') }}" defer></script>
     <script type="module" src="{{ asset('js/loading.js') }}" defer></script>
+    <script src="{{ asset('js/cta-button.js') }}" defer></script>
 {% endblock %}
 
 {% block body %}

--- a/tests/Frontend/E2E/cta-spinner.e2e.md
+++ b/tests/Frontend/E2E/cta-spinner.e2e.md
@@ -1,0 +1,7 @@
+# CTA Spinner E2E
+
+1. Visit the home page.
+2. Confirm the "Find a Groomer" button is enabled and no spinner is visible.
+3. Click the button once and ensure a spinner appears and the button becomes disabled.
+4. Attempt a rapid second click; it should not trigger another spinner.
+5. After navigation or when the request completes, the spinner should disappear and the button becomes enabled again.

--- a/tests/Frontend/Unit/CtaButtonTest.js
+++ b/tests/Frontend/Unit/CtaButtonTest.js
@@ -1,0 +1,49 @@
+const assert = require('assert');
+const path = require('path');
+const { initCtaButton } = require(path.join(__dirname, '../../../src/public/js/cta-button.js'));
+
+function createButton() {
+  const button = {
+    classList: {
+      list: [],
+      add(cls) { this.list.push(cls); },
+      remove(cls) { this.list = this.list.filter(c => c !== cls); },
+      contains(cls) { return this.list.includes(cls); },
+    },
+    attributes: {},
+    setAttribute(name, value) { this.attributes[name] = value; },
+    removeAttribute(name) { delete this.attributes[name]; },
+    getAttribute(name) { return this.attributes[name]; },
+    querySelector() { return null; },
+    appendChild(node) { this.spinner = node; },
+    after() {},
+    addEventListener(event, handler) { this.eventListeners[event] = handler; },
+    eventListeners: {},
+  };
+  return button;
+}
+
+function createDocument(button) {
+  return {
+    querySelector: () => button,
+    createElement: () => ({ className: '', hidden: false, setAttribute() {}, after() {} }),
+  };
+}
+
+(function testLoadingAndDebounce() {
+  const button = createButton();
+  const doc = createDocument(button);
+  let fetchCalls = 0;
+  function fakeFetch() {
+    fetchCalls += 1;
+    return new Promise(() => {});
+  }
+  initCtaButton(doc, fakeFetch, {});
+  assert.strictEqual(button.classList.contains('is-loading'), false, 'initially not loading');
+  button.eventListeners.click({ preventDefault() {} });
+  assert.strictEqual(button.classList.contains('is-loading'), true, 'loading after click');
+  button.eventListeners.click({ preventDefault() {} });
+  assert.strictEqual(fetchCalls, 1, 'debounced double click');
+})();
+
+console.log('CtaButton tests passed');


### PR DESCRIPTION
## Summary
- show spinner on Find a Groomer CTA only while network request is pending
- add button loading styles and wire script in home template
- cover CTA spinner with unit test and manual E2E doc

## Testing
- `node tests/Frontend/Unit/NavToggleTest.js`
- `node tests/Frontend/Unit/CtaButtonTest.js`
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_689f70f0aaf48322bbb05bb38243c7fb