### PR TITLE
fix: add versioned task status writes and rerun safety

### DIFF
--- a/scripts/pr.py
+++ b/scripts/pr.py
@@ -119,7 +119,7 @@ def open_or_update_pr(owner: str, repo: str, head: str, base: str = "staging") -
     Ensures the PR is labelled with ``codex-automation`` and returns the PR number.
     """
     pr_number = get_pr_number_by_branch(owner, repo, head)
-    if pr_number:
+    if pr_number is not None:
         _ensure_label(owner, repo, pr_number)
         return pr_number
 

--- a/tests/scripts/test_rerun_idempotent.py
+++ b/tests/scripts/test_rerun_idempotent.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repository root on path for importing scripts package
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts import pr, status  # noqa: E402
+
+
+def test_rerun_does_not_duplicate_pr_or_attempts(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tasks.yaml").write_text("- Do something\n")
+    status.init_status()
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+
+    created = {"flag": False}
+    create_calls = {"count": 0}
+
+    def fake_request(method, url, data=None):
+        if url.endswith("/pulls?head=owner:codex/task-1-do-something&state=open"):
+            if created["flag"]:
+                return 200, [{"number": 5}]
+            return 200, []
+        if url.endswith("/pulls") and method == "POST":
+            create_calls["count"] += 1
+            created["flag"] = True
+            return 201, {"number": 5}
+        if url.endswith("/issues/5/labels"):
+            return 200, {}
+        raise AssertionError(f"Unexpected call {method} {url}")
+
+    monkeypatch.setattr(pr, "_request", fake_request)
+
+    # First run
+    pr_number = pr.open_or_update_pr("owner", "repo", "codex/task-1-do-something")
+    assert pr_number == 5
+    status.begin_attempt(1)
+    data = status.load_status()
+    assert data["tasks"][0]["attempts"] == 1
+    version = data["meta"]["version"]
+
+    # Second run (after crash)
+    pr_number_2 = pr.open_or_update_pr("owner", "repo", "codex/task-1-do-something")
+    assert pr_number_2 == 5
+    status.begin_attempt(1)
+    data2 = status.load_status()
+    assert data2["tasks"][0]["attempts"] == 1
+    assert data2["meta"]["version"] == version
+    assert create_calls["count"] == 1


### PR DESCRIPTION
## Summary
- add version-controlled task status writes to avoid duplicate attempts
- clarify PR creation flow to reuse existing PRs
- test rerun resilience for task attempts and PR reuse

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `pytest tests/scripts -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1c0beedc8832294d628ad08f91c2f