### PR TITLE
feat: add admin blog post management and seeding

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -26,7 +26,7 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
-        # - { path: ^/admin, roles: ROLE_ADMIN }
+        - { path: ^/admin/blog, roles: ROLE_ADMIN }
         # - { path: ^/profile, roles: ROLE_USER }
 
 when@test:

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Seeder\BlogSeed;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:seed', description: 'Seed demo data')]
+final class SeedCommand extends Command
+{
+    public function __construct(private readonly BlogSeed $blogSeed)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('blog', null, InputOption::VALUE_NONE, 'Seed blog demo content');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if ($input->getOption('blog')) {
+            $this->blogSeed->seed();
+            $output->writeln('<info>Blog content seeded.</info>');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/Admin/Blog/PostController.php
+++ b/src/Controller/Admin/Blog/PostController.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin\Blog;
+
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use App\Entity\Blog\BlogTag;
+use App\Form\Blog\BlogPostType;
+use App\Repository\Blog\BlogCategoryRepository;
+use App\Repository\Blog\BlogTagRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+#[IsGranted('ROLE_ADMIN')]
+#[Route('/admin/blog/posts')]
+final class PostController extends AbstractController
+{
+    #[Route('/new', name: 'admin_blog_post_new', methods: ['GET', 'POST'])]
+    public function new(Request $request, EntityManagerInterface $em, BlogCategoryRepository $categoryRepo, BlogTagRepository $tagRepo): Response
+    {
+        $defaultCategory = $categoryRepo->findOneBy([]) ?? new BlogCategory('temp');
+        $post = new BlogPost($defaultCategory, '', '', '');
+        $form = $this->createForm(BlogPostType::class, $post);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted()) {
+            $tagData = $form->get('tags')->getData();
+            $tagsInput = is_string($tagData) ? $tagData : '';
+            $tags = $this->parseTags($tagsInput);
+            if ($this->hasDuplicateTags($tags)) {
+                $form->get('tags')->addError(new FormError('Duplicate tag names are not allowed.'));
+            }
+
+            $this->handlePublishState($post, $form);
+
+            if ($form->isValid()) {
+                $this->syncTags($post, $tags, $tagRepo, $em);
+                $em->persist($post);
+                $em->flush();
+
+                return $this->redirectToRoute('admin_blog_post_edit', ['id' => $post->getId()]);
+            }
+        }
+
+        return $this->render('admin/blog/post_form.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'admin_blog_post_edit', methods: ['GET', 'POST'])]
+    public function edit(BlogPost $post, Request $request, EntityManagerInterface $em, BlogTagRepository $tagRepo): Response
+    {
+        $tagNames = [];
+        foreach ($post->getTags() as $tag) {
+            $tagNames[] = $tag->getName();
+        }
+        $form = $this->createForm(BlogPostType::class, $post);
+        $form->get('tags')->setData(implode(', ', $tagNames));
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted()) {
+            $tagData = $form->get('tags')->getData();
+            $tagsInput = is_string($tagData) ? $tagData : '';
+            $tags = $this->parseTags($tagsInput);
+            if ($this->hasDuplicateTags($tags)) {
+                $form->get('tags')->addError(new FormError('Duplicate tag names are not allowed.'));
+            }
+
+            $this->handlePublishState($post, $form);
+
+            if ($form->isValid()) {
+                foreach ($post->getTags() as $existing) {
+                    $post->removeTag($existing);
+                }
+                $this->syncTags($post, $tags, $tagRepo, $em);
+                $em->flush();
+
+                return $this->redirectToRoute('admin_blog_post_edit', ['id' => $post->getId()]);
+            }
+        }
+
+        return $this->render('admin/blog/post_form.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parseTags(string $input): array
+    {
+        $parts = array_filter(array_map(static fn (string $v): string => trim($v), explode(',', $input)));
+
+        return array_values($parts);
+    }
+
+    /**
+     * @param list<string> $tags
+     */
+    private function hasDuplicateTags(array $tags): bool
+    {
+        $slugger = new AsciiSlugger();
+        $slugs = [];
+        foreach ($tags as $tag) {
+            $slug = $slugger->slug(mb_strtolower($tag))->lower()->toString();
+            if (in_array($slug, $slugs, true)) {
+                return true;
+            }
+            $slugs[] = $slug;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<string> $tags
+     */
+    private function syncTags(BlogPost $post, array $tags, BlogTagRepository $tagRepo, EntityManagerInterface $em): void
+    {
+        $slugger = new AsciiSlugger();
+        foreach ($tags as $tagName) {
+            $slug = $slugger->slug(mb_strtolower($tagName))->lower()->toString();
+            $tag = $tagRepo->findOneBy(['slug' => $slug]);
+            if (null === $tag) {
+                $tag = new BlogTag($tagName);
+                $tag->refreshSlugFrom($tagName);
+                $em->persist($tag);
+            }
+            $post->addTag($tag);
+        }
+    }
+
+    private function handlePublishState(BlogPost $post, \Symfony\Component\Form\FormInterface $form): void
+    {
+        if ($post->isPublished()) {
+            $now = new \DateTimeImmutable();
+            $publishedAt = $post->getPublishedAt();
+            if (null === $publishedAt) {
+                $post->setPublishedAt($now);
+            } elseif ($publishedAt <= $now) {
+                $form->get('publishedAt')->addError(new FormError('Publish date must be in the future.'));
+            }
+        } else {
+            $post->setPublishedAt(null);
+        }
+    }
+}

--- a/src/Form/Blog/BlogPostType.php
+++ b/src/Form/Blog/BlogPostType.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\Blog;
+
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class BlogPostType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('title', TextType::class)
+            ->add('excerpt', TextareaType::class, ['required' => false])
+            ->add('contentHtml', TextareaType::class)
+            ->add('canonicalUrl', TextType::class, ['required' => false])
+            ->add('metaTitle', TextType::class, ['required' => false])
+            ->add('metaDescription', TextType::class, ['required' => false])
+            ->add('category', EntityType::class, [
+                'class' => BlogCategory::class,
+                'choice_label' => 'name',
+            ])
+            ->add('tags', TextType::class, [
+                'mapped' => false,
+                'required' => false,
+                'attr' => ['placeholder' => 'tag1, tag2'],
+            ])
+            ->add('isPublished', CheckboxType::class, ['required' => false])
+            ->add('publishedAt', DateTimeType::class, [
+                'widget' => 'single_text',
+                'required' => false,
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => BlogPost::class,
+        ]);
+    }
+}

--- a/src/Seeder/BlogSeed.php
+++ b/src/Seeder/BlogSeed.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Seeder;
+
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use App\Entity\Blog\BlogTag;
+use App\Repository\Blog\BlogCategoryRepository;
+use App\Repository\Blog\BlogPostRepository;
+use App\Repository\Blog\BlogTagRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+final class BlogSeed
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly BlogCategoryRepository $categoryRepository,
+        private readonly BlogTagRepository $tagRepository,
+        private readonly BlogPostRepository $postRepository,
+    ) {
+    }
+
+    public function seed(): void
+    {
+        $data = self::demoData();
+        $slugger = new AsciiSlugger();
+
+        $this->em->wrapInTransaction(function () use ($data, $slugger): void {
+            $categories = [];
+            foreach ($data['categories'] as $name) {
+                $slug = $slugger->slug(mb_strtolower($name))->lower()->toString();
+                $category = $this->categoryRepository->findOneBy(['slug' => $slug]);
+                if (null === $category) {
+                    $category = new BlogCategory($name);
+                    $category->refreshSlugFrom($name);
+                    $this->em->persist($category);
+                } else {
+                    $category->setName($name);
+                }
+                $categories[$name] = $category;
+            }
+
+            $tags = [];
+            foreach ($data['tags'] as $name) {
+                $slug = $slugger->slug(mb_strtolower($name))->lower()->toString();
+                $tag = $this->tagRepository->findOneBy(['slug' => $slug]);
+                if (null === $tag) {
+                    $tag = new BlogTag($name);
+                    $tag->refreshSlugFrom($name);
+                    $this->em->persist($tag);
+                } else {
+                    $tag->setName($name);
+                }
+                $tags[$name] = $tag;
+            }
+
+            foreach ($data['posts'] as $postData) {
+                $slug = $slugger->slug(mb_strtolower($postData['title']))->lower()->toString();
+                $post = $this->postRepository->findOneBy(['slug' => $slug]);
+
+                if (null === $post) {
+                    $category = $categories[$postData['category']];
+                    $post = new BlogPost($category, $postData['title'], $postData['excerpt'], $postData['content_html']);
+                    $post->refreshSlugFrom($postData['title']);
+                    $this->em->persist($post);
+                } else {
+                    $post->setCategory($categories[$postData['category']]);
+                    $post->setTitle($postData['title']);
+                    $post->setExcerpt($postData['excerpt']);
+                    $post->setContentHtml($postData['content_html']);
+                }
+
+                $post->setIsPublished($postData['is_published']);
+                $post->setPublishedAt($postData['published_at']);
+
+                foreach ($post->getTags() as $existing) {
+                    $post->removeTag($existing);
+                }
+                foreach ($postData['tags'] as $tagName) {
+                    $post->addTag($tags[$tagName]);
+                }
+            }
+
+            $this->em->flush();
+        });
+    }
+
+    /**
+     * @return array{
+     *     categories: list<string>,
+     *     tags: list<string>,
+     *     posts: list<array{
+     *         title: string,
+     *         excerpt: string,
+     *         content_html: string,
+     *         category: string,
+     *         tags: list<string>,
+     *         is_published: bool,
+     *         published_at: \DateTimeImmutable,
+     *     }>
+     * }
+     */
+    private static function demoData(): array
+    {
+        return [
+            'categories' => ['News'],
+            'tags' => ['General', 'Update'],
+            'posts' => [
+                [
+                    'title' => 'Welcome',
+                    'excerpt' => 'Welcome to our blog',
+                    'content_html' => '<p>First post</p>',
+                    'category' => 'News',
+                    'tags' => ['General', 'Update'],
+                    'is_published' => true,
+                    'published_at' => new \DateTimeImmutable('-1 day'),
+                ],
+            ],
+        ];
+    }
+}

--- a/templates/admin/blog/post_form.html.twig
+++ b/templates/admin/blog/post_form.html.twig
@@ -1,0 +1,3 @@
+{{ form_start(form) }}
+{{ form_widget(form) }}
+{{ form_end(form) }}

--- a/tests/Functional/Command/SeedBlogCommandTest.php
+++ b/tests/Functional/Command/SeedBlogCommandTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Command;
+
+use App\Entity\Blog\BlogPost;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class SeedBlogCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testSeedingIsIdempotent(): void
+    {
+        $application = new Application(self::$kernel);
+        $command = $application->find('app:seed');
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--blog' => true]);
+        $tester->execute(['--blog' => true]);
+
+        self::assertSame(1, $this->em->getRepository(BlogPost::class)->count([]));
+    }
+}

--- a/tests/Functional/Controller/Admin/BlogPostControllerTest.php
+++ b/tests/Functional/Controller/Admin/BlogPostControllerTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Controller\Admin;
+
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class BlogPostControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testAdminCanCreatePost(): void
+    {
+        $admin = (new User())
+            ->setEmail('admin@example.com')
+            ->setPassword('pass')
+            ->setRoles(['ROLE_ADMIN']);
+        $category = new BlogCategory('News');
+        $this->em->persist($admin);
+        $this->em->persist($category);
+        $this->em->flush();
+
+        $this->client->loginUser($admin);
+        $crawler = $this->client->request('GET', '/admin/blog/posts/new');
+        $token = $crawler->filter('input[name="blog_post[_token]"]')->attr('value');
+
+        $this->client->request('POST', '/admin/blog/posts/new', [
+            'blog_post' => [
+                '_token' => $token,
+                'title' => 'Hello',
+                'excerpt' => 'Ex',
+                'contentHtml' => '<p>Hi<script>alert(1)</script></p>',
+                'canonicalUrl' => '',
+                'metaTitle' => '',
+                'metaDescription' => '',
+                'category' => $category->getId(),
+                'tags' => 'Foo,Bar',
+                'isPublished' => 1,
+                'publishedAt' => '',
+            ],
+        ]);
+
+        self::assertResponseRedirects();
+        /** @var BlogPost|null $post */
+        $post = $this->em->getRepository(BlogPost::class)->findOneBy(['title' => 'Hello']);
+        self::assertNotNull($post);
+        self::assertStringNotContainsString('<script', $post->getContentHtml());
+        self::assertSame(2, $post->getTags()->count());
+        self::assertNotNull($post->getPublishedAt());
+    }
+
+    public function testDuplicateTagsRejected(): void
+    {
+        $admin = (new User())
+            ->setEmail('admin2@example.com')
+            ->setPassword('pass')
+            ->setRoles(['ROLE_ADMIN']);
+        $category = new BlogCategory('Guides');
+        $this->em->persist($admin);
+        $this->em->persist($category);
+        $this->em->flush();
+
+        $this->client->loginUser($admin);
+        $crawler = $this->client->request('GET', '/admin/blog/posts/new');
+        $token = $crawler->filter('input[name="blog_post[_token]"]')->attr('value');
+
+        $this->client->request('POST', '/admin/blog/posts/new', [
+            'blog_post' => [
+                '_token' => $token,
+                'title' => 'Dup',
+                'excerpt' => 'Ex',
+                'contentHtml' => '<p>Hi</p>',
+                'canonicalUrl' => '',
+                'metaTitle' => '',
+                'metaDescription' => '',
+                'category' => $category->getId(),
+                'tags' => 'Foo, foo',
+                'isPublished' => 0,
+                'publishedAt' => '',
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertSame(0, $this->em->getRepository(BlogPost::class)->count([]));
+    }
+
+    public function testScheduledPostRequiresFutureDate(): void
+    {
+        $admin = (new User())
+            ->setEmail('admin3@example.com')
+            ->setPassword('pass')
+            ->setRoles(['ROLE_ADMIN']);
+        $category = new BlogCategory('Tips');
+        $this->em->persist($admin);
+        $this->em->persist($category);
+        $this->em->flush();
+
+        $this->client->loginUser($admin);
+        $crawler = $this->client->request('GET', '/admin/blog/posts/new');
+        $token = $crawler->filter('input[name="blog_post[_token]"]')->attr('value');
+
+        $yesterday = (new \DateTimeImmutable('-1 day'))->format('Y-m-d\TH:i');
+        $this->client->request('POST', '/admin/blog/posts/new', [
+            'blog_post' => [
+                '_token' => $token,
+                'title' => 'Sched',
+                'excerpt' => 'Ex',
+                'contentHtml' => '<p>Hi</p>',
+                'canonicalUrl' => '',
+                'metaTitle' => '',
+                'metaDescription' => '',
+                'category' => $category->getId(),
+                'tags' => '',
+                'isPublished' => 1,
+                'publishedAt' => $yesterday,
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertSame(0, $this->em->getRepository(BlogPost::class)->count([]));
+    }
+}


### PR DESCRIPTION
## Summary
- add secured admin CRUD controller for blog posts with tag de-duplication and publish scheduling rules
- seed demo blog categories, tags, and posts and expose via `app:seed --blog`
- secure /admin/blog routes for ROLE_ADMIN

## Testing
- `composer fix:php`
- `composer stan`
- `php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a06d3c00d48322816d6ff830ad72ff