### PR TITLE
feat: enhance featured groomers carousel

### DIFF
--- a/assets/js/carousel.js
+++ b/assets/js/carousel.js
@@ -16,6 +16,33 @@ carousels.forEach((carousel) => {
         track.scrollBy({ left: offset, behavior: 'smooth' });
     }
 
+    let isDragging = false;
+    let startX;
+    let scrollStart;
+
+    track.addEventListener('pointerdown', (e) => {
+        isDragging = true;
+        startX = e.clientX;
+        scrollStart = track.scrollLeft;
+        track.setPointerCapture(e.pointerId);
+    });
+
+    track.addEventListener('pointermove', (e) => {
+        if (!isDragging) {
+            return;
+        }
+        const dx = e.clientX - startX;
+        track.scrollLeft = scrollStart - dx;
+    });
+
+    track.addEventListener('pointerup', () => {
+        isDragging = false;
+    });
+
+    track.addEventListener('pointerleave', () => {
+        isDragging = false;
+    });
+
     prev.addEventListener('click', () => {
         if (track.scrollLeft <= 0) {
             track.scrollTo({ left: track.scrollWidth, behavior: 'smooth' });

--- a/assets/styles/blocks/carousel.css
+++ b/assets/styles/blocks/carousel.css
@@ -1,0 +1,54 @@
+.carousel {
+    position: relative;
+}
+
+.carousel__track {
+    display: flex;
+    gap: var(--space-3);
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scroll-behavior: smooth;
+    padding-bottom: var(--space-2);
+    touch-action: pan-y;
+}
+
+.carousel__track:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: var(--space-1);
+}
+
+.carousel__card {
+    flex: 0 0 80%;
+    max-width: 300px;
+    scroll-snap-align: start;
+}
+
+.carousel__button {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background-color: var(--color-cream);
+    border: 1px solid var(--color-ink);
+    border-radius: var(--radius-md);
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
+.carousel__button--prev {
+    left: 0;
+}
+
+.carousel__button--next {
+    right: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .carousel__track {
+        scroll-behavior: auto;
+    }
+}
+

--- a/assets/styles/blocks/groomer-card.css
+++ b/assets/styles/blocks/groomer-card.css
@@ -1,0 +1,50 @@
+.card-groomer {
+    background-color: var(--color-cream);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.card-groomer__image-wrapper img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.card-groomer__body {
+    padding: var(--space-3);
+}
+
+.card-groomer__rating {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    margin-top: var(--space-1);
+}
+
+.card-groomer__price {
+    font-weight: 600;
+    margin-top: var(--space-1);
+}
+
+.card-groomer__services {
+    list-style: none;
+    display: flex;
+    gap: var(--space-2);
+    padding: 0;
+    margin: var(--space-2) 0;
+}
+
+.card-groomer__service {
+    font-size: 1.25rem;
+}
+
+.card-groomer__cta {
+    margin-top: auto;
+    align-self: flex-start;
+    text-decoration: none;
+    font-weight: 600;
+}
+

--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -1,3 +1,6 @@
+@import "./blocks/carousel.css";
+@import "./blocks/groomer-card.css";
+
 /* Block: hero */
 .hero {
     position: relative;
@@ -125,69 +128,6 @@
 /* Block: featured-groomers carousel */
 #featured-groomers {
     padding: var(--space-5) var(--space-3);
-}
-
-/* Block: carousel */
-.carousel {
-    position: relative;
-}
-
-.carousel__track {
-    display: flex;
-    gap: var(--space-3);
-    overflow-x: auto;
-    scroll-snap-type: x mandatory;
-    scroll-behavior: smooth;
-    padding-bottom: var(--space-2);
-}
-
-.carousel__track:focus {
-    outline: 2px solid var(--color-primary);
-    outline-offset: var(--space-1);
-}
-
-.carousel__card {
-    flex: 0 0 80%;
-    max-width: 300px;
-    scroll-snap-align: start;
-    background-color: var(--color-cream);
-    border-radius: var(--radius-md);
-    box-shadow: var(--shadow-sm);
-    padding: var(--space-3);
-    text-align: center;
-}
-
-.carousel__card img {
-    aspect-ratio: 1 / 1;
-}
-
-.carousel__button {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    background-color: var(--color-cream);
-    border: 1px solid var(--color-ink);
-    border-radius: var(--radius-round);
-    width: 40px;
-    height: 40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-}
-
-.carousel__button--prev {
-    left: 0;
-}
-
-.carousel__button--next {
-    right: 0;
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .carousel__track {
-        scroll-behavior: auto;
-    }
 }
 
 /* Utility: reveal in */

--- a/templates/home/_featured_groomers.html.twig
+++ b/templates/home/_featured_groomers.html.twig
@@ -1,43 +1,103 @@
 {% if featuredGroomers|length %}
-<section id="featured-groomers" class="featured-groomers">
-    <h2 class="featured-groomers__title">Featured Groomers</h2>
-    <div class="featured-groomers__grid">
-        {% for item in featuredGroomers %}
-            {% set g = item.profile %}
-            <article class="card-groomer">
-                <div class="card-groomer__image-wrapper">
-                    <img
-                        src="{{ g.logo|default('https://placehold.co/320x240?text=No+Photo') }}"
-                        alt="{{ g.businessName }} logo"
-                        loading="lazy"
-                        decoding="async"
-                        width="320"
-                        height="240"
-                        data-skeleton
-                    >
+    {% set isCarousel = featuredGroomers|length > 4 %}
+    <section id="featured-groomers" class="featured-groomers">
+        <h2 class="featured-groomers__title">Featured Groomers</h2>
+        {% if isCarousel %}
+            <div class="carousel" data-carousel>
+                <button class="carousel__button carousel__button--prev" data-carousel-prev aria-label="Previous">&#10094;</button>
+                <div class="carousel__track" tabindex="0">
+                    {% for item in featuredGroomers %}
+                        {% set g = item.profile %}
+                        <article class="carousel__card card-groomer">
+                            <div class="card-groomer__image-wrapper">
+                                <img
+                                    src="{{ g.logo|default('https://placehold.co/320x240?text=No+Photo') }}"
+                                    alt="{{ g.businessName }} logo"
+                                    loading="lazy"
+                                    decoding="async"
+                                    width="320"
+                                    height="240"
+                                    data-skeleton
+                                >
+                            </div>
+                            <div class="card-groomer__body">
+                                <h3 class="card-groomer__name">
+                                    <a href="{{ path('app_groomer_show', {slug: g.slug}) }}">{{ g.businessName }}</a>
+                                </h3>
+                                <p class="card-groomer__city">{{ g.city.name }}</p>
+                                <div class="card-groomer__rating" aria-label="Rating {{ item.rating|number_format(1) }} out of 5">
+                                    <span class="card-groomer__stars" style="--rating: {{ item.rating|number_format(1, '.', '') }}" aria-hidden="true"></span>
+                                    <span class="card-groomer__rating-number">{{ item.rating|number_format(1) }}</span>
+                                    <span class="card-groomer__review-count">({{ item.reviewCount }})</span>
+                                </div>
+                                {% if g.priceRange %}
+                                    <p class="card-groomer__price">Starting at {{ g.priceRange }}</p>
+                                {% endif %}
+                                {% set iconMap = {
+                                    'grooming': '✂️',
+                                    'bathing': '🛁',
+                                    'walking': '🐕',
+                                    'training': '🎓'
+                                } %}
+                                {% set tags = g.services|slice(0,3) %}
+                                {% if tags|length %}
+                                    <ul class="card-groomer__services">
+                                        {% for service in tags %}
+                                            {% set icon = iconMap[service.slug]|default('🐾') %}
+                                            <li class="card-groomer__service" aria-label="{{ service.name }}" title="{{ service.name }}">{{ icon }}</li>
+                                        {% endfor %}
+                                    </ul>
+                                {% endif %}
+                                <a class="card-groomer__cta card-groomer__book" href="{{ path('app_groomer_show', {slug: g.slug}) }}#book">Book Now</a>
+                            </div>
+                        </article>
+                    {% endfor %}
                 </div>
-                <div class="card-groomer__body">
-                    <h3 class="card-groomer__name">
-                        <a href="{{ path('app_groomer_show', {slug: g.slug}) }}">{{ g.businessName }}</a>
-                    </h3>
-                    <p class="card-groomer__city">{{ g.city.name }}</p>
-                    <div class="card-groomer__rating" aria-label="Rating {{ item.rating|number_format(1) }} out of 5">
-                        <span class="card-groomer__stars" style="--rating: {{ item.rating|number_format(1, '.', '') }}" aria-hidden="true"></span>
-                        <span class="card-groomer__rating-number">{{ item.rating|number_format(1) }}</span>
-                        <span class="card-groomer__review-count">({{ item.reviewCount }})</span>
-                    </div>
-                    {% set tags = g.services|slice(0,3) %}
-                    {% if tags|length %}
-                        <ul class="card-groomer__services">
-                            {% for service in tags %}
-                                <li>{{ service.name }}</li>
-                            {% endfor %}
-                        </ul>
-                    {% endif %}
-                    <a class="card-groomer__cta" href="{{ path('app_groomer_show', {slug: g.slug}) }}">View profile</a>
-                </div>
-            </article>
-        {% endfor %}
-    </div>
-</section>
+                <button class="carousel__button carousel__button--next" data-carousel-next aria-label="Next">&#10095;</button>
+            </div>
+        {% else %}
+            <div class="featured-groomers__grid">
+                {% for item in featuredGroomers %}
+                    {% set g = item.profile %}
+                    <article class="card-groomer">
+                        <div class="card-groomer__image-wrapper">
+                            <img
+                                src="{{ g.logo|default('https://placehold.co/320x240?text=No+Photo') }}"
+                                alt="{{ g.businessName }} logo"
+                                loading="lazy"
+                                decoding="async"
+                                width="320"
+                                height="240"
+                                data-skeleton
+                            >
+                        </div>
+                        <div class="card-groomer__body">
+                            <h3 class="card-groomer__name">
+                                <a href="{{ path('app_groomer_show', {slug: g.slug}) }}">{{ g.businessName }}</a>
+                            </h3>
+                            <p class="card-groomer__city">{{ g.city.name }}</p>
+                            <div class="card-groomer__rating" aria-label="Rating {{ item.rating|number_format(1) }} out of 5">
+                                <span class="card-groomer__stars" style="--rating: {{ item.rating|number_format(1, '.', '') }}" aria-hidden="true"></span>
+                                <span class="card-groomer__rating-number">{{ item.rating|number_format(1) }}</span>
+                                <span class="card-groomer__review-count">({{ item.reviewCount }})</span>
+                            </div>
+                            {% if g.priceRange %}
+                                <p class="card-groomer__price">Starting at {{ g.priceRange }}</p>
+                            {% endif %}
+                            {% set tags = g.services|slice(0,3) %}
+                            {% if tags|length %}
+                                <ul class="card-groomer__services">
+                                    {% for service in tags %}
+                                        {% set icon = iconMap[service.slug]|default('🐾') %}
+                                        <li class="card-groomer__service" aria-label="{{ service.name }}" title="{{ service.name }}">{{ icon }}</li>
+                                    {% endfor %}
+                                </ul>
+                            {% endif %}
+                            <a class="card-groomer__cta card-groomer__book" href="{{ path('app_groomer_show', {slug: g.slug}) }}#book">Book Now</a>
+                        </div>
+                    </article>
+                {% endfor %}
+            </div>
+        {% endif %}
+    </section>
 {% endif %}

--- a/tests/E2E/FeaturedGroomersCarouselTest.php
+++ b/tests/E2E/FeaturedGroomersCarouselTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E;
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists(PantherTestCase::class)) {
+    class FeaturedGroomersCarouselTest extends TestCase
+    {
+        public function testPantherMissing(): void
+        {
+            $this->markTestSkipped('Panther not installed');
+        }
+    }
+
+    return;
+}
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Review;
+use App\Entity\Service;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Component\Panther\PantherTestCase;
+
+final class FeaturedGroomersCarouselTest extends PantherTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testCarouselButtonsAndBookNow(): void
+    {
+        $city = new City('Sofia');
+        $city->refreshSlugFrom($city->getName());
+        $service = (new Service())->setName('Grooming');
+        $service->refreshSlugFrom($service->getName());
+        $this->em->persist($city);
+        $this->em->persist($service);
+
+        for ($i = 0; $i < 5; ++$i) {
+            $gUser = (new User())
+                ->setEmail(sprintf('g%d@example.com', $i))
+                ->setPassword('hash')
+                ->setRoles([User::ROLE_GROOMER]);
+            $author = (new User())
+                ->setEmail(sprintf('a%d@example.com', $i))
+                ->setPassword('hash');
+            $profile = new GroomerProfile($gUser, $city, 'Groomer '.$i, 'About');
+            $profile->addService($service);
+            $profile->setPriceRange('$10');
+            $this->em->persist($gUser);
+            $this->em->persist($author);
+            $this->em->persist($profile);
+            $this->em->persist(new Review($profile, $author, 5, 'Great'));
+        }
+        $this->em->flush();
+
+        $client = self::createPantherClient();
+        $client->request('GET', '/');
+
+        $initial = $client->executeScript('return document.querySelector(".carousel__track").scrollLeft;');
+        $client->executeScript('document.querySelector("[data-carousel-next]").click();');
+        $afterNext = $client->executeScript('return document.querySelector(".carousel__track").scrollLeft;');
+        self::assertGreaterThan($initial, $afterNext);
+
+        $client->executeScript('document.querySelector("[data-carousel-prev]").click();');
+        $afterPrev = $client->executeScript('return document.querySelector(".carousel__track").scrollLeft;');
+        self::assertEquals($initial, $afterPrev);
+
+        $client->waitForReload(function () use ($client) {
+            $client->executeScript('document.querySelector(".card-groomer__book").click();');
+        });
+
+        $path = parse_url($client->getCurrentURL(), PHP_URL_PATH);
+        self::assertStringStartsWith('/groomers/', (string) $path);
+    }
+}

--- a/tests/Frontend/Unit/CardGroomerMarkupTest.html
+++ b/tests/Frontend/Unit/CardGroomerMarkupTest.html
@@ -14,9 +14,11 @@
             console.assert(name && name.textContent.trim().length > 0, 'name link present');
             const rating = card.querySelector('.card-groomer__rating');
             console.assert(rating && rating.getAttribute('aria-label'), 'rating aria-label present');
+            console.assert(card.querySelector('.card-groomer__review-count'), 'review count present');
+            console.assert(card.querySelector('.card-groomer__price'), 'price present');
             console.assert(card.querySelector('.card-groomer__services li'), 'service tag present');
             const cta = card.querySelector('.card-groomer__cta');
-            console.assert(cta && cta.textContent.includes('View profile'), 'CTA present');
+            console.assert(cta && cta.textContent.includes('Book Now'), 'CTA present');
             console.log('Card groomer markup tests passed');
         });
     </script>
@@ -34,11 +36,13 @@
                 <div class="card-groomer__rating" aria-label="Rating 4.8 out of 5">
                     <span class="card-groomer__stars" style="--rating:4.8" aria-hidden="true"></span>
                     <span class="card-groomer__rating-number">4.8</span>
+                    <span class="card-groomer__review-count">(10)</span>
                 </div>
+                <p class="card-groomer__price">Starting at $20</p>
                 <ul class="card-groomer__services">
-                    <li>Baths</li>
+                    <li aria-label="Baths">🛁</li>
                 </ul>
-                <a class="card-groomer__cta" href="#">View profile</a>
+                <a class="card-groomer__cta" href="#">Book Now</a>
             </div>
         </article>
     </div>

--- a/tests/Integration/FeaturedGroomersCarouselTest.php
+++ b/tests/Integration/FeaturedGroomersCarouselTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Review;
+use App\Entity\Service;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class FeaturedGroomersCarouselTest extends WebTestCase
+{
+    private EntityManagerInterface $em;
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testCarouselMarkupAppearsWhenMoreThanFourGroomers(): void
+    {
+        $city = new City('Sofia');
+        $city->refreshSlugFrom($city->getName());
+        $service = (new Service())->setName('Grooming');
+        $service->refreshSlugFrom($service->getName());
+
+        $this->em->persist($city);
+        $this->em->persist($service);
+
+        for ($i = 0; $i < 5; ++$i) {
+            $gUser = (new User())
+                ->setEmail(sprintf('g%d@example.com', $i))
+                ->setPassword('hash')
+                ->setRoles([User::ROLE_GROOMER]);
+            $author = (new User())
+                ->setEmail(sprintf('a%d@example.com', $i))
+                ->setPassword('hash');
+            $profile = new GroomerProfile($gUser, $city, 'Groomer '.$i, 'About');
+            $profile->setPriceRange('$10');
+            $profile->addService($service);
+            $this->em->persist($gUser);
+            $this->em->persist($author);
+            $this->em->persist($profile);
+            $this->em->persist(new Review($profile, $author, 5, 'Great'));
+        }
+        $this->em->flush();
+
+        $crawler = $this->client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('#featured-groomers [data-carousel]');
+        self::assertCount(5, $crawler->filter('#featured-groomers .carousel__card'));
+        self::assertSelectorExists('#featured-groomers .card-groomer__price');
+        self::assertSelectorTextContains('#featured-groomers .card-groomer__book', 'Book Now');
+    }
+}


### PR DESCRIPTION
## Summary
- show review count, starting price, service icons, and Book Now button on featured groomer cards
- convert featured section to a carousel when more than four items and add swipe support
- style groomer cards and carousel, add tests for carousel markup and navigation

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `make setup` *(fails: No rule to make target)*
- `make test -k` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_689f9f646cdc83228f3accdc90437f4c