### PR TITLE
fix: autostash rebase in Codex task runner

### DIFF
--- a/scripts/run_codex_task.sh
+++ b/scripts/run_codex_task.sh
@@ -27,8 +27,8 @@ else
   git checkout -b "$BRANCH" "origin/$BASE_BRANCH"
 fi
 
-# Rebase on top of latest base branch
-git rebase "origin/$BASE_BRANCH"
+# Rebase on top of latest base branch (autostash to handle local changes)
+git rebase --autostash "origin/$BASE_BRANCH"
 
 CODEX_BIN="${CODEX_CMD:-codex}"
 CODEX_STATUS=0


### PR DESCRIPTION
## Summary
- ensure `run_codex_task.sh` rebases with `--autostash` to handle local edits

## Testing
- `composer lint:php`
- `composer stan`
- `composer test`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `CODEX_DRY_RUN=1 scripts/run_codex_task.sh 1 "Test" 1 work`


------
https://chatgpt.com/codex/tasks/task_e_68a1e6823c908322ab6f53f8f895b3e7