### PR TITLE
feat: refresh popular cities section

### DIFF
--- a/public/css/sections/popular-cities.css
+++ b/public/css/sections/popular-cities.css
@@ -1,0 +1,72 @@
+.popular-cities {
+    padding: var(--space-4) 0;
+}
+
+.popular-cities__grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--space-3);
+    grid-template-columns: repeat(2, 1fr);
+}
+
+@media (min-width: 480px) {
+    .popular-cities__grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media (min-width: 768px) {
+    .popular-cities__grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}
+
+.popular-cities__link {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    background-color: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 9999px;
+    text-decoration: none;
+    color: inherit;
+    min-height: 3rem;
+}
+
+.popular-cities__link:hover,
+.popular-cities__link:focus {
+    border-color: var(--color-accent, #2563eb);
+    box-shadow: 0 0 0 2px var(--color-accent, #2563eb);
+}
+
+.popular-cities__link:focus {
+    outline: none;
+}
+
+.popular-cities__avatar {
+    flex-shrink: 0;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    background-color: #f3f4f6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    text-transform: uppercase;
+    overflow: hidden;
+}
+
+.popular-cities__avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+}
+
+.popular-cities__name {
+    overflow-wrap: anywhere;
+}

--- a/templates/home/_popular_cities.html.twig
+++ b/templates/home/_popular_cities.html.twig
@@ -1,0 +1,21 @@
+<section class="popular-cities">
+    <h2>Popular Cities</h2>
+    <ul class="popular-cities__grid" role="list">
+        {% for city in popularCities %}
+            <li class="popular-cities__item">
+                <a class="popular-cities__link" href="{{ path('app_city_show', {slug: city.slug}) }}" aria-label="Groomers in {{ city.name }}">
+                    <span class="popular-cities__avatar" aria-hidden="true">
+                        {% if city.image is defined and city.image %}
+                            <img src="{{ city.image }}" alt="" loading="lazy">
+                        {% else %}
+                            {{ city.name|slice(0,1) }}
+                        {% endif %}
+                    </span>
+                    <span class="popular-cities__name">{{ city.name }}</span>
+                </a>
+            </li>
+        {% else %}
+            <li class="popular-cities__item">City coming soon</li>
+        {% endfor %}
+    </ul>
+</section>

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="{{ asset('css/components/button.css') }}">
     <link rel="stylesheet" href="{{ asset('css/sections/hero.css') }}">
     <link rel="stylesheet" href="{{ asset('css/components/card-groomer.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/sections/popular-cities.css') }}">
 {% endblock %}
 
 {% block javascripts %}
@@ -27,5 +28,6 @@
     {% include 'home/partials/_cta_banner.html.twig' %}
     {% include 'home/partials/_how_it_works.html.twig' %}
     {% include 'home/_featured_groomers.html.twig' %}
-    {% include 'home/partials/_popular.html.twig' %}
+    {% include 'home/_popular_cities.html.twig' %}
+    {% include 'home/partials/_popular_services.html.twig' %}
 {% endblock %}

--- a/templates/home/partials/_popular_services.html.twig
+++ b/templates/home/partials/_popular_services.html.twig
@@ -1,24 +1,4 @@
-<section id="popular">
-    <h2>Popular Cities</h2>
-    <ul class="popular-grid" role="list">
-        {% for city in popularCities %}
-            <li class="popular-card">
-                <a href="{{ path('app_city_show', {slug: city.slug}) }}">
-                    <span class="popular-card__title">{{ city.name }}</span>
-                    <span class="popular-card__overlay">
-                        {% if city.groomerCount is defined and city.groomerCount is not null %}
-                            {{ city.groomerCount }} groomers
-                        {% else %}
-                            Browse
-                        {% endif %}
-                    </span>
-                </a>
-            </li>
-        {% else %}
-            <li class="popular-card">City coming soon</li>
-        {% endfor %}
-    </ul>
-
+<section id="popular-services">
     <h2>Popular Services</h2>
     <ul class="popular-grid" role="list">
         {% set defaultCity = popularCities|first %}
@@ -46,4 +26,3 @@
         {% endfor %}
     </ul>
 </section>
-

--- a/tests/E2E/Homepage/PopularNavTest.php
+++ b/tests/E2E/Homepage/PopularNavTest.php
@@ -44,7 +44,7 @@ final class PopularNavTest extends WebTestCase
 
         $citySlugs = ['bucharest', 'ruse', 'sofia'];
         foreach ($citySlugs as $slug) {
-            $link = sprintf('#popular a[href="/cities/%s"]', $slug);
+            $link = sprintf('.popular-cities__link[href="/cities/%s"]', $slug);
             self::assertSame(1, $crawler->filter($link)->count());
         }
 
@@ -57,7 +57,7 @@ final class PopularNavTest extends WebTestCase
         $serviceSlugs = ['dog', 'cat', 'mobile'];
         foreach ($serviceSlugs as $serviceSlug) {
             $href = sprintf('/groomers/%s/%s', $firstCity, $serviceSlug);
-            self::assertSame(1, $crawler->filter(sprintf('#popular a[href="%s"]', $href))->count());
+            self::assertSame(1, $crawler->filter(sprintf('#popular-services a[href="%s"]', $href))->count());
         }
 
         foreach ($serviceSlugs as $serviceSlug) {
@@ -66,8 +66,8 @@ final class PopularNavTest extends WebTestCase
             self::assertResponseIsSuccessful();
         }
 
-        $cssPath = static::getContainer()->getParameter('kernel.project_dir').'/assets/styles/home.css';
+        $cssPath = static::getContainer()->getParameter('kernel.project_dir').'/public/css/sections/popular-cities.css';
         $css = file_get_contents($cssPath);
-        self::assertStringContainsString('.popular-card:focus', $css);
+        self::assertStringContainsString('.popular-cities__link:focus', $css);
     }
 }

--- a/tests/Frontend/E2E/popular-cities.e2e.md
+++ b/tests/Frontend/E2E/popular-cities.e2e.md
@@ -1,0 +1,10 @@
+# Popular Cities Section E2E
+
+1. Visit the home page.
+2. Scroll to the "Popular Cities" section.
+3. Verify the grid displays two columns on small screens, three on tablets, and up to four on desktop.
+4. Each city appears as a pill link with an avatar and city name.
+5. Hover and keyboard focus on a link to confirm a visible state change.
+6. Inspect a link and confirm its accessible name reads "Groomers in {City}".
+7. Confirm a city with a long name wraps within the pill without overflow.
+8. On mobile, run Lighthouse and ensure tap targets pass accessibility checks.

--- a/tests/Frontend/Unit/PopularCitiesMarkupTest.html
+++ b/tests/Frontend/Unit/PopularCitiesMarkupTest.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Popular Cities Markup Test</title>
+    <script>
+        window.addEventListener('DOMContentLoaded', function () {
+            const link = document.querySelector('.popular-cities__link');
+            console.assert(link && link.getAttribute('aria-label') === 'Groomers in Springfield', 'accessible link name');
+            const avatar = link.querySelector('.popular-cities__avatar');
+            console.assert(avatar, 'avatar element present');
+            const name = link.querySelector('.popular-cities__name');
+            console.assert(name && name.textContent.trim() === 'Springfield', 'name displayed');
+            console.log('Popular cities markup tests passed');
+        });
+    </script>
+</head>
+<body>
+<section class="popular-cities">
+    <ul class="popular-cities__grid" role="list">
+        <li class="popular-cities__item">
+            <a class="popular-cities__link" href="/city/springfield" aria-label="Groomers in Springfield">
+                <span class="popular-cities__avatar" aria-hidden="true">S</span>
+                <span class="popular-cities__name">Springfield</span>
+            </a>
+        </li>
+    </ul>
+</section>
+</body>
+</html>

--- a/tests/Integration/HomepagePopularSectionTest.php
+++ b/tests/Integration/HomepagePopularSectionTest.php
@@ -43,12 +43,12 @@ final class HomepagePopularSectionTest extends WebTestCase
         self::assertResponseIsSuccessful();
 
         foreach (['bucharest', 'ruse', 'sofia'] as $slug) {
-            self::assertSelectorExists(sprintf('#popular a[href="/cities/%s"]', $slug));
+            self::assertSelectorExists(sprintf('.popular-cities__link[href="/cities/%s"]', $slug));
         }
 
         $firstCitySlug = 'bucharest';
         foreach (['dog', 'cat', 'mobile'] as $serviceSlug) {
-            self::assertSelectorExists(sprintf('#popular a[href="/groomers/%s/%s"]', $firstCitySlug, $serviceSlug));
+            self::assertSelectorExists(sprintf('#popular-services a[href="/groomers/%s/%s"]', $firstCitySlug, $serviceSlug));
         }
     }
 }


### PR DESCRIPTION
## Summary
- redesign popular cities into responsive pill grid with avatar fallback and accessible links
- style pills for hover/focus states and responsive layout
- update homepage and tests to reflect new popular cities section

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*
- `composer lint:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689f7da62ce48322aa69cf3adebd5c81