### PR TITLE
feat: make how-it-works cards clickable

### DIFF
--- a/assets/styles/blocks/how-it-works.css
+++ b/assets/styles/blocks/how-it-works.css
@@ -1,0 +1,38 @@
+/* Block: how-it-works */
+.how-it-works {
+    padding: var(--space-5) var(--space-3);
+    text-align: center;
+}
+
+.how-it-works__cards {
+    display: grid;
+    gap: var(--space-3);
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    margin-top: var(--space-4);
+}
+
+.how-it-works__card {
+    display: block;
+    background-color: var(--color-cream);
+    padding: var(--space-3);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
+    text-decoration: none;
+    color: inherit;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.how-it-works__card img {
+    width: 80px;
+    height: 80px;
+    margin-bottom: var(--space-2);
+    aspect-ratio: 1 / 1;
+}
+
+.how-it-works__card:focus,
+.how-it-works__card:hover {
+    outline: 2px solid var(--color-primary);
+    outline-offset: var(--space-1);
+    transform: scale(1.03);
+    box-shadow: var(--shadow-md);
+}

--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -116,41 +116,6 @@
     }
 }
 
-/* Block: how-it-works */
-.how-it-works {
-    padding: var(--space-5) var(--space-3);
-    text-align: center;
-}
-
-.how-it-works__cards {
-    display: grid;
-    gap: var(--space-3);
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    margin-top: var(--space-4);
-}
-
-.how-it-works__card {
-    background-color: var(--color-cream);
-    padding: var(--space-3);
-    border-radius: var(--radius-md);
-    box-shadow: var(--shadow-sm);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.how-it-works__card img {
-    width: 80px;
-    height: 80px;
-    margin-bottom: var(--space-2);
-    aspect-ratio: 1 / 1;
-}
-
-.how-it-works__card:focus,
-.how-it-works__card:hover {
-    outline: none;
-    transform: scale(1.03);
-    box-shadow: var(--shadow-md);
-}
-
 .reveal-on-scroll {
     opacity: 0;
     transform: translateY(20px);

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -4,6 +4,7 @@
     {{ parent() }}
     <link rel="stylesheet" href="{{ asset('styles/forms.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/blocks/search.css') }}">
+    <link rel="stylesheet" href="{{ asset('styles/blocks/how-it-works.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/home.css') }}">
     <link rel="stylesheet" href="{{ asset('css/components/button.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/blocks/hero.css') }}">

--- a/templates/home/partials/_how_it_works.html.twig
+++ b/templates/home/partials/_how_it_works.html.twig
@@ -1,20 +1,20 @@
 <section id="how-it-works" class="how-it-works reveal-on-scroll">
     <h2>How It Works</h2>
     <div class="how-it-works__cards">
-        <div class="how-it-works__card" tabindex="0">
+        <a href="#search-form" class="how-it-works__card" aria-label="Browse vetted groomers in your area.">
             <img src="{{ asset('assets/illustrations/search.svg') }}" alt="" aria-hidden="true" width="80" height="80" loading="lazy" decoding="async">
             <h3>Search</h3>
-            <p>Find trusted groomers near you.</p>
-        </div>
-        <div class="how-it-works__card" tabindex="0">
+            <p>Browse vetted groomers in your area.</p>
+        </a>
+        <a href="/blog/how-to-book" class="how-it-works__card" aria-label="Choose a time that fits your schedule.">
             <img src="{{ asset('assets/illustrations/calendar.svg') }}" alt="" aria-hidden="true" width="80" height="80" loading="lazy" decoding="async">
             <h3>Book</h3>
-            <p>Choose a time that works.</p>
-        </div>
-        <div class="how-it-works__card" tabindex="0">
+            <p>Choose a time that fits your schedule.</p>
+        </a>
+        <a href="#featured-groomers" class="how-it-works__card" aria-label="Your pet returns fresh, happy, and healthy.">
             <img src="{{ asset('assets/illustrations/paw.svg') }}" alt="" aria-hidden="true" width="80" height="80" loading="lazy" decoding="async">
             <h3>Relax</h3>
-            <p>Your pet leaves fresh and clean.</p>
-        </div>
+            <p>Your pet returns fresh, happy, and healthy.</p>
+        </a>
     </div>
 </section>

--- a/tests/E2E/HeaderNavigationTest.php
+++ b/tests/E2E/HeaderNavigationTest.php
@@ -6,7 +6,7 @@ namespace App\Tests\E2E;
 
 use PHPUnit\Framework\TestCase;
 
-if (!class_exists(\Symfony\Component\Panther\PantherTestCase::class)) {
+if (!class_exists(PantherTestCase::class)) {
     class HeaderNavigationTest extends TestCase
     {
         public function testPantherMissing(): void
@@ -14,6 +14,7 @@ if (!class_exists(\Symfony\Component\Panther\PantherTestCase::class)) {
             $this->markTestSkipped('Panther not installed');
         }
     }
+
     return;
 }
 

--- a/tests/E2E/Homepage/HowItWorksAccessibilityTest.php
+++ b/tests/E2E/Homepage/HowItWorksAccessibilityTest.php
@@ -33,7 +33,8 @@ final class HowItWorksAccessibilityTest extends WebTestCase
         self::assertGreaterThanOrEqual(3, $cards->count());
 
         $cards->each(function (Crawler $card): void {
-            self::assertSame('0', $card->attr('tabindex'));
+            self::assertNotNull($card->attr('href'));
+            self::assertNotNull($card->attr('aria-label'));
         });
 
         $crawler->filter('#how-it-works img')->each(function (Crawler $img): void {

--- a/tests/E2E/Homepage/HowItWorksKeyboardNavigationTest.php
+++ b/tests/E2E/Homepage/HowItWorksKeyboardNavigationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E\Homepage;
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists(PantherTestCase::class)) {
+    class HowItWorksKeyboardNavigationTest extends TestCase
+    {
+        public function testPantherMissing(): void
+        {
+            $this->markTestSkipped('Panther not installed');
+        }
+    }
+
+    return;
+}
+
+use Facebook\WebDriver\WebDriverKeys;
+use Symfony\Component\Panther\PantherTestCase;
+
+final class HowItWorksKeyboardNavigationTest extends PantherTestCase
+{
+    public function testCardsActivateWithKeyboard(): void
+    {
+        $client = self::createPantherClient();
+        $client->request('GET', '/');
+
+        // first card
+        $client->executeScript("document.querySelectorAll('.how-it-works__card')[0].focus();");
+        $client->getWebDriver()->getKeyboard()->pressKey(WebDriverKeys::ENTER);
+        self::assertStringContainsString('#search-form', $client->getCurrentURL());
+
+        // book card
+        $client->back();
+        $client->executeScript("document.querySelectorAll('.how-it-works__card')[1].focus();");
+        $client->getWebDriver()->getKeyboard()->pressKey(WebDriverKeys::ENTER);
+        self::assertStringContainsString('/blog/how-to-book', $client->getCurrentURL());
+
+        // relax card
+        $client->back();
+        $client->executeScript("document.querySelectorAll('.how-it-works__card')[2].focus();");
+        $client->getWebDriver()->getKeyboard()->pressKey(WebDriverKeys::ENTER);
+        self::assertStringContainsString('#featured-groomers', $client->getCurrentURL());
+    }
+}

--- a/tests/Integration/HowItWorksSectionRenderTest.php
+++ b/tests/Integration/HowItWorksSectionRenderTest.php
@@ -11,8 +11,15 @@ final class HowItWorksSectionRenderTest extends WebTestCase
     public function testSectionHeadingsAndStepsRender(): void
     {
         $client = static::createClient();
-        $client->request('GET', '/');
+        $crawler = $client->request('GET', '/');
         self::assertSelectorTextContains('#how-it-works h2', 'How It Works');
-        self::assertSelectorCount(3, '#how-it-works .how-it-works__card');
+        $cards = $crawler->filter('#how-it-works .how-it-works__card');
+        self::assertCount(3, $cards);
+        self::assertSelectorTextContains('#how-it-works .how-it-works__card:nth-of-type(1) p', 'Browse vetted groomers in your area.');
+        self::assertSame('#search-form', $cards->eq(0)->attr('href'));
+        self::assertSelectorTextContains('#how-it-works .how-it-works__card:nth-of-type(2) p', 'Choose a time that fits your schedule.');
+        self::assertSame('/blog/how-to-book', $cards->eq(1)->attr('href'));
+        self::assertSelectorTextContains('#how-it-works .how-it-works__card:nth-of-type(3) p', 'Your pet returns fresh, happy, and healthy.');
+        self::assertSame('#featured-groomers', $cards->eq(2)->attr('href'));
     }
 }

--- a/tests/Unit/Repository/BlogPostRepositoryTest.php
+++ b/tests/Unit/Repository/BlogPostRepositoryTest.php
@@ -7,9 +7,9 @@ namespace App\Tests\Unit\Repository;
 use App\Entity\Blog\BlogPost;
 use App\Repository\Blog\BlogPostRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 
@@ -27,7 +27,7 @@ final class BlogPostRepositoryTest extends TestCase
             ->disableOriginalConstructor()
             ->onlyMethods([
                 'select', 'join', 'andWhere', 'setParameter',
-                'orderBy', 'setFirstResult', 'setMaxResults', 'getQuery'
+                'orderBy', 'setFirstResult', 'setMaxResults', 'getQuery',
             ])
             ->getMock();
         $qb->method('select')->willReturnSelf();


### PR DESCRIPTION
## Summary
- rewrite How It Works cards with benefit-focused copy and wrap each in links
- add standalone block stylesheet with hover/focus outlines
- cover new copy and links with integration, accessibility, and keyboard navigation tests

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d zend.enable_gc=0 -d memory_limit=1G ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_689f9ca713288322b306bf507d2ff761