### PR TITLE
feat: add blog caching and critical css

### DIFF
--- a/src/Controller/Blog/BlogTaxonomyController.php
+++ b/src/Controller/Blog/BlogTaxonomyController.php
@@ -45,6 +45,15 @@ final class BlogTaxonomyController extends AbstractController
         $page = max(1, $request->query->getInt('page', 1));
         $perPage = self::PER_PAGE;
         $posts = $this->posts->findByCategorySlug($canonicalSlug, $page, $perPage);
+        $latest = null;
+        foreach ($posts as $post) {
+            if (isset($post['updatedAt']) && (null === $latest || $post['updatedAt'] > $latest)) {
+                $latest = $post['updatedAt'];
+            }
+        }
+        if ($latest instanceof \DateTimeImmutable) {
+            $request->attributes->set('updated_at', $latest);
+        }
 
         if ($page > 1 && [] === $posts) {
             throw $this->createNotFoundException();
@@ -94,6 +103,15 @@ final class BlogTaxonomyController extends AbstractController
         $page = max(1, $request->query->getInt('page', 1));
         $perPage = self::PER_PAGE;
         $posts = $this->posts->findByTagSlug($canonicalSlug, $page, $perPage);
+        $latest = null;
+        foreach ($posts as $post) {
+            if (isset($post['updatedAt']) && (null === $latest || $post['updatedAt'] > $latest)) {
+                $latest = $post['updatedAt'];
+            }
+        }
+        if ($latest instanceof \DateTimeImmutable) {
+            $request->attributes->set('updated_at', $latest);
+        }
 
         if ($page > 1 && [] === $posts) {
             throw $this->createNotFoundException();

--- a/src/EventSubscriber/BlogPostCacheSubscriber.php
+++ b/src/EventSubscriber/BlogPostCacheSubscriber.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Entity\Blog\BlogPost;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\Events;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+#[AsDoctrineListener(event: Events::postUpdate)]
+#[AsDoctrineListener(event: Events::postPersist)]
+#[AsDoctrineListener(event: Events::postRemove)]
+final class BlogPostCacheSubscriber
+{
+    public function __construct(private TagAwareCacheInterface $cache)
+    {
+    }
+
+    public function postUpdate(PostUpdateEventArgs $args): void
+    {
+        $this->invalidate($args->getObject());
+    }
+
+    public function postPersist(PostPersistEventArgs $args): void
+    {
+        $this->invalidate($args->getObject());
+    }
+
+    public function postRemove(PostRemoveEventArgs $args): void
+    {
+        $this->invalidate($args->getObject());
+    }
+
+    private function invalidate(object $entity): void
+    {
+        if (!$entity instanceof BlogPost) {
+            return;
+        }
+
+        $this->cache->invalidateTags(['blog_posts']);
+    }
+}

--- a/src/EventSubscriber/HttpCacheSubscriber.php
+++ b/src/EventSubscriber/HttpCacheSubscriber.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class HttpCacheSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private Security $security)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        ];
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        $request = $event->getRequest();
+        $response = $event->getResponse();
+
+        $route = $request->attributes->get('_route');
+        if (!\is_string($route) || !str_starts_with($route, 'app_blog_')) {
+            return;
+        }
+
+        if (null !== $this->security->getUser()) {
+            $response->setPrivate();
+
+            return;
+        }
+
+        $response->setPublic();
+        $response->setSharedMaxAge(600);
+
+        $updatedAt = $request->attributes->get('updated_at');
+        if ($updatedAt instanceof \DateTimeInterface) {
+            $response->setLastModified($updatedAt);
+            $response->setEtag(md5($updatedAt->format(DATE_ATOM).$request->getPathInfo()));
+
+            if ($response->isNotModified($request)) {
+                $event->setResponse($response);
+            }
+        }
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -12,6 +12,7 @@
         {% include 'seo/_head_meta.html.twig' with { seo: seo|default(legacySeo) } %}
         {% block jsonld %}{% endblock %}
         <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
+        {% block critical_css %}{% endblock %}
         {% block stylesheets %}
             <link rel="preconnect" href="https://fonts.googleapis.com">
             <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/templates/blog/category.html.twig
+++ b/templates/blog/category.html.twig
@@ -1,8 +1,15 @@
 {% extends 'base.html.twig' %}
 
+{% block critical_css %}
+    <style>
+        .blog-header { margin-bottom: var(--space-3); }
+    </style>
+{% endblock %}
+
 {% block stylesheets %}
     {{ parent() }}
-    <link rel="stylesheet" href="{{ asset('styles/blog.css') }}">
+    <link rel="preload" href="{{ asset('styles/blog.css') }}" as="style" onload="this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="{{ asset('styles/blog.css') }}"></noscript>
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/blog/detail.html.twig
+++ b/templates/blog/detail.html.twig
@@ -5,9 +5,16 @@
     {{ seo_jsonld.render(jsonld|default({})) }}
 {% endblock %}
 
+{% block critical_css %}
+    <style>
+        .blog-header { margin-bottom: var(--space-3); }
+    </style>
+{% endblock %}
+
 {% block stylesheets %}
     {{ parent() }}
-    <link rel="stylesheet" href="{{ asset('styles/blog.css') }}">
+    <link rel="preload" href="{{ asset('styles/blog.css') }}" as="style" onload="this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="{{ asset('styles/blog.css') }}"></noscript>
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/blog/index.html.twig
+++ b/templates/blog/index.html.twig
@@ -1,8 +1,15 @@
 {% extends 'base.html.twig' %}
 
+{% block critical_css %}
+    <style>
+        .blog-header { margin-bottom: var(--space-3); }
+    </style>
+{% endblock %}
+
 {% block stylesheets %}
     {{ parent() }}
-    <link rel="stylesheet" href="{{ asset('styles/blog.css') }}">
+    <link rel="preload" href="{{ asset('styles/blog.css') }}" as="style" onload="this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="{{ asset('styles/blog.css') }}"></noscript>
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/blog/tag.html.twig
+++ b/templates/blog/tag.html.twig
@@ -1,8 +1,15 @@
 {% extends 'base.html.twig' %}
 
+{% block critical_css %}
+    <style>
+        .blog-header { margin-bottom: var(--space-3); }
+    </style>
+{% endblock %}
+
 {% block stylesheets %}
     {{ parent() }}
-    <link rel="stylesheet" href="{{ asset('styles/blog.css') }}">
+    <link rel="preload" href="{{ asset('styles/blog.css') }}" as="style" onload="this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="{{ asset('styles/blog.css') }}"></noscript>
 {% endblock %}
 
 {% block javascripts %}

--- a/tests/Functional/HttpCacheTest.php
+++ b/tests/Functional/HttpCacheTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class HttpCacheTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testDetailReturns304WithEtag(): void
+    {
+        $category = new BlogCategory('News');
+        $category->refreshSlugFrom($category->getName());
+        $post = new BlogPost($category, 'Cache Post', 'Ex', '<p>Body</p>');
+        $post->refreshSlugFrom($post->getTitle());
+        $post->setIsPublished(true);
+        $post->setPublishedAt(new \DateTimeImmutable('-1 day'));
+        $this->em->persist($category);
+        $this->em->persist($post);
+        $this->em->flush();
+
+        $path = sprintf('/blog/%s/%s/%s', $post->getPublishedAt()->format('Y'), $post->getPublishedAt()->format('m'), $post->getSlug());
+
+        $this->client->request('GET', $path);
+        self::assertResponseIsSuccessful();
+        $response = $this->client->getResponse();
+        self::assertSame('public, s-maxage=600', $response->headers->get('Cache-Control'));
+        $etag = $response->headers->get('ETag');
+        self::assertNotEmpty($etag);
+        self::assertNotEmpty($response->headers->get('Last-Modified'));
+
+        $this->client->request('GET', $path, server: ['HTTP_IF_NONE_MATCH' => $etag]);
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_MODIFIED);
+    }
+}

--- a/tests/Unit/EventSubscriber/BlogPostCacheSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/BlogPostCacheSubscriberTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\EventSubscriber;
+
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use App\EventSubscriber\BlogPostCacheSubscriber;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+final class BlogPostCacheSubscriberTest extends TestCase
+{
+    public function testInvalidateOnUpdate(): void
+    {
+        $cache = $this->createMock(TagAwareCacheInterface::class);
+        $cache->expects(self::once())->method('invalidateTags')->with(['blog_posts']);
+
+        $subscriber = new BlogPostCacheSubscriber($cache);
+
+        $post = new BlogPost(new BlogCategory('News'), 'Title', 'Ex', '<p>Body</p>');
+        $em = $this->createMock(EntityManagerInterface::class);
+        $args = new PostUpdateEventArgs($post, $em);
+
+        $subscriber->postUpdate($args);
+    }
+}

--- a/tests/Unit/Repository/BlogPostRepositoryTest.php
+++ b/tests/Unit/Repository/BlogPostRepositoryTest.php
@@ -12,6 +12,8 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 final class BlogPostRepositoryTest extends TestCase
 {
@@ -46,8 +48,15 @@ final class BlogPostRepositoryTest extends TestCase
         $registry = $this->createMock(ManagerRegistry::class);
         $registry->method('getManagerForClass')->with(BlogPost::class)->willReturn($em);
 
+        $cache = $this->createMock(TagAwareCacheInterface::class);
+        $cache->method('get')->willReturnCallback(function (string $key, callable $callback) {
+            $item = $this->createMock(ItemInterface::class);
+
+            return $callback($item);
+        });
+
         $repository = $this->getMockBuilder(BlogPostRepository::class)
-            ->setConstructorArgs([$registry])
+            ->setConstructorArgs([$registry, $cache])
             ->onlyMethods(['createQueryBuilder'])
             ->getMock();
 


### PR DESCRIPTION
## Summary
- add HTTP cache headers and ETag handling for blog routes
- cache blog post listings with tag invalidation
- inline critical blog header CSS and defer full stylesheet

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a0683058688322806cbf39fa21d340