### PR TITLE
feat: stream sitemap and RSS feed

### DIFF
--- a/src/Controller/RssFeedController.php
+++ b/src/Controller/RssFeedController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Repository\Blog\BlogPostRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Twig\Environment;
 
@@ -19,14 +20,19 @@ final class RssFeedController extends AbstractController
     #[Route('/feed.xml', name: 'app_rss_feed', methods: ['GET'])]
     public function __invoke(): Response
     {
-        $posts = iterator_to_array($this->posts->findLatestForFeed(50));
-        $lastBuildDate = $posts[0]['updatedAt'] ?? new \DateTimeImmutable();
+        $lastPost = iterator_to_array($this->posts->findLatestForFeed(1));
+        $lastBuildDate = $lastPost[0]['updatedAt'] ?? new \DateTimeImmutable();
+        $posts = $this->posts->findLatestForFeed(50);
 
-        $content = $this->twig->render('rss/feed.xml.twig', [
-            'posts' => $posts,
-            'lastBuildDate' => $lastBuildDate,
-        ]);
+        $response = new StreamedResponse(function () use ($posts, $lastBuildDate): void {
+            $this->twig->display('rss/feed.xml.twig', [
+                'posts' => $posts,
+                'lastBuildDate' => $lastBuildDate,
+            ]);
+        });
 
-        return new Response($content, Response::HTTP_OK, ['Content-Type' => 'application/rss+xml; charset=UTF-8']);
+        $response->headers->set('Content-Type', 'application/rss+xml; charset=UTF-8');
+
+        return $response;
     }
 }

--- a/src/Repository/Blog/BlogCategoryRepository.php
+++ b/src/Repository/Blog/BlogCategoryRepository.php
@@ -27,4 +27,19 @@ class BlogCategoryRepository extends ServiceEntityRepository
             ->getQuery()
             ->getOneOrNullResult();
     }
+
+    /**
+     * @return iterable<int, array{slug: string}>
+     */
+    public function findAllSlugs(): iterable
+    {
+        /** @var iterable<int, array{slug: string}> $result */
+        $result = $this->createQueryBuilder('c')
+            ->select('c.slug AS slug')
+            ->orderBy('c.slug', 'ASC')
+            ->getQuery()
+            ->toIterable();
+
+        return $result;
+    }
 }

--- a/tests/Functional/Controller/RssFeedControllerTest.php
+++ b/tests/Functional/Controller/RssFeedControllerTest.php
@@ -49,8 +49,9 @@ final class RssFeedControllerTest extends WebTestCase
         self::assertResponseIsSuccessful();
         self::assertSame('application/rss+xml; charset=UTF-8', $this->client->getResponse()->headers->get('content-type'));
 
+        $content = $this->client->getInternalResponse()->getContent();
         $dom = new \DOMDocument();
-        $dom->loadXML((string) $this->client->getResponse()->getContent());
+        $dom->loadXML($content);
         $items = $dom->getElementsByTagName('item');
         self::assertSame(50, $items->length);
     }

--- a/tests/Functional/Controller/SitemapControllerTest.php
+++ b/tests/Functional/Controller/SitemapControllerTest.php
@@ -55,8 +55,9 @@ final class SitemapControllerTest extends WebTestCase
         self::assertResponseIsSuccessful();
         self::assertSame('application/xml; charset=UTF-8', $this->client->getResponse()->headers->get('content-type'));
 
+        $content = $this->client->getInternalResponse()->getContent();
         $dom = new \DOMDocument();
-        $dom->loadXML((string) $this->client->getResponse()->getContent());
+        $dom->loadXML($content);
         $urls = $dom->getElementsByTagName('url');
         self::assertSame(4, $urls->length);
     }


### PR DESCRIPTION
## Summary
- stream sitemap generation for posts and categories with lastmod timestamps
- stream RSS feed of latest posts
- update functional tests for streamed responses

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a05603d2ec83228a92ca2e427cd0a0