### PR TITLE
feat: redesign footer with legal and utility navigation

### DIFF
--- a/src/public/css/components/footer.css
+++ b/src/public/css/components/footer.css
@@ -1,0 +1,66 @@
+.site-footer {
+    background: var(--color-neutral);
+    color: var(--color-text);
+    padding: var(--space-4) var(--space-3);
+}
+
+.site-footer a {
+    color: var(--color-text);
+    text-decoration: none;
+}
+
+.site-footer a:hover,
+.site-footer a:focus {
+    text-decoration: underline;
+}
+
+.footer-top {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+}
+
+.footer-brand .footer-logo {
+    font-weight: 700;
+    font-size: 1.25rem;
+}
+
+.footer-brand p {
+    margin: var(--space-1) 0 0;
+}
+
+.footer-nav ul,
+.footer-legal ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.footer-bottom {
+    margin-top: var(--space-4);
+    border-top: 1px solid var(--color-pastel);
+    padding-top: var(--space-2);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.back-to-top {
+    align-self: flex-start;
+}
+
+@media (min-width: 768px) {
+    .footer-top {
+        flex-direction: row;
+        justify-content: space-between;
+    }
+
+    .footer-bottom {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -13,6 +13,7 @@
             <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;600;700&display=swap" rel="stylesheet">
             <link rel="stylesheet" href="{{ asset('styles/accessibility.css') }}">
             <link rel="stylesheet" href="{{ asset('css/components/header.css') }}">
+            <link rel="stylesheet" href="{{ asset('css/components/footer.css') }}">
         {% endblock %}
 
         {% block javascripts %}
@@ -20,49 +21,13 @@
             <script src="{{ asset('js/nav-toggle.js') }}" defer></script>
         {% endblock %}
     </head>
-    <body data-route="{{ app.request.attributes.get('_route') }}">
+    <body id="top" data-route="{{ app.request.attributes.get('_route') }}">
         <a href="#main-content" class="skip-link">Skip to main content</a>
         {% include 'partials/_header.html.twig' %}
         <main id="main-content" tabindex="-1">
             {% block body %}{% endblock %}
         </main>
 
-        <footer class="site-footer">
-            <nav class="footer-nav">
-                <ul>
-                    <li><a href="#about">About</a></li>
-                    <li><a href="#contact">Contact</a></li>
-                    <li><a href="#faq">FAQ</a></li>
-                    <li><a href="#blog">Blog</a></li>
-                    <li><a href="#terms">Terms</a></li>
-                    <li><a href="#privacy">Privacy</a></li>
-                </ul>
-            </nav>
-            <div class="footer-social">
-                <a href="#facebook">Facebook</a>
-                <a href="#instagram">Instagram</a>
-            </div>
-            <div class="footer-locale">
-                <span>Language</span> | <span>Currency</span>
-            </div>
-            <div class="footer-links">
-                <div class="footer-cities">
-                    <h4>Cities</h4>
-                    <ul>
-                        {% for city in footerCities|default([])|slice(0, 5) %}
-                            <li><a href="{{ path('app_city_show', {slug: city.slug}) }}">{{ city.name }}</a></li>
-                        {% endfor %}
-                    </ul>
-                </div>
-                <div class="footer-services">
-                    <h4>Services</h4>
-                    <ul>
-                        {% for service in footerServices|default([])|slice(0, 5) %}
-                            <li><a href="#">{{ service.name }}</a></li>
-                        {% endfor %}
-                    </ul>
-                </div>
-            </div>
-        </footer>
+        {% include 'partials/_footer.html.twig' %}
     </body>
 </html>

--- a/templates/partials/_footer.html.twig
+++ b/templates/partials/_footer.html.twig
@@ -1,0 +1,26 @@
+<footer class="site-footer">
+  <div class="footer-top">
+    <div class="footer-brand">
+      <a href="{{ path('app_homepage') }}" class="footer-logo">CleanWhiskers</a>
+      <p class="footer-tagline">Find trusted pet care near you.</p>
+    </div>
+    <nav class="footer-nav" aria-label="Footer">
+      <ul>
+        <li><a href="#about">About</a></li>
+        <li><a href="#contact">Contact</a></li>
+        <li><a href="#faq">FAQ</a></li>
+        <li><a href="{{ path('app_blog_index') }}">Blog</a></li>
+      </ul>
+    </nav>
+    <nav class="footer-legal" aria-label="Legal">
+      <ul>
+        <li><a href="#terms">Terms</a></li>
+        <li><a href="#privacy">Privacy</a></li>
+      </ul>
+    </nav>
+  </div>
+  <div class="footer-bottom">
+    <a href="#top" class="back-to-top">Back to top</a>
+    <p>&copy; {{ 'now'|date('Y') }} CleanWhiskers</p>
+  </div>
+</footer>

--- a/tests/Integration/CitySeoIntroRenderTest.php
+++ b/tests/Integration/CitySeoIntroRenderTest.php
@@ -35,7 +35,7 @@ final class CitySeoIntroRenderTest extends WebTestCase
         self::assertResponseIsSuccessful();
         $content = $this->client->getResponse()->getContent();
         $this->assertStringContainsString('Amazing place for pets.', $content);
-        $this->assertSame(2, substr_count($content, '<p>'));
+        $this->assertSame(3, substr_count($content, '<p>'));
     }
 
     public function testNoSeoIntroRendersNothing(): void
@@ -48,6 +48,6 @@ final class CitySeoIntroRenderTest extends WebTestCase
         $this->client->request('GET', '/cities/'.$city->getSlug());
         self::assertResponseIsSuccessful();
         $content = $this->client->getResponse()->getContent();
-        $this->assertSame(1, substr_count($content, '<p>'));
+        $this->assertSame(2, substr_count($content, '<p>'));
     }
 }

--- a/tests/Integration/FooterLinksRenderTest.php
+++ b/tests/Integration/FooterLinksRenderTest.php
@@ -4,54 +4,28 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration;
 
-use App\Entity\City;
-use App\Entity\Service;
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 final class FooterLinksRenderTest extends WebTestCase
 {
-    private EntityManagerInterface $em;
     private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
 
     protected function setUp(): void
     {
         $this->client = static::createClient();
-        $this->em = static::getContainer()->get('doctrine')->getManager();
-        $schemaTool = new SchemaTool($this->em);
-        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
-        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
     }
 
-    public function testFooterRendersLimitedLinks(): void
+    public function testFooterRendersLinks(): void
     {
-        for ($i = 1; $i <= 7; ++$i) {
-            $city = new City('City '.$i);
-            $city->refreshSlugFrom('City '.$i);
-            $this->em->persist($city);
-        }
-
-        for ($i = 1; $i <= 7; ++$i) {
-            $service = new Service();
-            $service->setName('Service '.$i);
-            $service->refreshSlugFrom('Service '.$i);
-            $this->em->persist($service);
-        }
-
-        $this->em->flush();
-
-        $crawler = $this->client->request('GET', '/');
+        $this->client->request('GET', '/');
 
         self::assertResponseIsSuccessful();
         self::assertSelectorExists('footer .footer-nav a[href="#about"]');
         self::assertSelectorExists('footer .footer-nav a[href="#contact"]');
         self::assertSelectorExists('footer .footer-nav a[href="#faq"]');
-        self::assertSelectorExists('footer .footer-nav a[href="#blog"]');
-        self::assertSelectorExists('footer .footer-nav a[href="#terms"]');
-        self::assertSelectorExists('footer .footer-nav a[href="#privacy"]');
-
-        self::assertSame(5, $crawler->filter('.footer-cities li')->count());
-        self::assertSame(5, $crawler->filter('.footer-services li')->count());
+        self::assertSelectorExists('footer .footer-nav a[href="/blog"]');
+        self::assertSelectorExists('footer .footer-legal a[href="#terms"]');
+        self::assertSelectorExists('footer .footer-legal a[href="#privacy"]');
+        self::assertSelectorExists('footer .back-to-top[href="#top"]');
     }
 }


### PR DESCRIPTION
## Summary
- implement responsive footer partial with brand blurb, utility links, legal links, and back-to-top control
- add footer styles and wire into base template with top anchor
- adjust integration tests for updated footer structure and paragraph counts

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689f826e4f308322ac146d7321a20758