### PR TITLE
Modularize homepage into partials with consistent spacing

### DIFF
--- a/public/css/pages/home.css
+++ b/public/css/pages/home.css
@@ -1,0 +1,9 @@
+.home-section {
+    padding: var(--space-5) 0;
+}
+
+.home-section__inner {
+    max-width: 80rem;
+    margin-inline: auto;
+    padding-inline: var(--space-3);
+}

--- a/src/public/css/pages/home.css
+++ b/src/public/css/pages/home.css
@@ -1,0 +1,9 @@
+.home-section {
+    padding: var(--space-5) 0;
+}
+
+.home-section__inner {
+    max-width: 80rem;
+    margin-inline: auto;
+    padding-inline: var(--space-3);
+}

--- a/templates/home/_featured_groomers.html.twig
+++ b/templates/home/_featured_groomers.html.twig
@@ -1,5 +1,6 @@
 {% if featuredGroomers|length %}
-<section id="featured-groomers" class="featured-groomers">
+<section id="featured-groomers" class="featured-groomers home-section">
+    <div class="home-section__inner">
     <h2 class="featured-groomers__title">Featured Groomers</h2>
     <div class="featured-groomers__grid">
         {% for item in featuredGroomers %}
@@ -38,6 +39,7 @@
                 </div>
             </article>
         {% endfor %}
+    </div>
     </div>
 </section>
 {% endif %}

--- a/templates/home/_popular_cities.html.twig
+++ b/templates/home/_popular_cities.html.twig
@@ -1,4 +1,5 @@
-<section class="popular-cities">
+<section id="popular-cities" class="popular-cities home-section">
+    <div class="home-section__inner">
     <h2>Popular Cities</h2>
     <ul class="popular-cities__grid" role="list">
         {% for city in popularCities %}
@@ -18,4 +19,5 @@
             <li class="popular-cities__item">City coming soon</li>
         {% endfor %}
     </ul>
+    </div>
 </section>

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -3,29 +3,23 @@
 {% block stylesheets %}
     {{ parent() }}
     <link rel="stylesheet" href="{{ asset('styles/forms.css') }}">
-    <link rel="stylesheet" href="{{ asset('styles/home.css') }}">
     <link rel="stylesheet" href="{{ asset('css/components/button.css') }}">
     <link rel="stylesheet" href="{{ asset('css/sections/hero.css') }}">
     <link rel="stylesheet" href="{{ asset('css/components/card-groomer.css') }}">
     <link rel="stylesheet" href="{{ asset('css/sections/popular-cities.css') }}">
     <link rel="stylesheet" href="{{ asset('css/sections/popular-services.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/pages/home.css') }}">
 {% endblock %}
 
 {% block javascripts %}
     {{ parent() }}
     <script type="module" src="{{ asset('js/form-enhance.js') }}" defer></script>
-    <script type="module" src="{{ asset('js/sticky-search.js') }}" defer></script>
-    <script type="module" src="{{ asset('js/section-reveal.js') }}" defer></script>
-    <script src="{{ asset('js/cta-button.js') }}" defer></script>
     <script src="{{ asset('js/hero.js') }}" defer></script>
     <script src="{{ asset('js/lazy-images.js') }}" defer></script>
 {% endblock %}
 
 {% block body %}
-    {% include 'home/partials/_sticky_search.html.twig' %}
     {% include 'home/partials/_hero.html.twig' %}
-    {% include 'home/partials/_cta_banner.html.twig' %}
-    {% include 'home/partials/_how_it_works.html.twig' %}
     {% include 'home/_featured_groomers.html.twig' %}
     {% include 'home/_popular_cities.html.twig' %}
     {% include 'home/partials/_popular_services.html.twig' %}

--- a/templates/home/partials/_hero.html.twig
+++ b/templates/home/partials/_hero.html.twig
@@ -1,6 +1,7 @@
-<section class="hero">
-    <div class="hero__card">
-        <div class="hero__content">
+<section id="hero" class="hero home-section">
+    <div class="home-section__inner">
+        <div class="hero__card">
+            <div class="hero__content">
                 <h1>Find trusted pet care</h1>
                 <p class="hero__microcopy">Mobile groomers near you.</p>
                 <a href="{{ ctaLinks.list.url }}" class="hero__cta-link btn btn--accent">{{ ctaLinks.list.label }}</a>
@@ -24,5 +25,6 @@
                 {{ ctaLinks.find.label }}
             </button>
         </form>
+        </div>
     </div>
 </section>

--- a/templates/home/partials/_popular_services.html.twig
+++ b/templates/home/partials/_popular_services.html.twig
@@ -1,7 +1,8 @@
 {% set defaultCity = popularCities|first %}
 {% set activeGrooming = popularServices|filter(s => s.slug == 'grooming')|first %}
 {% if defaultCity and activeGrooming and (activeGrooming.active|default(true)) %}
-<section id="popular-services" class="popular-services">
+<section id="popular-services" class="popular-services home-section">
+    <div class="home-section__inner">
     <h2>Popular Services</h2>
     <a class="popular-services__spotlight" href="{{ path('app_groomer_list_by_city_service', {citySlug: defaultCity.slug, serviceSlug: activeGrooming.slug}) }}">
         <span class="popular-services__title">{{ activeGrooming.name }}</span>
@@ -11,5 +12,6 @@
             <li>Nail trim</li>
         </ul>
     </a>
+    </div>
 </section>
 {% endif %}


### PR DESCRIPTION
## Summary
- Compose homepage using hero, featured groomers, popular cities, and popular services partials
- Add shared home-section styles for uniform spacing and deep-link anchors

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `php -d memory_limit=1G ./vendor/bin/phpunit --testdox` *(fails: 4 failures)*
- `make setup` *(fails: No rule to make target)*
- `make test -k` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_689f89257c808322a5e58cd59f53920f