### PR TITLE
fix: use codex-cli in codex-runner workflow

### DIFF
--- a/.github/workflows/codex-runner.yml
+++ b/.github/workflows/codex-runner.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Install Codex CLI
         run: |
           pipx install codex-cli
-          codex --version
+          codex-cli --version
+          echo "CODEX_CMD=codex-cli" >> "$GITHUB_ENV"
 
       - name: Initialize status
         run: python scripts/status.py --init


### PR DESCRIPTION
## Summary
- ensure codex-runner workflow uses codex-cli binary

## Testing
- `composer lint:php`
- `composer stan`
- `composer test`
- `./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a20804eda48322bf96f4bc1e1dd33f