### PR TITLE
feat: redirect outdated blog slugs

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,6 +20,7 @@ services:
         tags:
             - { name: doctrine.event_listener, event: prePersist }
             - { name: doctrine.event_listener, event: preUpdate }
+            - { name: doctrine.event_listener, event: postFlush }
 
     App\Infrastructure\Doctrine\ContentSanitizerListener:
         tags:

--- a/migrations/Version20250810180002.php
+++ b/migrations/Version20250810180002.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250810180002 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add blog_post_slugs table to track historical slugs';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->createTable('blog_post_slugs');
+        $table->addColumn('id', Types::INTEGER, ['autoincrement' => true]);
+        $table->addColumn('post_id', Types::INTEGER);
+        $table->addColumn('slug', Types::STRING, ['length' => 255]);
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['slug'], 'UNIQ_BLOG_POST_SLUGS_SLUG');
+        $table->addIndex(['post_id'], 'IDX_BLOG_POST_SLUGS_POST_ID');
+        $table->addForeignKeyConstraint('blog_post', ['post_id'], ['id'], ['onDelete' => 'CASCADE']);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable('blog_post_slugs');
+    }
+}

--- a/src/Entity/Blog/BlogPostSlugHistory.php
+++ b/src/Entity/Blog/BlogPostSlugHistory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Blog;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'blog_post_slugs')]
+#[ORM\Index(name: 'idx_blog_post_slugs_slug', columns: ['slug'])]
+class BlogPostSlugHistory
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    /** @phpstan-ignore-next-line */
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: BlogPost::class)]
+    #[ORM\JoinColumn(name: 'post_id', nullable: false, onDelete: 'CASCADE')]
+    private BlogPost $post;
+
+    #[ORM\Column(length: 255, unique: true)]
+    private string $slug;
+
+    public function __construct(BlogPost $post, string $slug)
+    {
+        $this->post = $post;
+        $this->slug = $slug;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getPost(): BlogPost
+    {
+        return $this->post;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+}

--- a/src/Repository/Blog/BlogPostSlugHistoryRepository.php
+++ b/src/Repository/Blog/BlogPostSlugHistoryRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository\Blog;
+
+use App\Entity\Blog\BlogPost;
+use App\Entity\Blog\BlogPostSlugHistory;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<BlogPostSlugHistory>
+ */
+class BlogPostSlugHistoryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, BlogPostSlugHistory::class);
+    }
+
+    public function existsBySlug(string $slug): bool
+    {
+        return null !== $this->createQueryBuilder('h')
+            ->select('1')
+            ->where('h.slug = :slug')
+            ->setParameter('slug', $slug)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findPublishedPostBySlug(string $slug): ?BlogPost
+    {
+        /** @var BlogPostSlugHistory|null $history */
+        $history = $this->createQueryBuilder('h')
+            ->join('h.post', 'p')
+            ->addSelect('p')
+            ->andWhere('h.slug = :slug')
+            ->andWhere('p.isPublished = 1')
+            ->andWhere('p.publishedAt <= :now')
+            ->setParameter('slug', $slug)
+            ->setParameter('now', new \DateTimeImmutable())
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $history?->getPost();
+    }
+}

--- a/tests/Functional/Controller/BlogControllerTest.php
+++ b/tests/Functional/Controller/BlogControllerTest.php
@@ -101,4 +101,20 @@ final class BlogControllerTest extends WebTestCase
         $this->client->request('GET', $path);
         self::assertResponseRedirects(sprintf('/blog/%s/%s/%s', $post->getPublishedAt()->format('Y'), $post->getPublishedAt()->format('m'), $post->getSlug()), Response::HTTP_MOVED_PERMANENTLY);
     }
+
+    public function testDetailRedirectsFromHistoricalSlug(): void
+    {
+        $post = $this->createPublishedPost('Original Title');
+        $oldSlug = $post->getSlug();
+        $post->setTitle('Updated Title');
+        $this->em->flush();
+
+        $oldPath = sprintf('/blog/%s/%s/%s', $post->getPublishedAt()->format('Y'), $post->getPublishedAt()->format('m'), $oldSlug);
+        $newPath = sprintf('/blog/%s/%s/%s', $post->getPublishedAt()->format('Y'), $post->getPublishedAt()->format('m'), $post->getSlug());
+
+        $this->client->request('GET', $oldPath);
+        self::assertResponseRedirects($newPath, Response::HTTP_MOVED_PERMANENTLY);
+        $this->client->followRedirect();
+        self::assertResponseIsSuccessful();
+    }
 }

--- a/tests/Unit/Entity/BlogPostTest.php
+++ b/tests/Unit/Entity/BlogPostTest.php
@@ -10,6 +10,7 @@ use App\Entity\Blog\BlogTag;
 use App\Infrastructure\Doctrine\SlugListener;
 use App\Repository\Blog\BlogCategoryRepository;
 use App\Repository\Blog\BlogPostRepository;
+use App\Repository\Blog\BlogPostSlugHistoryRepository;
 use App\Repository\Blog\BlogTagRepository;
 use App\Repository\CityRepository;
 use App\Repository\GroomerProfileRepository;
@@ -42,6 +43,7 @@ final class BlogPostTest extends TestCase
             $this->createMock(BlogCategoryRepository::class),
             $this->createMock(BlogTagRepository::class),
             $this->createMock(BlogPostRepository::class),
+            $this->createMock(BlogPostSlugHistoryRepository::class),
         );
         $em = $this->createMock(EntityManagerInterface::class);
         $listener->prePersist(new PrePersistEventArgs($post, $em));

--- a/tests/Unit/Infrastructure/SlugListenerTest.php
+++ b/tests/Unit/Infrastructure/SlugListenerTest.php
@@ -10,6 +10,7 @@ use App\Entity\City;
 use App\Infrastructure\Doctrine\SlugListener;
 use App\Repository\Blog\BlogCategoryRepository;
 use App\Repository\Blog\BlogPostRepository;
+use App\Repository\Blog\BlogPostSlugHistoryRepository;
 use App\Repository\Blog\BlogTagRepository;
 use App\Repository\CityRepository;
 use App\Repository\GroomerProfileRepository;
@@ -27,6 +28,7 @@ final class SlugListenerTest extends TestCase
     private BlogCategoryRepository $blogCategoryRepository;
     private BlogTagRepository $blogTagRepository;
     private BlogPostRepository $blogPostRepository;
+    private BlogPostSlugHistoryRepository $blogPostSlugHistoryRepository;
     private SlugListener $listener;
 
     protected function setUp(): void
@@ -37,6 +39,7 @@ final class SlugListenerTest extends TestCase
         $this->blogCategoryRepository = $this->createMock(BlogCategoryRepository::class);
         $this->blogTagRepository = $this->createMock(BlogTagRepository::class);
         $this->blogPostRepository = $this->createMock(BlogPostRepository::class);
+        $this->blogPostSlugHistoryRepository = $this->createMock(BlogPostSlugHistoryRepository::class);
 
         $this->listener = new SlugListener(
             $this->cityRepository,
@@ -45,6 +48,7 @@ final class SlugListenerTest extends TestCase
             $this->blogCategoryRepository,
             $this->blogTagRepository,
             $this->blogPostRepository,
+            $this->blogPostSlugHistoryRepository,
         );
     }
 


### PR DESCRIPTION
## Summary
- track historical blog slugs
- redirect requests for outdated slugs to current URL
- cover slug history redirect with tests

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a05ac438a48322933a159a5d2bfc53