### PR TITLE
feat: redesign popular cities section

### DIFF
--- a/public/css/sections/popular-cities.css
+++ b/public/css/sections/popular-cities.css
@@ -1,0 +1,56 @@
+.popular-cities {
+    padding: 2rem 0;
+}
+
+.popular-cities__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+}
+
+.popular-cities__link {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 0.75rem;
+    border-radius: 9999px;
+    background-color: #f3f4f6;
+    border: 1px solid #e5e7eb;
+    text-decoration: none;
+    color: inherit;
+    transition: background-color 0.2s, box-shadow 0.2s;
+}
+
+.popular-cities__link:hover,
+.popular-cities__link:focus {
+    background-color: #e5e7eb;
+    box-shadow: 0 0 0 2px #000;
+    outline: none;
+}
+
+.popular-cities__avatar {
+    width: 2.5rem;
+    height: 2.5rem;
+    margin-right: 0.5rem;
+    border-radius: 50%;
+    overflow: hidden;
+    flex-shrink: 0;
+    background-color: #d1d5db;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    color: #374151;
+}
+
+.popular-cities__avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.popular-cities__name {
+    flex: 1;
+    white-space: normal;
+    overflow-wrap: anywhere;
+}

--- a/src/public/css/sections/popular-cities.css
+++ b/src/public/css/sections/popular-cities.css
@@ -1,0 +1,56 @@
+.popular-cities {
+    padding: 2rem 0;
+}
+
+.popular-cities__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+}
+
+.popular-cities__link {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 0.75rem;
+    border-radius: 9999px;
+    background-color: #f3f4f6;
+    border: 1px solid #e5e7eb;
+    text-decoration: none;
+    color: inherit;
+    transition: background-color 0.2s, box-shadow 0.2s;
+}
+
+.popular-cities__link:hover,
+.popular-cities__link:focus {
+    background-color: #e5e7eb;
+    box-shadow: 0 0 0 2px #000;
+    outline: none;
+}
+
+.popular-cities__avatar {
+    width: 2.5rem;
+    height: 2.5rem;
+    margin-right: 0.5rem;
+    border-radius: 50%;
+    overflow: hidden;
+    flex-shrink: 0;
+    background-color: #d1d5db;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    color: #374151;
+}
+
+.popular-cities__avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.popular-cities__name {
+    flex: 1;
+    white-space: normal;
+    overflow-wrap: anywhere;
+}

--- a/templates/home/_popular_cities.html.twig
+++ b/templates/home/_popular_cities.html.twig
@@ -1,0 +1,21 @@
+<section class="popular-cities">
+    <h2>Popular Cities</h2>
+    <ul class="popular-cities__grid" role="list">
+        {% for city in popularCities %}
+            <li class="popular-cities__item">
+                <a class="popular-cities__link" href="{{ path('app_city_show', {slug: city.slug}) }}" aria-label="Groomers in {{ city.name }}">
+                    <span class="popular-cities__avatar">
+                        {% if city.image is defined and city.image %}
+                            <img src="{{ city.image }}" alt="" loading="lazy">
+                        {% else %}
+                            {{ city.name|slice(0,1)|upper }}
+                        {% endif %}
+                    </span>
+                    <span class="popular-cities__name">{{ city.name }}</span>
+                </a>
+            </li>
+        {% else %}
+            <li class="popular-cities__item">City coming soon</li>
+        {% endfor %}
+    </ul>
+</section>

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="{{ asset('css/components/button.css') }}">
     <link rel="stylesheet" href="{{ asset('css/sections/hero.css') }}">
     <link rel="stylesheet" href="{{ asset('css/components/card-groomer.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/sections/popular-cities.css') }}">
 {% endblock %}
 
 {% block javascripts %}
@@ -27,5 +28,5 @@
     {% include 'home/partials/_cta_banner.html.twig' %}
     {% include 'home/partials/_how_it_works.html.twig' %}
     {% include 'home/_featured_groomers.html.twig' %}
-    {% include 'home/partials/_popular.html.twig' %}
+    {% include 'home/_popular_cities.html.twig' %}
 {% endblock %}

--- a/tests/Frontend/E2E/popular-cities.e2e.md
+++ b/tests/Frontend/E2E/popular-cities.e2e.md
@@ -1,0 +1,15 @@
+# Popular Cities Grid E2E
+
+## Desktop
+1. Visit the home page at viewport width 1280px.
+2. Confirm the popular cities section displays four city pills per row.
+3. Hover a city link and ensure a visible background and outline appear.
+
+## Tablet
+1. Set viewport to 768px width.
+2. Verify the grid adjusts to two columns without overflow.
+
+## Mobile
+1. Set viewport to 360px width.
+2. Confirm pills stack in a single column and long names wrap within the pill.
+3. Ensure each link has a comfortable tap target (at least 48px height).

--- a/tests/Frontend/Unit/PopularCitiesMarkupTest.html
+++ b/tests/Frontend/Unit/PopularCitiesMarkupTest.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Popular Cities Markup Test</title>
+    <script>
+        window.addEventListener('DOMContentLoaded', function () {
+            const grid = document.querySelector('.popular-cities__grid');
+            console.assert(grid, 'grid exists');
+            const links = grid.querySelectorAll('a.popular-cities__link');
+            console.assert(links.length === 2, 'two city links rendered');
+            const first = links[0];
+            console.assert(first.getAttribute('aria-label') === 'Groomers in Springfield', 'accessible link name');
+            const avatar = first.querySelector('.popular-cities__avatar');
+            console.assert(avatar && (avatar.querySelector('img') || avatar.textContent.trim().length > 0), 'avatar image or initial');
+            const name = first.querySelector('.popular-cities__name');
+            console.assert(name && name.textContent.trim() === 'Springfield', 'city name text');
+            console.log('Popular cities markup tests passed');
+        });
+    </script>
+</head>
+<body>
+<section class="popular-cities">
+    <ul class="popular-cities__grid" role="list">
+        <li class="popular-cities__item">
+            <a class="popular-cities__link" href="#" aria-label="Groomers in Springfield">
+                <span class="popular-cities__avatar"><img src="https://placehold.co/80" alt="" loading="lazy"></span>
+                <span class="popular-cities__name">Springfield</span>
+            </a>
+        </li>
+        <li class="popular-cities__item">
+            <a class="popular-cities__link" href="#" aria-label="Groomers in Very Long City Name Example">
+                <span class="popular-cities__avatar">V</span>
+                <span class="popular-cities__name">Very Long City Name Example</span>
+            </a>
+        </li>
+    </ul>
+</section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- style popular cities section with responsive pill grid and avatars
- include popular cities partial on homepage with accessible link names
- add unit and E2E tests for popular cities layout

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `make setup && make test -k` *(fails: No rule to make target 'setup')*

------
https://chatgpt.com/codex/tasks/task_e_689f7ad3ce908322be6a4f56ec7a6e43