### PR TITLE
feat: add task attempt lifecycle helpers

### DIFF
--- a/scripts/status.py
+++ b/scripts/status.py
@@ -3,7 +3,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
-from typing import List
+from typing import Callable, List
 
 import fcntl
 
@@ -55,6 +55,78 @@ def save_status(data: dict, path: Path = STATUS_FILE) -> None:
         os.close(fd)
 
 
+def _load_status_unlocked(path: Path = STATUS_FILE) -> dict:
+    if not path.exists():
+        return {"tasks": [], "meta": {"schemaVersion": SCHEMA_VERSION}}
+    with open(path, "r") as fh:
+        return json.load(fh)
+
+
+def _save_status_unlocked(data: dict, path: Path = STATUS_FILE) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(path.parent))
+    with os.fdopen(tmp_fd, "w") as tmp_fh:
+        json.dump(data, tmp_fh, indent=2)
+        tmp_fh.flush()
+        os.fsync(tmp_fh.fileno())
+    os.replace(tmp_path, path)
+
+
+def _update_task(task_id: int, updater: Callable[[dict], None]) -> None:
+    fd = os.open(LOCK_FILE, os.O_CREAT | os.O_RDWR)
+    try:
+        _lock_file(fd)
+        data = _load_status_unlocked()
+        for task in data.get("tasks", []):
+            if task.get("id") == task_id:
+                updater(task)
+                break
+        _save_status_unlocked(data)
+    finally:
+        _unlock_file(fd)
+        os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def begin_attempt(task_id: int) -> None:
+    def updater(task: dict) -> None:
+        if task.get("status") != "in_progress":
+            task["attempts"] = task.get("attempts", 0) + 1
+            task["status"] = "in_progress"
+
+    _update_task(task_id, updater)
+
+
+def mark_merged(task_id: int, pr_number: int) -> None:
+    def updater(task: dict) -> None:
+        task["status"] = "merged"
+        task["last_pr"] = pr_number
+
+    _update_task(task_id, updater)
+
+
+def mark_failed(task_id: int, pr_number: int) -> None:
+    def updater(task: dict) -> None:
+        task["last_pr"] = pr_number
+        if task.get("attempts", 0) >= 3:
+            task["status"] = "failed"
+        else:
+            task["status"] = "pending"
+
+    _update_task(task_id, updater)
+
+
+def update_last_pr(task_id: int, pr_number: int) -> None:
+    def updater(task: dict) -> None:
+        task["last_pr"] = pr_number
+
+    _update_task(task_id, updater)
+
+
 # ---------------------------------------------------------------------------
 # Task parsing
 # ---------------------------------------------------------------------------
@@ -102,9 +174,24 @@ def init_status() -> None:
 def main(argv: List[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Task status helper")
     parser.add_argument("--init", action="store_true", help="create status file")
+    parser.add_argument("--begin-attempt", type=int, metavar="TASK_ID", help="increment attempts and mark in progress")
+    parser.add_argument("--mark-merged", nargs=2, type=int, metavar=("TASK_ID", "PR"), help="mark task as merged")
+    parser.add_argument("--mark-failed", nargs=2, type=int, metavar=("TASK_ID", "PR"), help="mark task as failed or pending")
+    parser.add_argument("--update-last-pr", nargs=2, type=int, metavar=("TASK_ID", "PR"), help="update last PR number")
     args = parser.parse_args(argv)
     if args.init:
         init_status()
+    if args.begin_attempt is not None:
+        begin_attempt(args.begin_attempt)
+    if args.mark_merged:
+        tid, pr = args.mark_merged
+        mark_merged(tid, pr)
+    if args.mark_failed:
+        tid, pr = args.mark_failed
+        mark_failed(tid, pr)
+    if args.update_last_pr:
+        tid, pr = args.update_last_pr
+        update_last_pr(tid, pr)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_status_transitions.py
+++ b/tests/scripts/test_status_transitions.py
@@ -1,0 +1,70 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repository root on path for importing scripts package
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts import status  # noqa: E402
+
+
+def _write_status(tmp_path: Path, tasks: list[dict]) -> None:
+    data = {"tasks": tasks, "meta": {"schemaVersion": status.SCHEMA_VERSION}}
+    (tmp_path / ".task_status.json").write_text(json.dumps(data, indent=2))
+
+
+def _read_status(tmp_path: Path) -> dict:
+    return json.loads((tmp_path / ".task_status.json").read_text())
+
+
+def test_begin_attempt_idempotent(tmp_path, monkeypatch):
+    _write_status(tmp_path, [{"id": 1, "title": "A", "attempts": 0, "status": "pending", "last_pr": 0}])
+    monkeypatch.chdir(tmp_path)
+    status.begin_attempt(1)
+    status.begin_attempt(1)
+    data = _read_status(tmp_path)
+    assert data["tasks"][0]["attempts"] == 1
+    assert data["tasks"][0]["status"] == "in_progress"
+
+
+def test_attempt_flow_and_failure(tmp_path, monkeypatch):
+    _write_status(tmp_path, [{"id": 1, "title": "A", "attempts": 0, "status": "pending", "last_pr": 0}])
+    monkeypatch.chdir(tmp_path)
+
+    status.begin_attempt(1)
+    status.mark_failed(1, 10)
+    data = _read_status(tmp_path)
+    assert data["tasks"][0]["attempts"] == 1
+    assert data["tasks"][0]["status"] == "pending"
+    assert data["tasks"][0]["last_pr"] == 10
+
+    status.begin_attempt(1)
+    status.mark_failed(1, 11)
+    data = _read_status(tmp_path)
+    assert data["tasks"][0]["attempts"] == 2
+    assert data["tasks"][0]["status"] == "pending"
+    assert data["tasks"][0]["last_pr"] == 11
+
+    status.begin_attempt(1)
+    status.mark_failed(1, 12)
+    data = _read_status(tmp_path)
+    assert data["tasks"][0]["attempts"] == 3
+    assert data["tasks"][0]["status"] == "failed"
+    assert data["tasks"][0]["last_pr"] == 12
+
+
+def test_mark_merged_and_update_last_pr(tmp_path, monkeypatch):
+    _write_status(tmp_path, [{"id": 1, "title": "A", "attempts": 1, "status": "in_progress", "last_pr": 0}])
+    monkeypatch.chdir(tmp_path)
+    status.mark_merged(1, 50)
+    status.mark_merged(1, 50)
+    data = _read_status(tmp_path)
+    assert data["tasks"][0]["status"] == "merged"
+    assert data["tasks"][0]["last_pr"] == 50
+    assert data["tasks"][0]["attempts"] == 1
+
+    status.update_last_pr(1, 51)
+    data = _read_status(tmp_path)
+    assert data["tasks"][0]["last_pr"] == 51


### PR DESCRIPTION
## Summary
- add begin_attempt, mark_merged, mark_failed and update_last_pr helpers with CLI flags
- test attempt lifecycle from first run through failure

## Testing
- `composer fix:php`
- `pytest tests/scripts/test_status_transitions.py -q`
- `make test -k`


------
https://chatgpt.com/codex/tasks/task_e_68a1b80d93188322b69e00d811a6a970