### PR TITLE
fix: add PR permissions to codex runner workflow

### DIFF
--- a/.github/workflows/codex-runner.yml
+++ b/.github/workflows/codex-runner.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   run:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     env:
       SLEEP_SECONDS: ${{ vars.SLEEP_SECONDS || 300 }}


### PR DESCRIPTION
## Summary
- ensure codex runner workflow has permissions to create pull requests

## Testing
- `composer ci` *(fails: Allowed memory size of 134217728 bytes exhausted)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dd86ce288322805f977a27dece2d