### PR TITLE
feat: add sitemap and RSS feed

### DIFF
--- a/src/Controller/RssFeedController.php
+++ b/src/Controller/RssFeedController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Repository\Blog\BlogPostRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Twig\Environment;
+
+final class RssFeedController extends AbstractController
+{
+    public function __construct(private BlogPostRepository $posts, private Environment $twig)
+    {
+    }
+
+    #[Route('/feed.xml', name: 'app_rss_feed', methods: ['GET'])]
+    public function __invoke(): Response
+    {
+        $posts = iterator_to_array($this->posts->findLatestForFeed(50));
+        $lastBuildDate = $posts[0]['updatedAt'] ?? new \DateTimeImmutable();
+
+        $content = $this->twig->render('rss/feed.xml.twig', [
+            'posts' => $posts,
+            'lastBuildDate' => $lastBuildDate,
+        ]);
+
+        return new Response($content, Response::HTTP_OK, ['Content-Type' => 'application/rss+xml; charset=UTF-8']);
+    }
+}

--- a/src/Controller/SitemapController.php
+++ b/src/Controller/SitemapController.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Repository\Blog\BlogCategoryRepository;
+use App\Repository\Blog\BlogPostRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class SitemapController extends AbstractController
+{
+    public function __construct(
+        private BlogPostRepository $posts,
+        private BlogCategoryRepository $categories,
+        private UrlGeneratorInterface $urls,
+    ) {
+    }
+
+    #[Route('/sitemap.xml', name: 'app_sitemap', methods: ['GET'])]
+    public function __invoke(): Response
+    {
+        $content = '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+
+        $staticUrls = [
+            $this->urls->generate('app_homepage', [], UrlGeneratorInterface::ABSOLUTE_URL),
+            $this->urls->generate('app_blog_index', [], UrlGeneratorInterface::ABSOLUTE_URL),
+        ];
+        foreach ($staticUrls as $loc) {
+            $content .= sprintf('<url><loc>%s</loc></url>', htmlspecialchars($loc, ENT_XML1));
+        }
+
+        foreach ($this->categories->findAll() as $category) {
+            $loc = $this->urls->generate('app_blog_category', ['slug' => $category->getSlug()], UrlGeneratorInterface::ABSOLUTE_URL);
+            $content .= sprintf('<url><loc>%s</loc></url>', htmlspecialchars($loc, ENT_XML1));
+        }
+
+        foreach ($this->posts->findAllForSitemap() as $post) {
+            $loc = $this->urls->generate('app_blog_detail', [
+                'year' => $post['publishedAt']->format('Y'),
+                'month' => $post['publishedAt']->format('m'),
+                'slug' => $post['slug'],
+            ], UrlGeneratorInterface::ABSOLUTE_URL);
+            $content .= sprintf('<url><loc>%s</loc><lastmod>%s</lastmod></url>', htmlspecialchars($loc, ENT_XML1), $post['updatedAt']->format('Y-m-d'));
+        }
+
+        $content .= '</urlset>';
+
+        return new Response($content, Response::HTTP_OK, ['Content-Type' => 'application/xml; charset=UTF-8']);
+    }
+}

--- a/src/Repository/Blog/BlogPostRepository.php
+++ b/src/Repository/Blog/BlogPostRepository.php
@@ -101,6 +101,51 @@ class BlogPostRepository extends ServiceEntityRepository
         return $result;
     }
 
+    /**
+     * @return iterable<int, array{slug: string, publishedAt: \DateTimeImmutable, updatedAt: \DateTimeImmutable}>
+     */
+    public function findAllForSitemap(): iterable
+    {
+        /** @var iterable<int, array{slug: string, publishedAt: \DateTimeImmutable, updatedAt: \DateTimeImmutable}> $result */
+        $result = $this->createQueryBuilder('p')
+            ->select('p.slug AS slug', 'p.publishedAt AS publishedAt', 'p.updatedAt AS updatedAt')
+            ->andWhere('p.isPublished = 1')
+            ->andWhere('p.publishedAt <= :now')
+            ->setParameter('now', new \DateTimeImmutable())
+            ->orderBy('p.publishedAt', 'DESC')
+            ->getQuery()
+            ->toIterable();
+
+        return $result;
+    }
+
+    /**
+     * @return iterable<int, array{slug: string, title: string, excerpt: ?string, publishedAt: \DateTimeImmutable, updatedAt: \DateTimeImmutable}>
+     */
+    public function findLatestForFeed(int $limit): iterable
+    {
+        /**
+         * @var iterable<int, array{slug: string, title: string, excerpt: ?string, publishedAt: \DateTimeImmutable, updatedAt: \DateTimeImmutable}> $result
+         */
+        $result = $this->createQueryBuilder('p')
+            ->select(
+                'p.slug AS slug',
+                'p.title AS title',
+                'p.excerpt AS excerpt',
+                'p.publishedAt AS publishedAt',
+                'p.updatedAt AS updatedAt'
+            )
+            ->andWhere('p.isPublished = 1')
+            ->andWhere('p.publishedAt <= :now')
+            ->setParameter('now', new \DateTimeImmutable())
+            ->orderBy('p.publishedAt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->toIterable();
+
+        return $result;
+    }
+
     public function findOnePublishedBySlug(string $slug): ?BlogPost
     {
         /** @var BlogPost|null $result */

--- a/templates/rss/feed.xml.twig
+++ b/templates/rss/feed.xml.twig
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>CleanWhiskers Blog</title>
+    <link>{{ absolute_url(path('app_blog_index')) }}</link>
+    <description>Latest posts from the CleanWhiskers blog</description>
+    <lastBuildDate>{{ lastBuildDate|date('r') }}</lastBuildDate>
+    {% for post in posts %}
+      <item>
+        <title>{{ post.title }}</title>
+        <link>{{ absolute_url(path('app_blog_detail', {
+          year: post.publishedAt|date('Y'),
+          month: post.publishedAt|date('m'),
+          slug: post.slug
+        })) }}</link>
+        <guid>{{ absolute_url(path('app_blog_detail', {
+          year: post.publishedAt|date('Y'),
+          month: post.publishedAt|date('m'),
+          slug: post.slug
+        })) }}</guid>
+        <pubDate>{{ post.publishedAt|date('r') }}</pubDate>
+        {% if post.excerpt %}
+        <description><![CDATA[{{ post.excerpt }}]]></description>
+        {% endif %}
+      </item>
+    {% endfor %}
+  </channel>
+</rss>

--- a/tests/Functional/Controller/RssFeedControllerTest.php
+++ b/tests/Functional/Controller/RssFeedControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class RssFeedControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testFeedReturnsLatestPublishedPosts(): void
+    {
+        gc_enable();
+        $category = new BlogCategory('News');
+        $category->refreshSlugFrom($category->getName());
+        $this->em->persist($category);
+
+        for ($i = 0; $i < 51; ++$i) {
+            $post = new BlogPost($category, 'Post '.$i, 'Excerpt', '<p>Content</p>');
+            $post->refreshSlugFrom($post->getTitle());
+            $post->setIsPublished(true);
+            $post->setPublishedAt(new \DateTimeImmutable(sprintf('-%d days', $i + 1)));
+            $post->setUpdatedAt(new \DateTimeImmutable(sprintf('-%d days', $i + 1)));
+            $this->em->persist($post);
+            $this->em->flush();
+            $this->em->detach($post);
+            unset($post);
+        }
+        $this->em->clear();
+
+        $this->client->request('GET', '/feed.xml');
+        self::assertResponseIsSuccessful();
+        self::assertSame('application/rss+xml; charset=UTF-8', $this->client->getResponse()->headers->get('content-type'));
+
+        $dom = new \DOMDocument();
+        $dom->loadXML((string) $this->client->getResponse()->getContent());
+        $items = $dom->getElementsByTagName('item');
+        self::assertSame(50, $items->length);
+    }
+}

--- a/tests/Functional/Controller/SitemapControllerTest.php
+++ b/tests/Functional/Controller/SitemapControllerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class SitemapControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testSitemapIncludesPublishedPostsAndCategories(): void
+    {
+        $category = new BlogCategory('News');
+        $category->refreshSlugFrom($category->getName());
+
+        $post = new BlogPost($category, 'Published Post', 'Excerpt', '<p>Content</p>');
+        $post->refreshSlugFrom($post->getTitle());
+        $post->setIsPublished(true);
+        $post->setPublishedAt(new \DateTimeImmutable('-1 day'));
+        $post->setUpdatedAt(new \DateTimeImmutable('-1 day'));
+
+        $draft = new BlogPost($category, 'Draft Post', 'Excerpt', '<p>Content</p>');
+        $draft->refreshSlugFrom($draft->getTitle());
+
+        $future = new BlogPost($category, 'Future Post', 'Excerpt', '<p>Content</p>');
+        $future->refreshSlugFrom($future->getTitle());
+        $future->setIsPublished(true);
+        $future->setPublishedAt(new \DateTimeImmutable('+1 day'));
+        $future->setUpdatedAt(new \DateTimeImmutable('+1 day'));
+
+        $this->em->persist($category);
+        $this->em->persist($post);
+        $this->em->persist($draft);
+        $this->em->persist($future);
+        $this->em->flush();
+
+        $this->client->request('GET', '/sitemap.xml');
+        self::assertResponseIsSuccessful();
+        self::assertSame('application/xml; charset=UTF-8', $this->client->getResponse()->headers->get('content-type'));
+
+        $dom = new \DOMDocument();
+        $dom->loadXML((string) $this->client->getResponse()->getContent());
+        $urls = $dom->getElementsByTagName('url');
+        self::assertSame(4, $urls->length);
+    }
+}


### PR DESCRIPTION
## Summary
- add dynamic sitemap with posts, categories, and core pages
- expose RSS feed for latest blog posts
- cover sitemap and feed endpoints with functional tests

## Testing
- `composer lint:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689f9fd1c0c88322bedf07510eabcb26