### PR TITLE
feat: add blog entities and migrations

### DIFF
--- a/migrations/Version20250815193000.php
+++ b/migrations/Version20250815193000.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250815193000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create blog tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $category = $schema->createTable('blog_category');
+        $category->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $category->addColumn('name', Types::STRING, ['length' => 255]);
+        $category->addColumn('slug', Types::STRING, ['length' => 255]);
+        $category->setPrimaryKey(['id']);
+        $category->addUniqueIndex(['slug']);
+        $category->addIndex(['slug'], 'idx_blog_category_slug');
+
+        $tag = $schema->createTable('blog_tag');
+        $tag->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $tag->addColumn('name', Types::STRING, ['length' => 255]);
+        $tag->addColumn('slug', Types::STRING, ['length' => 255]);
+        $tag->setPrimaryKey(['id']);
+        $tag->addUniqueIndex(['slug']);
+        $tag->addIndex(['slug'], 'idx_blog_tag_slug');
+
+        $post = $schema->createTable('blog_post');
+        $post->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $post->addColumn('category_id', Types::INTEGER);
+        $post->addColumn('title', Types::STRING, ['length' => 255]);
+        $post->addColumn('excerpt', Types::TEXT, ['notnull' => false]);
+        $post->addColumn('content_html', Types::TEXT);
+        $post->addColumn('cover_image_path', Types::STRING, ['length' => 255, 'notnull' => false]);
+        $post->addColumn('is_published', Types::BOOLEAN);
+        $post->addColumn('published_at', Types::DATETIME_IMMUTABLE, ['notnull' => false]);
+        $post->addColumn('updated_at', Types::DATETIME_IMMUTABLE);
+        $post->addColumn('canonical_url', Types::STRING, ['length' => 255, 'notnull' => false]);
+        $post->addColumn('meta_title', Types::STRING, ['length' => 255, 'notnull' => false]);
+        $post->addColumn('meta_description', Types::STRING, ['length' => 255, 'notnull' => false]);
+        $post->addColumn('reading_minutes', Types::SMALLINT, ['notnull' => false]);
+        $post->addColumn('slug', Types::STRING, ['length' => 255]);
+        $post->setPrimaryKey(['id']);
+        $post->addUniqueIndex(['slug']);
+        $post->addIndex(['slug'], 'idx_blog_post_slug');
+        $post->addIndex(['category_id']);
+        $post->addForeignKeyConstraint('blog_category', ['category_id'], ['id']);
+
+        $postTag = $schema->createTable('blog_post_blog_tag');
+        $postTag->addColumn('blog_post_id', Types::INTEGER);
+        $postTag->addColumn('blog_tag_id', Types::INTEGER);
+        $postTag->setPrimaryKey(['blog_post_id', 'blog_tag_id']);
+        $postTag->addIndex(['blog_post_id']);
+        $postTag->addIndex(['blog_tag_id']);
+        $postTag->addForeignKeyConstraint('blog_post', ['blog_post_id'], ['id'], ['onDelete' => 'CASCADE']);
+        $postTag->addForeignKeyConstraint('blog_tag', ['blog_tag_id'], ['id'], ['onDelete' => 'CASCADE']);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable('blog_post_blog_tag');
+        $schema->dropTable('blog_post');
+        $schema->dropTable('blog_tag');
+        $schema->dropTable('blog_category');
+    }
+}

--- a/src/Entity/Blog/BlogCategory.php
+++ b/src/Entity/Blog/BlogCategory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Blog;
+
+use App\Domain\Shared\SluggerTrait;
+use App\Repository\BlogCategoryRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: BlogCategoryRepository::class)]
+#[ORM\Table(name: 'blog_category')]
+#[ORM\Index(name: 'idx_blog_category_slug', fields: ['slug'])]
+class BlogCategory
+{
+    use SluggerTrait;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    /** @phpstan-ignore-next-line */
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Entity/Blog/BlogPost.php
+++ b/src/Entity/Blog/BlogPost.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Blog;
+
+use App\Domain\Shared\SluggerTrait;
+use App\Repository\BlogPostRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: BlogPostRepository::class)]
+#[ORM\Table(name: 'blog_post')]
+#[ORM\Index(name: 'idx_blog_post_slug', fields: ['slug'])]
+class BlogPost
+{
+    use SluggerTrait;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    /** @phpstan-ignore-next-line */
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: BlogCategory::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private BlogCategory $category;
+
+    #[ORM\Column(length: 255)]
+    private string $title;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $excerpt = null;
+
+    #[ORM\Column(name: 'content_html', type: Types::TEXT)]
+    private string $contentHtml;
+
+    #[ORM\Column(name: 'cover_image_path', length: 255, nullable: true)]
+    private ?string $coverImagePath = null;
+
+    #[ORM\Column(name: 'is_published')]
+    private bool $isPublished = false;
+
+    #[ORM\Column(name: 'published_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $publishedAt = null;
+
+    #[ORM\Column(name: 'updated_at', type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $updatedAt;
+
+    #[ORM\Column(name: 'canonical_url', length: 255, nullable: true)]
+    private ?string $canonicalUrl = null;
+
+    #[ORM\Column(name: 'meta_title', length: 255, nullable: true)]
+    private ?string $metaTitle = null;
+
+    #[ORM\Column(name: 'meta_description', length: 255, nullable: true)]
+    private ?string $metaDescription = null;
+
+    #[ORM\Column(name: 'reading_minutes', type: Types::SMALLINT, nullable: true)]
+    private ?int $readingMinutes = null;
+
+    /** @var Collection<int, BlogTag> */
+    #[ORM\ManyToMany(targetEntity: BlogTag::class, inversedBy: 'posts')]
+    #[ORM\JoinTable(name: 'blog_post_blog_tag')]
+    private Collection $tags;
+
+    public function __construct(BlogCategory $category, string $title, string $excerpt, string $contentHtml)
+    {
+        $this->category = $category;
+        $this->title = $title;
+        $this->excerpt = $excerpt;
+        $this->contentHtml = $contentHtml;
+        $this->tags = new ArrayCollection();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCategory(): BlogCategory
+    {
+        return $this->category;
+    }
+
+    public function setCategory(BlogCategory $category): void
+    {
+        $this->category = $category;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getExcerpt(): ?string
+    {
+        return $this->excerpt;
+    }
+
+    public function setExcerpt(?string $excerpt): void
+    {
+        $this->excerpt = $excerpt;
+    }
+
+    public function getContentHtml(): string
+    {
+        return $this->contentHtml;
+    }
+
+    public function setContentHtml(string $contentHtml): void
+    {
+        $this->contentHtml = $contentHtml;
+    }
+
+    public function getCoverImagePath(): ?string
+    {
+        return $this->coverImagePath;
+    }
+
+    public function setCoverImagePath(?string $coverImagePath): void
+    {
+        $this->coverImagePath = $coverImagePath;
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->isPublished;
+    }
+
+    public function setIsPublished(bool $isPublished): void
+    {
+        $this->isPublished = $isPublished;
+    }
+
+    public function getPublishedAt(): ?\DateTimeImmutable
+    {
+        return $this->publishedAt;
+    }
+
+    public function setPublishedAt(?\DateTimeImmutable $publishedAt): void
+    {
+        $this->publishedAt = $publishedAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeImmutable $updatedAt): void
+    {
+        $this->updatedAt = $updatedAt;
+    }
+
+    public function getCanonicalUrl(): ?string
+    {
+        return $this->canonicalUrl;
+    }
+
+    public function setCanonicalUrl(?string $canonicalUrl): void
+    {
+        $this->canonicalUrl = $canonicalUrl;
+    }
+
+    public function getMetaTitle(): ?string
+    {
+        return $this->metaTitle;
+    }
+
+    public function setMetaTitle(?string $metaTitle): void
+    {
+        $this->metaTitle = $metaTitle;
+    }
+
+    public function getMetaDescription(): ?string
+    {
+        return $this->metaDescription;
+    }
+
+    public function setMetaDescription(?string $metaDescription): void
+    {
+        $this->metaDescription = $metaDescription;
+    }
+
+    public function getReadingMinutes(): ?int
+    {
+        return $this->readingMinutes;
+    }
+
+    public function setReadingMinutes(?int $readingMinutes): void
+    {
+        $this->readingMinutes = $readingMinutes;
+    }
+
+    /**
+     * @return Collection<int, BlogTag>
+     */
+    public function getTags(): Collection
+    {
+        return $this->tags;
+    }
+
+    public function addTag(BlogTag $tag): void
+    {
+        if (!$this->tags->contains($tag)) {
+            $this->tags->add($tag);
+            $tag->getPosts()->add($this);
+        }
+    }
+
+    public function removeTag(BlogTag $tag): void
+    {
+        if ($this->tags->removeElement($tag)) {
+            $tag->getPosts()->removeElement($this);
+        }
+    }
+}

--- a/src/Entity/Blog/BlogTag.php
+++ b/src/Entity/Blog/BlogTag.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Blog;
+
+use App\Domain\Shared\SluggerTrait;
+use App\Repository\BlogTagRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: BlogTagRepository::class)]
+#[ORM\Table(name: 'blog_tag')]
+#[ORM\Index(name: 'idx_blog_tag_slug', fields: ['slug'])]
+class BlogTag
+{
+    use SluggerTrait;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    /** @phpstan-ignore-next-line */
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private string $name;
+
+    /** @var Collection<int, BlogPost> */
+    #[ORM\ManyToMany(targetEntity: BlogPost::class, mappedBy: 'tags')]
+    private Collection $posts;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+        $this->posts = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return Collection<int, BlogPost>
+     */
+    public function getPosts(): Collection
+    {
+        return $this->posts;
+    }
+}

--- a/src/Infrastructure/Doctrine/SlugListener.php
+++ b/src/Infrastructure/Doctrine/SlugListener.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace App\Infrastructure\Doctrine;
 
 use App\Domain\Shared\Exception\SlugCollisionException;
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use App\Entity\Blog\BlogTag;
 use App\Entity\City;
 use App\Entity\GroomerProfile;
 use App\Entity\Service;
+use App\Repository\BlogCategoryRepository;
+use App\Repository\BlogPostRepository;
+use App\Repository\BlogTagRepository;
 use App\Repository\CityRepository;
 use App\Repository\GroomerProfileRepository;
 use App\Repository\ServiceRepository;
@@ -21,6 +27,9 @@ class SlugListener
         private readonly CityRepository $cityRepository,
         private readonly ServiceRepository $serviceRepository,
         private readonly GroomerProfileRepository $groomerProfileRepository,
+        private readonly BlogCategoryRepository $blogCategoryRepository,
+        private readonly BlogTagRepository $blogTagRepository,
+        private readonly BlogPostRepository $blogPostRepository,
     ) {
     }
 
@@ -43,6 +52,21 @@ class SlugListener
                 $entity->refreshSlugFrom($entity->getBusinessName());
             }
             $this->ensureGroomerProfileSlugUnique($entity);
+        } elseif ($entity instanceof BlogCategory) {
+            if ('' === $entity->getSlug()) {
+                $entity->refreshSlugFrom($entity->getName());
+            }
+            $this->ensureBlogCategorySlugUnique($entity);
+        } elseif ($entity instanceof BlogTag) {
+            if ('' === $entity->getSlug()) {
+                $entity->refreshSlugFrom($entity->getName());
+            }
+            $this->ensureBlogTagSlugUnique($entity);
+        } elseif ($entity instanceof BlogPost) {
+            if ('' === $entity->getSlug()) {
+                $entity->refreshSlugFrom($entity->getTitle());
+            }
+            $this->ensureBlogPostSlugUnique($entity);
         }
     }
 
@@ -57,6 +81,12 @@ class SlugListener
             $this->handleServiceUpdate($entity, $args, $em);
         } elseif ($entity instanceof GroomerProfile) {
             $this->handleGroomerProfileUpdate($entity, $args, $em);
+        } elseif ($entity instanceof BlogCategory) {
+            $this->handleBlogCategoryUpdate($entity, $args, $em);
+        } elseif ($entity instanceof BlogTag) {
+            $this->handleBlogTagUpdate($entity, $args, $em);
+        } elseif ($entity instanceof BlogPost) {
+            $this->handleBlogPostUpdate($entity, $args, $em);
         }
     }
 
@@ -99,6 +129,45 @@ class SlugListener
         }
     }
 
+    private function handleBlogCategoryUpdate(BlogCategory $category, PreUpdateEventArgs $args, EntityManagerInterface $em): void
+    {
+        $oldSlug = $category->getSlug();
+        if ($args->hasChangedField('name')) {
+            $category->refreshSlugFrom($category->getName());
+            $this->recompute($em, $category, 'slug', $oldSlug, $category->getSlug());
+        }
+
+        if ($oldSlug !== $category->getSlug() || $args->hasChangedField('slug')) {
+            $this->ensureBlogCategorySlugUnique($category);
+        }
+    }
+
+    private function handleBlogTagUpdate(BlogTag $tag, PreUpdateEventArgs $args, EntityManagerInterface $em): void
+    {
+        $oldSlug = $tag->getSlug();
+        if ($args->hasChangedField('name')) {
+            $tag->refreshSlugFrom($tag->getName());
+            $this->recompute($em, $tag, 'slug', $oldSlug, $tag->getSlug());
+        }
+
+        if ($oldSlug !== $tag->getSlug() || $args->hasChangedField('slug')) {
+            $this->ensureBlogTagSlugUnique($tag);
+        }
+    }
+
+    private function handleBlogPostUpdate(BlogPost $post, PreUpdateEventArgs $args, EntityManagerInterface $em): void
+    {
+        $oldSlug = $post->getSlug();
+        if ($args->hasChangedField('title')) {
+            $post->refreshSlugFrom($post->getTitle());
+            $this->recompute($em, $post, 'slug', $oldSlug, $post->getSlug());
+        }
+
+        if ($oldSlug !== $post->getSlug() || $args->hasChangedField('slug')) {
+            $this->ensureBlogPostSlugUnique($post);
+        }
+    }
+
     private function recompute(EntityManagerInterface $em, object $entity, string $field, mixed $oldValue, mixed $newValue): void
     {
         $uow = $em->getUnitOfWork();
@@ -124,6 +193,27 @@ class SlugListener
     {
         if ($this->groomerProfileRepository->existsBySlug($profile->getSlug())) {
             throw new SlugCollisionException('GroomerProfile slug already exists.');
+        }
+    }
+
+    private function ensureBlogCategorySlugUnique(BlogCategory $category): void
+    {
+        if ($this->blogCategoryRepository->existsBySlug($category->getSlug())) {
+            throw new SlugCollisionException('BlogCategory slug already exists.');
+        }
+    }
+
+    private function ensureBlogTagSlugUnique(BlogTag $tag): void
+    {
+        if ($this->blogTagRepository->existsBySlug($tag->getSlug())) {
+            throw new SlugCollisionException('BlogTag slug already exists.');
+        }
+    }
+
+    private function ensureBlogPostSlugUnique(BlogPost $post): void
+    {
+        if ($this->blogPostRepository->existsBySlug($post->getSlug())) {
+            throw new SlugCollisionException('BlogPost slug already exists.');
         }
     }
 }

--- a/src/Repository/BlogCategoryRepository.php
+++ b/src/Repository/BlogCategoryRepository.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Blog\BlogCategory;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<BlogCategory>
+ */
+class BlogCategoryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, BlogCategory::class);
+    }
+
+    public function existsBySlug(string $slug): bool
+    {
+        return null !== $this->createQueryBuilder('c')
+            ->select('1')
+            ->where('c.slug = :slug')
+            ->setParameter('slug', $slug)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/src/Repository/BlogPostRepository.php
+++ b/src/Repository/BlogPostRepository.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use App\Entity\Blog\BlogTag;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<BlogPost>
+ */
+class BlogPostRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, BlogPost::class);
+    }
+
+    public function existsBySlug(string $slug): bool
+    {
+        return null !== $this->createQueryBuilder('p')
+            ->select('1')
+            ->where('p.slug = :slug')
+            ->setParameter('slug', $slug)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
+     * @return BlogPost[]
+     */
+    public function findPublished(): array
+    {
+        /** @var BlogPost[] $result */
+        $result = $this->basePublishedQueryBuilder()
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
+
+    /**
+     * @return BlogPost[]
+     */
+    public function findPublishedByCategory(BlogCategory $category): array
+    {
+        /** @var BlogPost[] $result */
+        $result = $this->basePublishedQueryBuilder()
+            ->andWhere('p.category = :category')
+            ->setParameter('category', $category)
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
+
+    /**
+     * @return BlogPost[]
+     */
+    public function findPublishedByTag(BlogTag $tag): array
+    {
+        /** @var BlogPost[] $result */
+        $result = $this->basePublishedQueryBuilder()
+            ->join('p.tags', 't')
+            ->andWhere('t = :tag')
+            ->setParameter('tag', $tag)
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
+
+    private function basePublishedQueryBuilder(): QueryBuilder
+    {
+        return $this->createQueryBuilder('p')
+            ->andWhere('p.isPublished = 1')
+            ->andWhere('p.publishedAt <= :now')
+            ->setParameter('now', new \DateTimeImmutable())
+            ->orderBy('p.publishedAt', 'DESC');
+    }
+}

--- a/src/Repository/BlogTagRepository.php
+++ b/src/Repository/BlogTagRepository.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Blog\BlogTag;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<BlogTag>
+ */
+class BlogTagRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, BlogTag::class);
+    }
+
+    public function existsBySlug(string $slug): bool
+    {
+        return null !== $this->createQueryBuilder('t')
+            ->select('1')
+            ->where('t.slug = :slug')
+            ->setParameter('slug', $slug)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/tests/Functional/Repository/BlogPostRepositoryTest.php
+++ b/tests/Functional/Repository/BlogPostRepositoryTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Repository;
+
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use App\Entity\Blog\BlogTag;
+use App\Repository\BlogPostRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class BlogPostRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private BlogPostRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $this->repository = $this->em->getRepository(BlogPost::class);
+    }
+
+    public function testFindPublishedExcludesDraftsAndFuture(): void
+    {
+        $category = new BlogCategory('General');
+        $post1 = new BlogPost($category, 'Published', 'Ex', '<p>Published</p>');
+        $post1->setIsPublished(true);
+        $post1->setPublishedAt(new \DateTimeImmutable('-1 day'));
+
+        $post2 = new BlogPost($category, 'Draft', 'Ex', '<p>Draft</p>');
+        $post2->setIsPublished(false);
+        $post2->setPublishedAt(new \DateTimeImmutable('-1 day'));
+
+        $post3 = new BlogPost($category, 'Future', 'Ex', '<p>Future</p>');
+        $post3->setIsPublished(true);
+        $post3->setPublishedAt(new \DateTimeImmutable('+1 day'));
+
+        $this->em->persist($category);
+        $this->em->persist($post1);
+        $this->em->persist($post2);
+        $this->em->persist($post3);
+        $this->em->flush();
+        $this->em->clear();
+
+        $result = $this->repository->findPublished();
+        self::assertCount(1, $result);
+        self::assertSame('Published', $result[0]->getTitle());
+    }
+
+    public function testFindByCategory(): void
+    {
+        $catA = new BlogCategory('CatA');
+        $catB = new BlogCategory('CatB');
+
+        $postA = new BlogPost($catA, 'PostA', 'Ex', '<p>A</p>');
+        $postA->setIsPublished(true);
+        $postA->setPublishedAt(new \DateTimeImmutable('-1 day'));
+
+        $postB = new BlogPost($catB, 'PostB', 'Ex', '<p>B</p>');
+        $postB->setIsPublished(true);
+        $postB->setPublishedAt(new \DateTimeImmutable('-1 day'));
+
+        $this->em->persist($catA);
+        $this->em->persist($catB);
+        $this->em->persist($postA);
+        $this->em->persist($postB);
+        $this->em->flush();
+        $this->em->clear();
+
+        $catA = $this->em->getRepository(BlogCategory::class)->findOneBy(['name' => 'CatA']);
+        $result = $this->repository->findPublishedByCategory($catA);
+        self::assertCount(1, $result);
+        self::assertSame('PostA', $result[0]->getTitle());
+    }
+
+    public function testFindByTag(): void
+    {
+        $category = new BlogCategory('Cat');
+        $tagA = new BlogTag('TagA');
+        $tagB = new BlogTag('TagB');
+
+        $post1 = new BlogPost($category, 'Post1', 'Ex', '<p>1</p>');
+        $post1->setIsPublished(true);
+        $post1->setPublishedAt(new \DateTimeImmutable('-1 day'));
+        $post1->addTag($tagA);
+
+        $post2 = new BlogPost($category, 'Post2', 'Ex', '<p>2</p>');
+        $post2->setIsPublished(true);
+        $post2->setPublishedAt(new \DateTimeImmutable('-1 day'));
+        $post2->addTag($tagB);
+
+        $this->em->persist($category);
+        $this->em->persist($tagA);
+        $this->em->persist($tagB);
+        $this->em->persist($post1);
+        $this->em->persist($post2);
+        $this->em->flush();
+        $this->em->clear();
+
+        $tagA = $this->em->getRepository(BlogTag::class)->findOneBy(['name' => 'TagA']);
+        $result = $this->repository->findPublishedByTag($tagA);
+        self::assertCount(1, $result);
+        self::assertSame('Post1', $result[0]->getTitle());
+    }
+}

--- a/tests/Unit/Entity/BlogPostTest.php
+++ b/tests/Unit/Entity/BlogPostTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use App\Entity\Blog\BlogTag;
+use App\Infrastructure\Doctrine\SlugListener;
+use App\Repository\BlogCategoryRepository;
+use App\Repository\BlogPostRepository;
+use App\Repository\BlogTagRepository;
+use App\Repository\CityRepository;
+use App\Repository\GroomerProfileRepository;
+use App\Repository\ServiceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use PHPUnit\Framework\TestCase;
+
+final class BlogPostTest extends TestCase
+{
+    public function testAccessorsAndSlugGenerated(): void
+    {
+        $category = new BlogCategory('News');
+        $tag = new BlogTag('Updates');
+        $post = new BlogPost($category, 'Hello World', 'Short', '<p>Body</p>');
+        $post->addTag($tag);
+        $post->setCoverImagePath('cover.jpg');
+        $post->setCanonicalUrl('https://example.com');
+        $post->setMetaTitle('Meta');
+        $post->setMetaDescription('Description');
+        $post->setReadingMinutes(5);
+        $post->setIsPublished(true);
+        $now = new \DateTimeImmutable('-1 day');
+        $post->setPublishedAt($now);
+
+        $listener = new SlugListener(
+            $this->createMock(CityRepository::class),
+            $this->createMock(ServiceRepository::class),
+            $this->createMock(GroomerProfileRepository::class),
+            $this->createMock(BlogCategoryRepository::class),
+            $this->createMock(BlogTagRepository::class),
+            $this->createMock(BlogPostRepository::class),
+        );
+        $em = $this->createMock(EntityManagerInterface::class);
+        $listener->prePersist(new PrePersistEventArgs($post, $em));
+
+        self::assertSame('hello-world', $post->getSlug());
+        self::assertSame($category, $post->getCategory());
+        self::assertSame('Hello World', $post->getTitle());
+        self::assertSame('Short', $post->getExcerpt());
+        self::assertSame('<p>Body</p>', $post->getContentHtml());
+        self::assertSame('cover.jpg', $post->getCoverImagePath());
+        self::assertTrue($post->isPublished());
+        self::assertSame($now, $post->getPublishedAt());
+        self::assertSame('https://example.com', $post->getCanonicalUrl());
+        self::assertSame('Meta', $post->getMetaTitle());
+        self::assertSame('Description', $post->getMetaDescription());
+        self::assertSame(5, $post->getReadingMinutes());
+        self::assertCount(1, $post->getTags());
+        self::assertSame($tag, $post->getTags()->first());
+    }
+}

--- a/tests/Unit/Infrastructure/SlugListenerTest.php
+++ b/tests/Unit/Infrastructure/SlugListenerTest.php
@@ -8,6 +8,9 @@ use App\Domain\Shared\Exception\InvalidSlugSourceException;
 use App\Domain\Shared\Exception\SlugCollisionException;
 use App\Entity\City;
 use App\Infrastructure\Doctrine\SlugListener;
+use App\Repository\BlogCategoryRepository;
+use App\Repository\BlogPostRepository;
+use App\Repository\BlogTagRepository;
 use App\Repository\CityRepository;
 use App\Repository\GroomerProfileRepository;
 use App\Repository\ServiceRepository;
@@ -21,6 +24,9 @@ final class SlugListenerTest extends TestCase
     private CityRepository $cityRepository;
     private ServiceRepository $serviceRepository;
     private GroomerProfileRepository $groomerProfileRepository;
+    private BlogCategoryRepository $blogCategoryRepository;
+    private BlogTagRepository $blogTagRepository;
+    private BlogPostRepository $blogPostRepository;
     private SlugListener $listener;
 
     protected function setUp(): void
@@ -28,11 +34,17 @@ final class SlugListenerTest extends TestCase
         $this->cityRepository = $this->createMock(CityRepository::class);
         $this->serviceRepository = $this->createMock(ServiceRepository::class);
         $this->groomerProfileRepository = $this->createMock(GroomerProfileRepository::class);
+        $this->blogCategoryRepository = $this->createMock(BlogCategoryRepository::class);
+        $this->blogTagRepository = $this->createMock(BlogTagRepository::class);
+        $this->blogPostRepository = $this->createMock(BlogPostRepository::class);
 
         $this->listener = new SlugListener(
             $this->cityRepository,
             $this->serviceRepository,
-            $this->groomerProfileRepository
+            $this->groomerProfileRepository,
+            $this->blogCategoryRepository,
+            $this->blogTagRepository,
+            $this->blogPostRepository,
         );
     }
 


### PR DESCRIPTION
## Summary
- scaffold BlogPost, BlogCategory, and BlogTag entities with slug handling and relationships
- add repositories for blog entities with published/category/tag queries
- extend SlugListener and migrations for new blog schema

## Testing
- `DATABASE_URL=sqlite:///%kernel.project_dir%/var/data.db composer fix:php`
- `DATABASE_URL=sqlite:///%kernel.project_dir%/var/data.db composer stan`
- `DATABASE_URL=sqlite:///%kernel.project_dir%/var/data.db APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_689f86e51d408322b5b7e7a6329102f5