### PR TITLE
Remove dead hero video references

### DIFF
--- a/assets/js/home-hero.js
+++ b/assets/js/home-hero.js
@@ -8,17 +8,4 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    const video = document.getElementById('hero-video');
-    const toggle = document.getElementById('hero-video-toggle');
-    if (video && toggle) {
-        toggle.addEventListener('click', () => {
-            if (video.paused) {
-                video.play();
-                toggle.textContent = 'Pause';
-            } else {
-                video.pause();
-                toggle.textContent = 'Play';
-            }
-        });
-    }
 });

--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -69,11 +69,6 @@
     }
 }
 
-/* Element: video toggle */
-.hero__video-toggle {
-    margin-top: var(--space-2);
-}
-
 /* Block: sticky-search */
 .sticky-search {
     position: fixed;


### PR DESCRIPTION
## Summary
- drop unused hero video toggle styles
- strip hero JS of video controls so no MP4s are requested

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689f84f558ec8322a759d81039c1ac52