### PR TITLE
feat: add semantic blog templates

### DIFF
--- a/assets/js/blog.js
+++ b/assets/js/blog.js
@@ -1,0 +1,10 @@
+(function () {
+  document.addEventListener('DOMContentLoaded', function () {
+    var links = document.querySelectorAll('article a[target="_blank"]');
+    links.forEach(function (link) {
+      if (!link.rel.includes('noopener')) {
+        link.rel += (link.rel ? ' ' : '') + 'noopener';
+      }
+    });
+  });
+})();

--- a/assets/styles/blog.css
+++ b/assets/styles/blog.css
@@ -1,0 +1,23 @@
+.blog-header {
+    margin-bottom: var(--space-3);
+}
+
+.post-list {
+    display: grid;
+    gap: var(--space-3);
+}
+
+.post img,
+.blog-article img {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.post header {
+    margin-top: var(--space-2);
+}
+
+.blog-breadcrumb {
+    margin-top: var(--space-4);
+}

--- a/src/Controller/Blog/BlogController.php
+++ b/src/Controller/Blog/BlogController.php
@@ -49,7 +49,7 @@ final class BlogController extends AbstractController
             throw $this->createNotFoundException();
         }
 
-        return $this->render('blog/show.html.twig', [
+        return $this->render('blog/detail.html.twig', [
             'post' => $post,
             'seo_title' => $post->getMetaTitle() ?? $post->getTitle().' – CleanWhiskers',
             'seo_description' => $post->getMetaDescription(),

--- a/src/Controller/Blog/BlogTaxonomyController.php
+++ b/src/Controller/Blog/BlogTaxonomyController.php
@@ -39,7 +39,7 @@ final class BlogTaxonomyController extends AbstractController
         $page = max(1, (int) $request->query->get('page', 1));
         $posts = $this->posts->findByCategorySlug($canonicalSlug, $page, 10);
 
-        return $this->render('blog/index.html.twig', [
+        return $this->render('blog/category.html.twig', [
             'title' => $category->getName(),
             'posts' => $posts,
             'seo_title' => $category->getName().' – CleanWhiskers',
@@ -65,7 +65,7 @@ final class BlogTaxonomyController extends AbstractController
         $page = max(1, (int) $request->query->get('page', 1));
         $posts = $this->posts->findByTagSlug($canonicalSlug, $page, 10);
 
-        return $this->render('blog/index.html.twig', [
+        return $this->render('blog/tag.html.twig', [
             'title' => $tag->getName(),
             'posts' => $posts,
             'seo_title' => $tag->getName().' – CleanWhiskers',

--- a/templates/blog/_post_teaser.html.twig
+++ b/templates/blog/_post_teaser.html.twig
@@ -1,0 +1,16 @@
+<article class="post">
+    {% if post.coverImagePath is defined and post.coverImagePath %}
+        <img src="{{ asset(post.coverImagePath) }}" alt="{{ post.title }}" loading="lazy" width="400" height="225">
+    {% else %}
+        <img src="{{ asset('assets/illustrations/paw.svg') }}" alt="" loading="lazy" width="400" height="225">
+    {% endif %}
+    <header>
+        <h2>
+            <a href="{{ path('app_blog_detail', {year: post.publishedAt|date('Y'), month: post.publishedAt|date('m'), slug: post.slug}) }}">{{ post.title }}</a>
+        </h2>
+        {% if post.publishedAt %}
+            <time datetime="{{ post.publishedAt|date('Y-m-d') }}">{{ post.publishedAt|date('F j, Y') }}</time>
+        {% endif %}
+    </header>
+    <p>{{ post.excerpt }}</p>
+</article>

--- a/templates/blog/category.html.twig
+++ b/templates/blog/category.html.twig
@@ -14,6 +14,9 @@
 <header class="blog-header">
     <h1>{{ title }}</h1>
 </header>
+<nav class="blog-breadcrumb" aria-label="Breadcrumb">
+    <a href="{{ path('app_blog_index') }}">Blog home</a>
+</nav>
 <section class="post-list">
     {% for post in posts %}
         {% include 'blog/_post_teaser.html.twig' with {post: post} %}
@@ -21,5 +24,4 @@
         <p>No posts found.</p>
     {% endfor %}
 </section>
-<nav class="blog-pagination" aria-label="Pagination"></nav>
 {% endblock %}

--- a/templates/blog/detail.html.twig
+++ b/templates/blog/detail.html.twig
@@ -1,0 +1,31 @@
+{% extends 'base.html.twig' %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('styles/blog.css') }}">
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    <script src="{{ asset('js/blog.js') }}" defer></script>
+{% endblock %}
+
+{% block body %}
+<article class="blog-article">
+    <header>
+        <h1>{{ post.title }}</h1>
+        {% if post.publishedAt %}
+            <time datetime="{{ post.publishedAt|date('Y-m-d') }}">{{ post.publishedAt|date('F j, Y') }}</time>
+        {% endif %}
+    </header>
+    {% if post.coverImagePath %}
+        <img src="{{ asset(post.coverImagePath) }}" alt="{{ post.title }}" loading="lazy" width="800" height="450">
+    {% else %}
+        <img src="{{ asset('assets/illustrations/paw.svg') }}" alt="" loading="lazy" width="800" height="450">
+    {% endif %}
+    <section class="content">{{ post.contentHtml|raw }}</section>
+</article>
+<nav class="blog-breadcrumb" aria-label="Breadcrumb">
+    <a href="{{ path('app_blog_index') }}">&larr; Back to blog</a>
+</nav>
+{% endblock %}

--- a/templates/blog/show.html.twig
+++ b/templates/blog/show.html.twig
@@ -1,8 +1,0 @@
-{% extends 'base.html.twig' %}
-
-{% block body %}
-<article>
-    <h1>{{ post.getTitle() }}</h1>
-    <div class="content">{{ post.getContentHtml()|raw }}</div>
-</article>
-{% endblock %}

--- a/templates/blog/tag.html.twig
+++ b/templates/blog/tag.html.twig
@@ -14,6 +14,9 @@
 <header class="blog-header">
     <h1>{{ title }}</h1>
 </header>
+<nav class="blog-breadcrumb" aria-label="Breadcrumb">
+    <a href="{{ path('app_blog_index') }}">Blog home</a>
+</nav>
 <section class="post-list">
     {% for post in posts %}
         {% include 'blog/_post_teaser.html.twig' with {post: post} %}
@@ -21,5 +24,4 @@
         <p>No posts found.</p>
     {% endfor %}
 </section>
-<nav class="blog-pagination" aria-label="Pagination"></nav>
 {% endblock %}

--- a/tests/Functional/Controller/BlogControllerTest.php
+++ b/tests/Functional/Controller/BlogControllerTest.php
@@ -45,9 +45,10 @@ final class BlogControllerTest extends WebTestCase
     {
         $this->createPublishedPost('Hello World');
 
-        $this->client->request('GET', '/blog');
+        $crawler = $this->client->request('GET', '/blog');
         self::assertResponseIsSuccessful();
         self::assertStringContainsString('Hello World', (string) $this->client->getResponse()->getContent());
+        self::assertSame(1, $crawler->filter('article')->count());
     }
 
     public function testDetailShowsPost(): void
@@ -55,9 +56,10 @@ final class BlogControllerTest extends WebTestCase
         $post = $this->createPublishedPost('Detail Post');
         $path = sprintf('/blog/%s/%s/%s', $post->getPublishedAt()->format('Y'), $post->getPublishedAt()->format('m'), $post->getSlug());
 
-        $this->client->request('GET', $path);
+        $crawler = $this->client->request('GET', $path);
         self::assertResponseIsSuccessful();
         self::assertStringContainsString('Detail Post', (string) $this->client->getResponse()->getContent());
+        self::assertSame(1, $crawler->filter('article')->count());
     }
 
     public function testDetailReturns404ForFuturePost(): void

--- a/tests/Integration/BlogControllerTest.php
+++ b/tests/Integration/BlogControllerTest.php
@@ -45,7 +45,7 @@ final class BlogControllerTest extends WebTestCase
         $crawler = $this->client->request('GET', '/blog');
 
         self::assertResponseIsSuccessful();
-        self::assertSame(2, $crawler->filter('li.post')->count());
+        self::assertSame(2, $crawler->filter('article.post')->count());
         self::assertSelectorTextContains('h1', 'Blog');
     }
 
@@ -64,12 +64,13 @@ final class BlogControllerTest extends WebTestCase
         $this->em->flush();
 
         $path = sprintf('/blog/%s/%s/%s', $post->getPublishedAt()->format('Y'), $post->getPublishedAt()->format('m'), $post->getSlug());
-        $this->client->request('GET', $path);
+        $crawler = $this->client->request('GET', $path);
 
         self::assertResponseIsSuccessful();
         self::assertSelectorTextContains('h1', 'Welcome');
         $content = $this->client->getResponse()->getContent();
         self::assertStringContainsString('<title>Custom Title</title>', $content);
         self::assertStringContainsString('<meta name="description" content="Meta desc"', $content);
+        self::assertSame(1, $crawler->filter('article')->count());
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated blog templates and partials with semantic HTML
- style and script blog pages
- cover taxonomy routes and add functional smoke tests

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_689f945a26c4832289f8780ed49b1313