### PR TITLE
feat: add crawl-friendly blog pagination

### DIFF
--- a/src/Service/SeoMetaBuilder.php
+++ b/src/Service/SeoMetaBuilder.php
@@ -21,7 +21,15 @@ final class SeoMetaBuilder
     }
 
     /**
-     * @param array{title?: string, description?: string, image?: string, canonical_url?: string} $options
+     * @param array{
+     *     title?: string,
+     *     description?: string,
+     *     image?: string,
+     *     canonical_url?: string,
+     *     prev_url?: string,
+     *     next_url?: string,
+     *     robots?: string,
+     * } $options
      *
      * @return array{
      *     title: string,
@@ -36,22 +44,35 @@ final class SeoMetaBuilder
         $image = $options['image'] ?? self::DEFAULT_IMAGE;
         $canonical = $options['canonical_url'] ?? $this->deriveCanonical();
 
+        $meta = [
+            ['name' => 'description', 'content' => $description],
+            ['property' => 'og:title', 'content' => $title],
+            ['property' => 'og:description', 'content' => $description],
+            ['property' => 'og:type', 'content' => 'article'],
+            ['property' => 'og:image', 'content' => $image],
+            ['name' => 'twitter:card', 'content' => 'summary_large_image'],
+            ['name' => 'twitter:title', 'content' => $title],
+            ['name' => 'twitter:description', 'content' => $description],
+            ['name' => 'twitter:image', 'content' => $image],
+        ];
+        if (isset($options['robots'])) {
+            $meta[] = ['name' => 'robots', 'content' => $options['robots']];
+        }
+
+        $links = [
+            ['rel' => 'canonical', 'href' => $canonical],
+        ];
+        if (isset($options['prev_url'])) {
+            $links[] = ['rel' => 'prev', 'href' => $options['prev_url']];
+        }
+        if (isset($options['next_url'])) {
+            $links[] = ['rel' => 'next', 'href' => $options['next_url']];
+        }
+
         return [
             'title' => $title,
-            'meta' => [
-                ['name' => 'description', 'content' => $description],
-                ['property' => 'og:title', 'content' => $title],
-                ['property' => 'og:description', 'content' => $description],
-                ['property' => 'og:type', 'content' => 'article'],
-                ['property' => 'og:image', 'content' => $image],
-                ['name' => 'twitter:card', 'content' => 'summary_large_image'],
-                ['name' => 'twitter:title', 'content' => $title],
-                ['name' => 'twitter:description', 'content' => $description],
-                ['name' => 'twitter:image', 'content' => $image],
-            ],
-            'link' => [
-                ['rel' => 'canonical', 'href' => $canonical],
-            ],
+            'meta' => $meta,
+            'link' => $links,
         ];
     }
 

--- a/templates/blog/index.html.twig
+++ b/templates/blog/index.html.twig
@@ -21,5 +21,12 @@
         <p>No posts found.</p>
     {% endfor %}
 </section>
-<nav class="blog-pagination" aria-label="Pagination"></nav>
+<nav class="blog-pagination" aria-label="Pagination">
+    {% if prev_page %}
+        <a href="{{ path('app_blog_index', prev_page > 1 ? {page: prev_page} : {}) }}" rel="prev">Newer posts</a>
+    {% endif %}
+    {% if next_page %}
+        <a href="{{ path('app_blog_index', {page: next_page}) }}" rel="next">Older posts</a>
+    {% endif %}
+</nav>
 {% endblock %}

--- a/tests/E2E/HeaderNavigationTest.php
+++ b/tests/E2E/HeaderNavigationTest.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Tests\E2E;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Panther\PantherTestCase;
 
-if (!class_exists(\Symfony\Component\Panther\PantherTestCase::class)) {
+if (!class_exists(PantherTestCase::class)) {
     class HeaderNavigationTest extends TestCase
     {
         public function testPantherMissing(): void
@@ -14,12 +15,12 @@ if (!class_exists(\Symfony\Component\Panther\PantherTestCase::class)) {
             $this->markTestSkipped('Panther not installed');
         }
     }
+
     return;
 }
 
 use Facebook\WebDriver\WebDriverDimension;
 use Facebook\WebDriver\WebDriverKeys;
-use Symfony\Component\Panther\PantherTestCase;
 
 final class HeaderNavigationTest extends PantherTestCase
 {

--- a/tests/Unit/Repository/BlogPostRepositoryTest.php
+++ b/tests/Unit/Repository/BlogPostRepositoryTest.php
@@ -7,9 +7,9 @@ namespace App\Tests\Unit\Repository;
 use App\Entity\Blog\BlogPost;
 use App\Repository\Blog\BlogPostRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 
@@ -27,7 +27,7 @@ final class BlogPostRepositoryTest extends TestCase
             ->disableOriginalConstructor()
             ->onlyMethods([
                 'select', 'join', 'andWhere', 'setParameter',
-                'orderBy', 'setFirstResult', 'setMaxResults', 'getQuery'
+                'orderBy', 'setFirstResult', 'setMaxResults', 'getQuery',
             ])
             ->getMock();
         $qb->method('select')->willReturnSelf();

--- a/tests/Unit/Service/SeoMetaBuilderTest.php
+++ b/tests/Unit/Service/SeoMetaBuilderTest.php
@@ -42,4 +42,18 @@ final class SeoMetaBuilderTest extends TestCase
 
         self::assertSame('https://override.example/article', $seo['link'][0]['href']);
     }
+
+    public function testPrevNextAndRobotsOptions(): void
+    {
+        $builder = $this->createBuilder('https://example.com/blog?page=2');
+        $seo = $builder->build([
+            'prev_url' => 'https://example.com/blog?page=1',
+            'next_url' => 'https://example.com/blog?page=3',
+            'robots' => 'noindex,follow',
+        ]);
+
+        self::assertContains(['rel' => 'prev', 'href' => 'https://example.com/blog?page=1'], $seo['link']);
+        self::assertContains(['rel' => 'next', 'href' => 'https://example.com/blog?page=3'], $seo['link']);
+        self::assertContains(['name' => 'robots', 'content' => 'noindex,follow'], $seo['meta']);
+    }
 }


### PR DESCRIPTION
## Summary
- add prev/next link tags and robots control to SeoMetaBuilder
- paginate blog archive with canonical, prev/next, and noindex handling
- test blog pagination metadata

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_689f9d7bb82083229ec033ce1f607b3c