### PR TITLE
chore: add write permissions to codex-on-merge workflow

### DIFF
--- a/.github/workflows/codex-on-merge.yml
+++ b/.github/workflows/codex-on-merge.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   next-task:
+    permissions:
+      contents: write
+      pull-requests: write
     if: |
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'codex-automation') &&


### PR DESCRIPTION
## Summary
- grant workflow job write access to repository contents and PRs

## Testing
- `pip install pyyaml` *(fails: Tunnel connection failed: 403 Forbidden)*
- `php -r "require 'vendor/autoload.php'; Symfony\Component\Yaml\Yaml::parseFile('.github/workflows/codex-on-merge.yml'); echo 'YAML OK';"`


------
https://chatgpt.com/codex/tasks/task_e_68a1d2ab62b08322ba19e64e20a0c297