### PR TITLE
feat: highlight grooming in popular services

### DIFF
--- a/public/css/sections/popular-services.css
+++ b/public/css/sections/popular-services.css
@@ -1,0 +1,46 @@
+.popular-services {
+    padding: var(--space-4) 0;
+}
+
+.popular-services__spotlight {
+    display: block;
+    text-decoration: none;
+    background-color: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: var(--radius-lg, 0.5rem);
+    padding: var(--space-4);
+    text-align: center;
+    color: inherit;
+}
+
+.popular-services__spotlight:hover,
+.popular-services__spotlight:focus {
+    border-color: var(--color-accent, #2563eb);
+    box-shadow: 0 0 0 2px var(--color-accent, #2563eb);
+}
+
+.popular-services__spotlight:focus {
+    outline: none;
+}
+
+.popular-services__title {
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.popular-services__subservices {
+    list-style: none;
+    margin: var(--space-3) 0 0;
+    padding: 0;
+    display: flex;
+    gap: var(--space-2);
+    justify-content: center;
+    flex-wrap: wrap;
+    font-size: 0.875rem;
+}
+
+.popular-services__subservices li {
+    background-color: #f3f4f6;
+    padding: var(--space-1) var(--space-2);
+    border-radius: 9999px;
+}

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="{{ asset('css/sections/hero.css') }}">
     <link rel="stylesheet" href="{{ asset('css/components/card-groomer.css') }}">
     <link rel="stylesheet" href="{{ asset('css/sections/popular-cities.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/sections/popular-services.css') }}">
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/home/partials/_popular_services.html.twig
+++ b/templates/home/partials/_popular_services.html.twig
@@ -1,28 +1,15 @@
-<section id="popular-services">
+{% set defaultCity = popularCities|first %}
+{% set activeGrooming = popularServices|filter(s => s.slug == 'grooming')|first %}
+{% if defaultCity and activeGrooming and (activeGrooming.active|default(true)) %}
+<section id="popular-services" class="popular-services">
     <h2>Popular Services</h2>
-    <ul class="popular-grid" role="list">
-        {% set defaultCity = popularCities|first %}
-        {% for service in popularServices %}
-            {% if defaultCity %}
-                <li class="popular-card">
-                    <a href="{{ path('app_groomer_list_by_city_service', {citySlug: defaultCity.slug, serviceSlug: service.slug}) }}">
-                        <span class="popular-card__title">{{ service.name }}</span>
-                        <span class="popular-card__overlay">
-                            {% if service.groomerCount is defined and service.groomerCount is not null %}
-                                {{ service.groomerCount }} groomers
-                            {% else %}
-                                Browse
-                            {% endif %}
-                        </span>
-                    </a>
-                </li>
-            {% else %}
-                <li class="popular-card">
-                    <span class="popular-card__title">{{ service.name }}</span>
-                </li>
-            {% endif %}
-        {% else %}
-            <li class="popular-card">Service coming soon</li>
-        {% endfor %}
-    </ul>
+    <a class="popular-services__spotlight" href="{{ path('app_groomer_list_by_city_service', {citySlug: defaultCity.slug, serviceSlug: activeGrooming.slug}) }}">
+        <span class="popular-services__title">{{ activeGrooming.name }}</span>
+        <ul class="popular-services__subservices" role="list">
+            <li>Full groom</li>
+            <li>Bath &amp; brush</li>
+            <li>Nail trim</li>
+        </ul>
+    </a>
 </section>
+{% endif %}

--- a/tests/E2E/Homepage/PopularNavTest.php
+++ b/tests/E2E/Homepage/PopularNavTest.php
@@ -32,10 +32,8 @@ final class PopularNavTest extends WebTestCase
             $this->em->persist($city);
         }
 
-        foreach (['Dog', 'Cat', 'Mobile'] as $name) {
-            $service = (new Service())->setName($name);
-            $this->em->persist($service);
-        }
+        $service = (new Service())->setName('Grooming');
+        $this->em->persist($service);
 
         $this->em->flush();
 
@@ -54,20 +52,14 @@ final class PopularNavTest extends WebTestCase
         }
 
         $firstCity = 'bucharest';
-        $serviceSlugs = ['dog', 'cat', 'mobile'];
-        foreach ($serviceSlugs as $serviceSlug) {
-            $href = sprintf('/groomers/%s/%s', $firstCity, $serviceSlug);
-            self::assertSame(1, $crawler->filter(sprintf('#popular-services a[href="%s"]', $href))->count());
-        }
+        $href = sprintf('/groomers/%s/grooming', $firstCity);
+        self::assertSame(1, $crawler->filter(sprintf('#popular-services a[href="%s"]', $href))->count());
 
-        foreach ($serviceSlugs as $serviceSlug) {
-            $href = sprintf('/groomers/%s/%s', $firstCity, $serviceSlug);
-            $this->client->request('GET', $href);
-            self::assertResponseIsSuccessful();
-        }
+        $this->client->request('GET', $href);
+        self::assertResponseIsSuccessful();
 
-        $cssPath = static::getContainer()->getParameter('kernel.project_dir').'/public/css/sections/popular-cities.css';
+        $cssPath = static::getContainer()->getParameter('kernel.project_dir').'/public/css/sections/popular-services.css';
         $css = file_get_contents($cssPath);
-        self::assertStringContainsString('.popular-cities__link:focus', $css);
+        self::assertStringContainsString('.popular-services__spotlight:focus', $css);
     }
 }

--- a/tests/Frontend/E2E/popular-services.e2e.md
+++ b/tests/Frontend/E2E/popular-services.e2e.md
@@ -1,0 +1,8 @@
+# Popular Services Section E2E
+
+1. Visit the home page.
+2. Scroll to the "Popular Services" section.
+3. Confirm only a single tile appears titled "Grooming".
+4. Ensure no text on the page mentions "Boarding".
+5. Click the tile and verify it navigates to `/groomers/{city}/grooming`.
+6. Confirm the tile lists sub-services for information only: "Full groom", "Bath & brush", and "Nail trim".

--- a/tests/Frontend/Unit/PopularServicesVisibilityTest.html
+++ b/tests/Frontend/Unit/PopularServicesVisibilityTest.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Popular Services Visibility Test</title>
+    <script>
+        window.addEventListener('DOMContentLoaded', function () {
+            const bodyText = document.body.textContent;
+            console.assert(!bodyText.includes('Boarding'), 'boarding text not present');
+            const link = document.querySelector('.popular-services__spotlight');
+            console.assert(link && link.getAttribute('href') === '/groomers/springfield/grooming', 'links to grooming listings');
+            const subservices = link.querySelectorAll('.popular-services__subservices li');
+            console.assert(subservices.length === 3, 'three subservices listed');
+            console.log('Popular services visibility tests passed');
+        });
+    </script>
+</head>
+<body>
+<section id="popular-services" class="popular-services">
+    <h2>Popular Services</h2>
+    <a class="popular-services__spotlight" href="/groomers/springfield/grooming">
+        <span class="popular-services__title">Grooming</span>
+        <ul class="popular-services__subservices" role="list">
+            <li>Full groom</li>
+            <li>Bath &amp; brush</li>
+            <li>Nail trim</li>
+        </ul>
+    </a>
+</section>
+</body>
+</html>

--- a/tests/Integration/HomepagePopularSectionTest.php
+++ b/tests/Integration/HomepagePopularSectionTest.php
@@ -32,10 +32,8 @@ final class HomepagePopularSectionTest extends WebTestCase
             $this->em->persist($city);
         }
 
-        foreach (['Dog', 'Cat', 'Mobile'] as $name) {
-            $service = (new Service())->setName($name);
-            $this->em->persist($service);
-        }
+        $service = (new Service())->setName('Grooming');
+        $this->em->persist($service);
 
         $this->em->flush();
 
@@ -47,8 +45,7 @@ final class HomepagePopularSectionTest extends WebTestCase
         }
 
         $firstCitySlug = 'bucharest';
-        foreach (['dog', 'cat', 'mobile'] as $serviceSlug) {
-            self::assertSelectorExists(sprintf('#popular-services a[href="/groomers/%s/%s"]', $firstCitySlug, $serviceSlug));
-        }
+        self::assertSelectorExists(sprintf('#popular-services a[href="/groomers/%s/grooming"]', $firstCitySlug));
+        self::assertSelectorNotExists('#popular-services a[href*="boarding"]');
     }
 }


### PR DESCRIPTION
## Summary
- spotlight grooming on home page with informative sub-services
- add styling and tests for grooming-only popular services section
- update integration tests to reflect single-service design

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*
- `composer lint:php`
- `composer stan`
- `composer test`
- `php -d memory_limit=-1 ./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689f803654b88322869ef9226b20366c