### PR TITLE
feat: sanitize blog content and compute reading time

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -21,6 +21,11 @@ services:
             - { name: doctrine.event_listener, event: prePersist }
             - { name: doctrine.event_listener, event: preUpdate }
 
+    App\Infrastructure\Doctrine\ContentSanitizerListener:
+        tags:
+            - { name: doctrine.event_listener, event: prePersist }
+            - { name: doctrine.event_listener, event: preUpdate }
+
     App\Seed\Seeder:
         public: true
 

--- a/src/Infrastructure/Doctrine/ContentSanitizerListener.php
+++ b/src/Infrastructure/Doctrine/ContentSanitizerListener.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Doctrine;
+
+use App\Entity\Blog\BlogPost;
+use App\Service\ContentSanitizer;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+
+final class ContentSanitizerListener
+{
+    public function __construct(private readonly ContentSanitizer $sanitizer)
+    {
+    }
+
+    public function prePersist(PrePersistEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if ($entity instanceof BlogPost) {
+            $this->sanitizePost($entity);
+        }
+    }
+
+    public function preUpdate(PreUpdateEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if ($entity instanceof BlogPost) {
+            $this->sanitizePost($entity);
+
+            /** @var EntityManagerInterface $em */
+            $em = $args->getObjectManager();
+            $em->getUnitOfWork()->recomputeSingleEntityChangeSet(
+                $em->getClassMetadata(BlogPost::class),
+                $entity,
+            );
+        }
+    }
+
+    private function sanitizePost(BlogPost $post): void
+    {
+        $sanitized = $this->sanitizer->sanitize($post->getContentHtml());
+        $post->setContentHtml($sanitized);
+        $post->setReadingMinutes($this->sanitizer->computeReadingMinutes($sanitized));
+    }
+}

--- a/src/Service/ContentSanitizer.php
+++ b/src/Service/ContentSanitizer.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+final class ContentSanitizer
+{
+    /** @var object|null */
+    private $sanitizer;
+
+    /**
+     * @param array<int,string> $allowedTags
+     */
+    public function __construct(private array $allowedTags = ['p', 'a', 'code', 'pre', 'em', 'strong', 'ul', 'ol', 'li', 'blockquote', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
+    {
+        if (class_exists(\Symfony\Component\HtmlSanitizer\HtmlSanitizer::class)) {
+            $class = \Symfony\Component\HtmlSanitizer\HtmlSanitizer::class;
+            $this->sanitizer = new $class([
+                'allow_safe_elements' => true,
+                'allowed_elements' => $this->allowedTags,
+                'allowed_attributes' => ['href', 'title', 'src', 'alt'],
+            ]);
+        } else {
+            $this->sanitizer = null;
+        }
+    }
+
+    public function sanitize(string $html): string
+    {
+        if (is_object($this->sanitizer) && method_exists($this->sanitizer, 'sanitize')) {
+            return $this->sanitizer->sanitize($html); // @phpstan-ignore-line
+        }
+
+        $allowed = '<'.implode('><', $this->allowedTags).'>';
+        $clean = preg_replace('#<script[^>]*>.*?</script>#is', '', $html) ?? '';
+        $clean = strip_tags($clean, $allowed);
+        $clean = preg_replace('/\son\w+="[^"]*"/i', '', $clean) ?? '';
+        $clean = preg_replace("/\son\w+='[^']*'/i", '', $clean) ?? '';
+
+        return $clean;
+    }
+
+    public function computeReadingMinutes(string $html): int
+    {
+        $text = trim(strip_tags($html));
+        $words = str_word_count($text);
+
+        return max(1, (int) ceil($words / 200));
+    }
+}

--- a/templates/blog/detail.html.twig
+++ b/templates/blog/detail.html.twig
@@ -16,6 +16,9 @@
         <h1>{{ post.title }}</h1>
         {% if post.publishedAt %}
             <time datetime="{{ post.publishedAt|date('Y-m-d') }}">{{ post.publishedAt|date('F j, Y') }}</time>
+            {% if post.readingMinutes %}
+                <span class="reading-minutes">{{ post.readingMinutes }} min read</span>
+            {% endif %}
         {% endif %}
     </header>
     {% if post.coverImagePath %}

--- a/tests/Functional/Controller/BlogContentSanitizationTest.php
+++ b/tests/Functional/Controller/BlogContentSanitizationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class BlogContentSanitizationTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testSanitizedContentRenderedWithoutScripts(): void
+    {
+        $category = new BlogCategory('News');
+        $category->refreshSlugFrom($category->getName());
+        $html = '<p onclick="alert(1)">Hi<script>alert(1)</script><code>echo 1;</code></p>';
+        $post = new BlogPost($category, 'Sanitize', 'Excerpt', $html);
+        $post->refreshSlugFrom($post->getTitle());
+        $post->setIsPublished(true);
+        $post->setPublishedAt(new \DateTimeImmutable('-1 day'));
+        $this->em->persist($category);
+        $this->em->persist($post);
+        $this->em->flush();
+
+        self::assertStringNotContainsString('onclick', $post->getContentHtml());
+        self::assertStringNotContainsString('<script', $post->getContentHtml());
+        self::assertNotNull($post->getReadingMinutes());
+
+        $path = sprintf('/blog/%s/%s/%s', $post->getPublishedAt()->format('Y'), $post->getPublishedAt()->format('m'), $post->getSlug());
+        $crawler = $this->client->request('GET', $path);
+        self::assertResponseIsSuccessful();
+
+        $section = $crawler->filter('section.content')->html();
+        self::assertStringNotContainsString('onclick', $section);
+        self::assertStringNotContainsString('<script', $section);
+        self::assertStringContainsString('<code>echo 1;</code>', $section);
+
+        $content = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('min read', $content);
+    }
+}

--- a/tests/Unit/Service/ContentSanitizerTest.php
+++ b/tests/Unit/Service/ContentSanitizerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\ContentSanitizer;
+use PHPUnit\Framework\TestCase;
+
+final class ContentSanitizerTest extends TestCase
+{
+    public function testSanitizeRemovesScriptsAndAttributes(): void
+    {
+        $sanitizer = new ContentSanitizer();
+        $html = '<p onclick="alert(1)">Hi<script>alert(1)</script></p>';
+        $clean = $sanitizer->sanitize($html);
+
+        self::assertStringNotContainsString('onclick', $clean);
+        self::assertStringNotContainsString('<script', $clean);
+        self::assertSame('<p>Hi</p>', $clean);
+    }
+
+    public function testSanitizePreservesCodeBlocks(): void
+    {
+        $sanitizer = new ContentSanitizer();
+        $html = '<code>alert(1);</code>';
+        $clean = $sanitizer->sanitize($html);
+
+        self::assertSame('<code>alert(1);</code>', $clean);
+    }
+
+    public function testComputeReadingMinutes(): void
+    {
+        $sanitizer = new ContentSanitizer();
+        $words = str_repeat('word ', 400); // 400 words => 2 minutes
+        $html = '<p>'.$words.'</p>';
+        $minutes = $sanitizer->computeReadingMinutes($html);
+
+        self::assertSame(2, $minutes);
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize blog post HTML server-side and compute reading time
- register doctrine listener to sanitize content and update reading minutes on save
- display reading time in blog detail and test sanitization behavior

## Testing
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689f96c0d2a083228befb2315beec1cd