### PR TITLE
feat: streamline sitemap and feed generation

### DIFF
--- a/src/Controller/RssFeedController.php
+++ b/src/Controller/RssFeedController.php
@@ -19,8 +19,13 @@ final class RssFeedController extends AbstractController
     #[Route('/feed.xml', name: 'app_rss_feed', methods: ['GET'])]
     public function __invoke(): Response
     {
+        $lastBuildDate = new \DateTimeImmutable();
+        foreach ($this->posts->findLatestForFeed(1) as $latest) {
+            $lastBuildDate = $latest['updatedAt'];
+            break;
+        }
+
         $posts = iterator_to_array($this->posts->findLatestForFeed(50));
-        $lastBuildDate = $posts[0]['updatedAt'] ?? new \DateTimeImmutable();
 
         $content = $this->twig->render('rss/feed.xml.twig', [
             'posts' => $posts,

--- a/src/Controller/SitemapController.php
+++ b/src/Controller/SitemapController.php
@@ -33,8 +33,8 @@ final class SitemapController extends AbstractController
             $content .= sprintf('<url><loc>%s</loc></url>', htmlspecialchars($loc, ENT_XML1));
         }
 
-        foreach ($this->categories->findAll() as $category) {
-            $loc = $this->urls->generate('app_blog_category', ['slug' => $category->getSlug()], UrlGeneratorInterface::ABSOLUTE_URL);
+        foreach ($this->categories->findAllSlugs() as $category) {
+            $loc = $this->urls->generate('app_blog_category', ['slug' => $category['slug']], UrlGeneratorInterface::ABSOLUTE_URL);
             $content .= sprintf('<url><loc>%s</loc></url>', htmlspecialchars($loc, ENT_XML1));
         }
 

--- a/src/Repository/Blog/BlogCategoryRepository.php
+++ b/src/Repository/Blog/BlogCategoryRepository.php
@@ -27,4 +27,19 @@ class BlogCategoryRepository extends ServiceEntityRepository
             ->getQuery()
             ->getOneOrNullResult();
     }
+
+    /**
+     * @return iterable<int, array{slug: string}>
+     */
+    public function findAllSlugs(): iterable
+    {
+        /** @var iterable<int, array{slug: string}> $result */
+        $result = $this->createQueryBuilder('c')
+            ->select('c.slug AS slug')
+            ->orderBy('c.slug', 'ASC')
+            ->getQuery()
+            ->toIterable();
+
+        return $result;
+    }
 }


### PR DESCRIPTION
## Summary
- streamline sitemap build using slug-only category lookup
- include latest update timestamp when generating RSS feed
- add slug selection helper to blog category repository

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a057c8468c8322bf365e49c235df22