### PR TITLE
feat: add PR creation helper

### DIFF
--- a/scripts/pr.py
+++ b/scripts/pr.py
@@ -1,0 +1,125 @@
+import json
+import os
+import re
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import request, error
+
+try:
+    from scripts import status
+except ModuleNotFoundError:  # running as script
+    import sys
+    from pathlib import Path
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from scripts import status
+
+API_ROOT = "https://api.github.com"
+LABEL = "codex-automation"
+
+
+def _request(method: str, url: str, data: Optional[Dict[str, Any]] = None) -> Tuple[int, Any]:
+    """Perform an HTTP request to the GitHub API.
+
+    Returns a tuple of (status_code, parsed_json_or_none).
+    """
+    token = os.environ.get("GITHUB_TOKEN")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "cleanwhiskers-pr-script",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    body = None
+    if data is not None:
+        body = json.dumps(data).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with request.urlopen(req) as resp:  # type: ignore[arg-type]
+            status_code = resp.getcode()
+            if status_code == 204:
+                return status_code, None
+            text = resp.read().decode("utf-8")
+            return status_code, json.loads(text) if text else None
+    except error.HTTPError as exc:  # pragma: no cover - network errors
+        return exc.code, json.loads(exc.read().decode("utf-8") or "{}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers to fetch task info
+# ---------------------------------------------------------------------------
+
+def _task_id_from_branch(branch: str) -> Optional[int]:
+    match = re.search(r"task-(\d+)-", branch)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _task_info(task_id: int) -> Tuple[str, int]:
+    titles = status.read_tasks()
+    title = titles[task_id - 1] if 0 < task_id <= len(titles) else f"Task {task_id}"
+    data = status.load_status()
+    attempt = 1
+    for task in data.get("tasks", []):
+        if task.get("id") == task_id:
+            attempt = task.get("attempts", 0) + 1
+            break
+    return title, attempt
+
+
+# ---------------------------------------------------------------------------
+# GitHub helpers
+# ---------------------------------------------------------------------------
+
+def get_pr_number_by_branch(owner: str, repo: str, head: str) -> Optional[int]:
+    url = f"{API_ROOT}/repos/{owner}/{repo}/pulls?head={owner}:{head}&state=open"
+    status_code, data = _request("GET", url)
+    if status_code == 200 and isinstance(data, list) and data:
+        return data[0].get("number")
+    return None
+
+
+def is_pr_merged(owner: str, repo: str, pr_number: int) -> bool:
+    url = f"{API_ROOT}/repos/{owner}/{repo}/pulls/{pr_number}/merge"
+    status_code, _ = _request("GET", url)
+    return status_code == 204
+
+
+def _ensure_label(owner: str, repo: str, pr_number: int) -> None:
+    url = f"{API_ROOT}/repos/{owner}/{repo}/issues/{pr_number}/labels"
+    _request("POST", url, {"labels": [LABEL]})
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def open_or_update_pr(owner: str, repo: str, head: str, base: str = "staging") -> int:
+    """Open or update a pull request for *head*.
+
+    Ensures the PR is labelled with ``codex-automation`` and returns the PR number.
+    """
+    pr_number = get_pr_number_by_branch(owner, repo, head)
+    if pr_number:
+        _ensure_label(owner, repo, pr_number)
+        return pr_number
+
+    task_id = _task_id_from_branch(head)
+    title, attempt = ("", 1)
+    if task_id is not None:
+        title, attempt = _task_info(task_id)
+    pr_title = f"[codex] Task #{task_id}: {title}" if task_id else head
+    body = f"{title}\n\nAttempt #{attempt}" if title else f"Attempt #{attempt}"
+    url = f"{API_ROOT}/repos/{owner}/{repo}/pulls"
+    payload = {
+        "title": pr_title,
+        "head": head,
+        "base": base,
+        "body": body,
+    }
+    status_code, data = _request("POST", url, payload)
+    if status_code not in (200, 201) or not isinstance(data, dict):
+        raise RuntimeError(f"Failed to create PR: {status_code}")
+    pr_number = data["number"]
+    _ensure_label(owner, repo, pr_number)
+    return pr_number

--- a/tests/scripts/test_pr.py
+++ b/tests/scripts/test_pr.py
@@ -1,0 +1,95 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repository root on path for importing scripts package
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts import pr  # noqa: E402
+
+
+def _write_status(tmp_path: Path, tasks: list[dict]) -> None:
+    data = {"tasks": tasks, "meta": {"schemaVersion": 1}}
+    (tmp_path / ".task_status.json").write_text(json.dumps(data))
+
+
+def test_open_or_update_pr_creates_and_labels(tmp_path, monkeypatch):
+    (tmp_path / "tasks.yaml").write_text("- Do something\n")
+    _write_status(tmp_path, [{"id": 1, "title": "Do something", "attempts": 0, "status": "pending", "last_pr": 0}])
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    calls = []
+
+    def fake_request(method, url, data=None):
+        calls.append((method, url, data))
+        if url.endswith("/pulls?head=owner:codex/task-1-do-something&state=open"):
+            return 200, []
+        if url.endswith("/pulls") and method == "POST":
+            assert data["title"] == "[codex] Task #1: Do something"
+            assert data["body"] == "Do something\n\nAttempt #1"
+            return 201, {"number": 5}
+        if url.endswith("/issues/5/labels"):
+            assert data == {"labels": [pr.LABEL]}
+            return 200, {}
+        raise AssertionError(f"Unexpected call {method} {url}")
+
+    monkeypatch.setattr(pr, "_request", fake_request)
+
+    number = pr.open_or_update_pr("owner", "repo", "codex/task-1-do-something")
+    assert number == 5
+    assert [c[0] for c in calls] == ["GET", "POST", "POST"]
+
+
+def test_open_or_update_pr_existing(monkeypatch, tmp_path):
+    (tmp_path / "tasks.yaml").write_text("- Do something\n")
+    _write_status(tmp_path, [{"id": 1, "title": "Do something", "attempts": 1, "status": "pending", "last_pr": 5}])
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    calls = []
+
+    def fake_request(method, url, data=None):
+        calls.append((method, url, data))
+        if url.endswith("/pulls?head=owner:codex/task-1-do-something&state=open"):
+            return 200, [{"number": 5}]
+        if url.endswith("/issues/5/labels"):
+            return 200, {}
+        raise AssertionError(f"Unexpected call {method} {url}")
+
+    monkeypatch.setattr(pr, "_request", fake_request)
+
+    number = pr.open_or_update_pr("owner", "repo", "codex/task-1-do-something")
+    assert number == 5
+    assert [c[0] for c in calls] == ["GET", "POST"]
+
+
+def test_is_pr_merged(monkeypatch):
+    def fake_request(method, url, data=None):
+        return 204, None
+
+    monkeypatch.setattr(pr, "_request", fake_request)
+    assert pr.is_pr_merged("owner", "repo", 1) is True
+
+    def fake_request_not(method, url, data=None):
+        return 404, None
+
+    monkeypatch.setattr(pr, "_request", fake_request_not)
+    assert pr.is_pr_merged("owner", "repo", 1) is False
+
+
+def test_get_pr_number_by_branch(monkeypatch):
+    def fake_request(method, url, data=None):
+        return 200, [{"number": 99}]
+
+    monkeypatch.setattr(pr, "_request", fake_request)
+    num = pr.get_pr_number_by_branch("owner", "repo", "feature")
+    assert num == 99
+
+    def fake_request_none(method, url, data=None):
+        return 200, []
+
+    monkeypatch.setattr(pr, "_request", fake_request_none)
+    assert pr.get_pr_number_by_branch("owner", "repo", "feature") is None


### PR DESCRIPTION
## Summary
- add helper to open or update GitHub PRs and apply `codex-automation` label
- cover PR creation and merge checks with unit tests

## Testing
- `make setup`
- `make test -k` *(fails: Allowed memory size exhausted)*
- `pytest tests/scripts/test_pr.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1b489184483228fa0c83fbd3001e4