### PR TITLE
feat: add task status tracking scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 ###> phpstan/phpstan ###
 phpstan.neon
 ###< phpstan/phpstan ###
+
+# Task status lock file
+/.task_status.lock
+# Python artifacts
+__pycache__/
+*.pyc

--- a/.task_status.json
+++ b/.task_status.json
@@ -1,0 +1,14 @@
+{
+  "tasks": [
+    {
+      "id": 1,
+      "title": "Define task spec + status tracking (repo scaffolding)",
+      "attempts": 0,
+      "status": "pending",
+      "last_pr": 0
+    }
+  ],
+  "meta": {
+    "schemaVersion": 1
+  }
+}

--- a/scripts/slug.py
+++ b/scripts/slug.py
@@ -1,0 +1,15 @@
+import re
+import unicodedata
+
+
+def slugify(text: str) -> str:
+    """Return a filesystem-friendly slug for *text*.
+
+    Normalizes unicode characters, lowercases the string, and replaces any
+    non-alphanumeric characters with single hyphens. Leading and trailing
+    hyphens are stripped.
+    """
+    normalized = unicodedata.normalize("NFKD", text)
+    ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", ascii_text).strip("-")
+    return slug.lower()

--- a/scripts/status.py
+++ b/scripts/status.py
@@ -1,0 +1,111 @@
+import argparse
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import List
+
+import fcntl
+
+SCHEMA_VERSION = 1
+TASKS_FILE = Path("tasks.yaml")
+STATUS_FILE = Path(".task_status.json")
+LOCK_FILE = STATUS_FILE.with_suffix(".lock")
+
+
+# ---------------------------------------------------------------------------
+# File helpers
+# ---------------------------------------------------------------------------
+
+def _lock_file(fd: int) -> None:
+    fcntl.flock(fd, fcntl.LOCK_EX)
+
+
+def _unlock_file(fd: int) -> None:
+    fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+def load_status(path: Path = STATUS_FILE) -> dict:
+    """Load status JSON. Returns empty skeleton if file missing."""
+    if not path.exists():
+        return {"tasks": [], "meta": {"schemaVersion": SCHEMA_VERSION}}
+    with open(path, "r") as fh:
+        _lock_file(fh.fileno())
+        try:
+            data = json.load(fh)
+        finally:
+            _unlock_file(fh.fileno())
+    return data
+
+
+def save_status(data: dict, path: Path = STATUS_FILE) -> None:
+    """Atomically save *data* to *path* using a temp file and rename."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(LOCK_FILE, os.O_CREAT | os.O_RDWR)
+    try:
+        _lock_file(fd)
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=str(path.parent))
+        with os.fdopen(tmp_fd, "w") as tmp_fh:
+            json.dump(data, tmp_fh, indent=2)
+            tmp_fh.flush()
+            os.fsync(tmp_fh.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        _unlock_file(fd)
+        os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# Task parsing
+# ---------------------------------------------------------------------------
+
+def read_tasks(path: Path = TASKS_FILE) -> List[str]:
+    tasks: List[str] = []
+    if not path.exists():
+        return tasks
+    with open(path, "r") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("-"):
+                line = line[1:].strip()
+            tasks.append(line.strip('"'))
+    return tasks
+
+
+# ---------------------------------------------------------------------------
+# CLI operations
+# ---------------------------------------------------------------------------
+
+def init_status() -> None:
+    if STATUS_FILE.exists():
+        # already initialised
+        return
+    titles = read_tasks()
+    data = {
+        "tasks": [
+            {
+                "id": idx,
+                "title": title,
+                "attempts": 0,
+                "status": "pending",
+                "last_pr": 0,
+            }
+            for idx, title in enumerate(titles, start=1)
+        ],
+        "meta": {"schemaVersion": SCHEMA_VERSION},
+    }
+    save_status(data)
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Task status helper")
+    parser.add_argument("--init", action="store_true", help="create status file")
+    args = parser.parse_args(argv)
+    if args.init:
+        init_status()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1,0 +1,1 @@
+- Define task spec + status tracking (repo scaffolding)

--- a/tests/scripts/test_status.py
+++ b/tests/scripts/test_status.py
@@ -1,0 +1,44 @@
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from scripts import status
+
+
+def test_init_creates_file(tmp_path, monkeypatch):
+    tasks = tmp_path / "tasks.yaml"
+    tasks.write_text("- A task\n")
+    monkeypatch.chdir(tmp_path)
+    status.main(["--init"])
+    data = json.loads((tmp_path / ".task_status.json").read_text())
+    assert data["meta"]["schemaVersion"] == status.SCHEMA_VERSION
+    assert data["tasks"][0]["title"] == "A task"
+
+
+def test_init_idempotent(tmp_path, monkeypatch):
+    tasks = tmp_path / "tasks.yaml"
+    tasks.write_text("- First task\n")
+    monkeypatch.chdir(tmp_path)
+    status.main(["--init"])
+    first = (tmp_path / ".task_status.json").read_text()
+    status.main(["--init"])
+    second = (tmp_path / ".task_status.json").read_text()
+    assert first == second
+
+
+def test_concurrent_writes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data1 = {"tasks": [{"id": 1, "title": "A", "attempts": 0, "status": "pending", "last_pr": 0}], "meta": {"schemaVersion": 1}}
+    data2 = {"tasks": [{"id": 1, "title": "B", "attempts": 0, "status": "pending", "last_pr": 0}], "meta": {"schemaVersion": 1}}
+
+    def writer(data):
+        status.save_status(data, path=tmp_path / ".task_status.json")
+
+    t1 = threading.Thread(target=writer, args=(data1,))
+    t2 = threading.Thread(target=writer, args=(data2,))
+    t1.start(); t2.start(); t1.join(); t2.join()
+
+    with open(tmp_path / ".task_status.json") as fh:
+        json.load(fh)  # should not be corrupted


### PR DESCRIPTION
## Summary
- add tasks list and JSON ledger with atomic read/write helpers
- slugify utility for branch names
- tests for status initialization and concurrent saves

## Testing
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `./vendor/bin/phpunit`
- `python -m pytest tests/scripts/test_status.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1a644ad4083229f9944f478d78e6e