### PR TITLE
chore: ignore Codex runner artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ phpstan.neon
 
 # Task status lock file
 /.task_status.lock
+
+# Codex runner artifacts
+/.task_status.json
+/task.json
+
 # Python artifacts
 __pycache__/
 *.pyc


### PR DESCRIPTION
## Summary
- ignore Codex runner task files

## Testing
- `composer lint:php`
- `composer stan`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a2156357f4832283209e59aa5bbe49