### PR TITLE
feat: enhance blog accessibility and schema

### DIFF
--- a/assets/styles/blog.css
+++ b/assets/styles/blog.css
@@ -20,4 +20,23 @@
 
 .blog-breadcrumb {
     margin-top: var(--space-4);
+    font-size: 0.875rem;
+}
+
+.blog-breadcrumb ol {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+    padding: 0;
+    margin: 0;
+}
+
+.blog-breadcrumb li + li::before {
+    content: '/';
+    margin: 0 var(--space-1);
+}
+
+.blog-breadcrumb a {
+    text-decoration: none;
 }

--- a/src/Controller/Blog/BlogController.php
+++ b/src/Controller/Blog/BlogController.php
@@ -59,6 +59,23 @@ final class BlogController extends AbstractController
             $options['robots'] = 'noindex,follow';
         }
 
+        $breadcrumbs = [
+            ['name' => 'Home', 'url' => $this->generateUrl('app_homepage')],
+            ['name' => 'Blog', 'url' => $this->generateUrl('app_blog_index')],
+        ];
+        $jsonLd = [
+            'breadcrumbs' => [
+                [
+                    'name' => 'Home',
+                    'item' => $this->generateUrl('app_homepage', [], UrlGeneratorInterface::ABSOLUTE_URL),
+                ],
+                [
+                    'name' => 'Blog',
+                    'item' => $this->generateUrl('app_blog_index', [], UrlGeneratorInterface::ABSOLUTE_URL),
+                ],
+            ],
+        ];
+
         return $this->render('blog/index.html.twig', [
             'title' => 'Blog',
             'posts' => $posts,
@@ -66,6 +83,8 @@ final class BlogController extends AbstractController
             'next_page' => $hasNext ? $page + 1 : null,
             'prev_page' => $page > 1 ? $page - 1 : null,
             'seo' => $this->seo->build($options),
+            'breadcrumbs' => $breadcrumbs,
+            'jsonld' => $jsonLd,
         ]);
     }
 
@@ -118,6 +137,13 @@ final class BlogController extends AbstractController
             $options['canonical_url'] = $post->getCanonicalUrl();
         }
 
+        $breadcrumbs = [
+            ['name' => 'Home', 'url' => $this->generateUrl('app_homepage')],
+            ['name' => 'Blog', 'url' => $this->generateUrl('app_blog_index')],
+            ['name' => $post->getCategory()->getName(), 'url' => $this->generateUrl('app_blog_category', ['slug' => $post->getCategory()->getSlug()])],
+            ['name' => $post->getTitle(), 'url' => $this->generateUrl('app_blog_detail', ['year' => $year, 'month' => sprintf('%02d', $month), 'slug' => $post->getSlug()])],
+        ];
+
         $jsonLd = null;
         if ($post->isPublished()) {
             $jsonLd = [
@@ -154,6 +180,7 @@ final class BlogController extends AbstractController
             'post' => $post,
             'seo' => $this->seo->build($options),
             'jsonld' => $jsonLd,
+            'breadcrumbs' => $breadcrumbs,
         ]);
     }
 }

--- a/src/Controller/Blog/BlogTaxonomyController.php
+++ b/src/Controller/Blog/BlogTaxonomyController.php
@@ -74,6 +74,28 @@ final class BlogTaxonomyController extends AbstractController
             $options['robots'] = 'noindex,follow';
         }
 
+        $breadcrumbs = [
+            ['name' => 'Home', 'url' => $this->generateUrl('app_homepage')],
+            ['name' => 'Blog', 'url' => $this->generateUrl('app_blog_index')],
+            ['name' => $category->getName(), 'url' => $this->generateUrl('app_blog_category', ['slug' => $category->getSlug()])],
+        ];
+        $jsonLd = [
+            'breadcrumbs' => [
+                [
+                    'name' => 'Home',
+                    'item' => $this->generateUrl('app_homepage', [], UrlGeneratorInterface::ABSOLUTE_URL),
+                ],
+                [
+                    'name' => 'Blog',
+                    'item' => $this->generateUrl('app_blog_index', [], UrlGeneratorInterface::ABSOLUTE_URL),
+                ],
+                [
+                    'name' => $category->getName(),
+                    'item' => $this->generateUrl('app_blog_category', ['slug' => $category->getSlug()], UrlGeneratorInterface::ABSOLUTE_URL),
+                ],
+            ],
+        ];
+
         return $this->render('blog/category.html.twig', [
             'title' => $category->getName(),
             'posts' => $posts,
@@ -81,6 +103,8 @@ final class BlogTaxonomyController extends AbstractController
             'next_page' => $hasNext ? $page + 1 : null,
             'prev_page' => $page > 1 ? $page - 1 : null,
             'seo' => $this->seo->build($options),
+            'breadcrumbs' => $breadcrumbs,
+            'jsonld' => $jsonLd,
         ]);
     }
 
@@ -132,6 +156,28 @@ final class BlogTaxonomyController extends AbstractController
             $options['robots'] = 'noindex,follow';
         }
 
+        $breadcrumbs = [
+            ['name' => 'Home', 'url' => $this->generateUrl('app_homepage')],
+            ['name' => 'Blog', 'url' => $this->generateUrl('app_blog_index')],
+            ['name' => $tag->getName(), 'url' => $this->generateUrl('app_blog_tag', ['slug' => $tag->getSlug()])],
+        ];
+        $jsonLd = [
+            'breadcrumbs' => [
+                [
+                    'name' => 'Home',
+                    'item' => $this->generateUrl('app_homepage', [], UrlGeneratorInterface::ABSOLUTE_URL),
+                ],
+                [
+                    'name' => 'Blog',
+                    'item' => $this->generateUrl('app_blog_index', [], UrlGeneratorInterface::ABSOLUTE_URL),
+                ],
+                [
+                    'name' => $tag->getName(),
+                    'item' => $this->generateUrl('app_blog_tag', ['slug' => $tag->getSlug()], UrlGeneratorInterface::ABSOLUTE_URL),
+                ],
+            ],
+        ];
+
         return $this->render('blog/tag.html.twig', [
             'title' => $tag->getName(),
             'posts' => $posts,
@@ -139,6 +185,8 @@ final class BlogTaxonomyController extends AbstractController
             'next_page' => $hasNext ? $page + 1 : null,
             'prev_page' => $page > 1 ? $page - 1 : null,
             'seo' => $this->seo->build($options),
+            'breadcrumbs' => $breadcrumbs,
+            'jsonld' => $jsonLd,
         ]);
     }
 }

--- a/templates/blog/_post_teaser.html.twig
+++ b/templates/blog/_post_teaser.html.twig
@@ -1,6 +1,6 @@
 <article class="post">
     {% if post.coverImagePath is defined and post.coverImagePath %}
-        <img src="{{ asset(post.coverImagePath) }}" alt="{{ post.title }}" loading="lazy" width="400" height="225">
+        <img src="{{ asset(post.coverImagePath) }}" alt="Cover image for {{ post.title }}" loading="lazy" width="400" height="225">
     {% else %}
         <img src="{{ asset('assets/illustrations/paw.svg') }}" alt="" loading="lazy" width="400" height="225">
     {% endif %}

--- a/templates/blog/category.html.twig
+++ b/templates/blog/category.html.twig
@@ -1,4 +1,9 @@
 {% extends 'base.html.twig' %}
+{% import 'seo/_jsonld.html.twig' as seo_jsonld %}
+
+{% block jsonld %}
+    {{ seo_jsonld.render(jsonld|default({})) }}
+{% endblock %}
 
 {% block critical_css %}
     <style>
@@ -18,12 +23,10 @@
 {% endblock %}
 
 {% block body %}
+{% include 'partials/_breadcrumbs.html.twig' with {breadcrumbs: breadcrumbs|default([])} %}
 <header class="blog-header">
     <h1>{{ title }}</h1>
 </header>
-<nav class="blog-breadcrumb" aria-label="Breadcrumb">
-    <a href="{{ path('app_blog_index') }}">Blog home</a>
-</nav>
 <section class="post-list">
     {% for post in posts %}
         {% include 'blog/_post_teaser.html.twig' with {post: post} %}

--- a/templates/blog/detail.html.twig
+++ b/templates/blog/detail.html.twig
@@ -23,6 +23,7 @@
 {% endblock %}
 
 {% block body %}
+{% include 'partials/_breadcrumbs.html.twig' with {breadcrumbs: breadcrumbs|default([])} %}
 <article class="blog-article">
     <header>
         <h1>{{ post.title }}</h1>
@@ -34,13 +35,10 @@
         {% endif %}
     </header>
     {% if post.coverImagePath %}
-        <img src="{{ asset(post.coverImagePath) }}" alt="{{ post.title }}" loading="lazy" width="800" height="450">
+        <img src="{{ asset(post.coverImagePath) }}" alt="Cover image for {{ post.title }}" loading="lazy" width="800" height="450">
     {% else %}
         <img src="{{ asset('assets/illustrations/paw.svg') }}" alt="" loading="lazy" width="800" height="450">
     {% endif %}
     <section class="content">{{ post.contentHtml|raw }}</section>
 </article>
-<nav class="blog-breadcrumb" aria-label="Breadcrumb">
-    <a href="{{ path('app_blog_index') }}">&larr; Back to blog</a>
-</nav>
 {% endblock %}

--- a/templates/blog/index.html.twig
+++ b/templates/blog/index.html.twig
@@ -1,4 +1,9 @@
 {% extends 'base.html.twig' %}
+{% import 'seo/_jsonld.html.twig' as seo_jsonld %}
+
+{% block jsonld %}
+    {{ seo_jsonld.render(jsonld|default({})) }}
+{% endblock %}
 
 {% block critical_css %}
     <style>
@@ -18,6 +23,7 @@
 {% endblock %}
 
 {% block body %}
+{% include 'partials/_breadcrumbs.html.twig' with {breadcrumbs: breadcrumbs|default([])} %}
 <header class="blog-header">
     <h1>{{ title }}</h1>
 </header>

--- a/templates/blog/tag.html.twig
+++ b/templates/blog/tag.html.twig
@@ -1,4 +1,9 @@
 {% extends 'base.html.twig' %}
+{% import 'seo/_jsonld.html.twig' as seo_jsonld %}
+
+{% block jsonld %}
+    {{ seo_jsonld.render(jsonld|default({})) }}
+{% endblock %}
 
 {% block critical_css %}
     <style>
@@ -18,12 +23,10 @@
 {% endblock %}
 
 {% block body %}
+{% include 'partials/_breadcrumbs.html.twig' with {breadcrumbs: breadcrumbs|default([])} %}
 <header class="blog-header">
     <h1>{{ title }}</h1>
 </header>
-<nav class="blog-breadcrumb" aria-label="Breadcrumb">
-    <a href="{{ path('app_blog_index') }}">Blog home</a>
-</nav>
 <section class="post-list">
     {% for post in posts %}
         {% include 'blog/_post_teaser.html.twig' with {post: post} %}

--- a/templates/partials/_breadcrumbs.html.twig
+++ b/templates/partials/_breadcrumbs.html.twig
@@ -1,0 +1,13 @@
+{% if breadcrumbs is defined and breadcrumbs %}
+<nav class="blog-breadcrumb" aria-label="Breadcrumb">
+    <ol>
+        {% for crumb in breadcrumbs %}
+            {% if loop.last %}
+                <li aria-current="page">{{ crumb.name }}</li>
+            {% else %}
+                <li><a href="{{ crumb.url }}">{{ crumb.name }}</a></li>
+            {% endif %}
+        {% endfor %}
+    </ol>
+</nav>
+{% endif %}

--- a/tests/E2E/Blog/HeadingStructureTest.php
+++ b/tests/E2E/Blog/HeadingStructureTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E\Blog;
+
+use App\Entity\Blog\BlogCategory;
+use App\Entity\Blog\BlogPost;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class HeadingStructureTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    private function createPublishedPost(): BlogPost
+    {
+        $category = new BlogCategory('News');
+        $category->refreshSlugFrom($category->getName());
+        $post = new BlogPost($category, 'Heading Post', 'Ex', '<h2>Section</h2><p>Body</p>');
+        $post->refreshSlugFrom($post->getTitle());
+        $post->setIsPublished(true);
+        $post->setPublishedAt(new \DateTimeImmutable('-1 day'));
+        $this->em->persist($category);
+        $this->em->persist($post);
+        $this->em->flush();
+
+        return $post;
+    }
+
+    public function testIndexHeadingOutlineIsLogical(): void
+    {
+        $this->createPublishedPost();
+        $crawler = $this->client->request('GET', '/blog');
+        self::assertResponseIsSuccessful();
+
+        $main = $crawler->filter('main');
+        self::assertSame(1, $main->filter('h1')->count());
+
+        $headings = $main->filter('h1, h2, h3, h4, h5, h6');
+        $prevLevel = 1;
+        foreach ($headings as $index => $node) {
+            $level = (int) substr($node->nodeName, 1);
+            if (0 === $index) {
+                self::assertSame(1, $level);
+            } else {
+                self::assertLessThanOrEqual($prevLevel + 1, $level);
+            }
+            $prevLevel = $level;
+        }
+    }
+
+    public function testDetailHeadingOutlineIsLogical(): void
+    {
+        $post = $this->createPublishedPost();
+        $path = sprintf('/blog/%s/%s/%s', $post->getPublishedAt()->format('Y'), $post->getPublishedAt()->format('m'), $post->getSlug());
+
+        $crawler = $this->client->request('GET', $path);
+        self::assertResponseIsSuccessful();
+
+        $main = $crawler->filter('main');
+        self::assertSame(1, $main->filter('h1')->count());
+
+        $headings = $main->filter('h1, h2, h3, h4, h5, h6');
+        $prevLevel = 1;
+        foreach ($headings as $index => $node) {
+            $level = (int) substr($node->nodeName, 1);
+            if (0 === $index) {
+                self::assertSame(1, $level);
+            } else {
+                self::assertLessThanOrEqual($prevLevel + 1, $level);
+            }
+            $prevLevel = $level;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add styled breadcrumb component and JSON-LD data across blog pages
- improve blog image alt text and validate heading order
- add tests ensuring blog pages maintain logical heading hierarchy

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68a0727787c483229ccc69b82a83fd06