### PR TITLE
chore: add python lint and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
-.PHONY: setup test
+.PHONY: setup test php-test python-lint python-test
 
 setup:
 	composer install --no-interaction --prefer-dist
+	pip install --requirement requirements-dev.txt
 
-test:
+php-test:
 	composer ci
+
+python-lint:
+	ruff check scripts tests/scripts
+
+python-test:
+	pytest
+
+test: php-test python-lint python-test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+ruff
+pytest

--- a/scripts/pr.py
+++ b/scripts/pr.py
@@ -1,7 +1,7 @@
 import json
 import os
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 from urllib import request, error
 
 try:

--- a/tests/scripts/test_pr.py
+++ b/tests/scripts/test_pr.py
@@ -2,8 +2,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
-
 # Ensure repository root on path for importing scripts package
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 

--- a/tests/scripts/test_rerun_idempotent.py
+++ b/tests/scripts/test_rerun_idempotent.py
@@ -1,8 +1,6 @@
 import sys
 from pathlib import Path
 
-import pytest
-
 # Ensure repository root on path for importing scripts package
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 

--- a/tests/scripts/test_status.py
+++ b/tests/scripts/test_status.py
@@ -1,8 +1,5 @@
 import json
 import threading
-from pathlib import Path
-
-import pytest
 
 from scripts import status
 
@@ -38,7 +35,10 @@ def test_concurrent_writes(tmp_path, monkeypatch):
 
     t1 = threading.Thread(target=writer, args=(data1,))
     t2 = threading.Thread(target=writer, args=(data2,))
-    t1.start(); t2.start(); t1.join(); t2.join()
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
 
     with open(tmp_path / ".task_status.json") as fh:
         json.load(fh)  # should not be corrupted

--- a/tests/scripts/test_status_transitions.py
+++ b/tests/scripts/test_status_transitions.py
@@ -2,8 +2,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
-
 # Ensure repository root on path for importing scripts package
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 


### PR DESCRIPTION
## Summary
- add dev requirements for python tooling
- run ruff and pytest from makefile alongside PHP checks
- clean python scripts and tests for lint compliance

## Testing
- `ruff check scripts tests/scripts -v`
- `pytest`
- `composer lint:php`
- `composer stan`
- `composer test` (fails: script returned exit code 255)
- `./vendor/bin/phpunit` (hung; interrupted)
- `make -k test` (composer audit failed: curl error 56; python tests passed)


------
https://chatgpt.com/codex/tasks/task_e_68a1c3bd5b68832294b5ea8636e47772