### PR TITLE
feat: import block styles for home components

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -7,5 +7,7 @@ import './bootstrap.js';
  */
 import './styles/app.css';
 import './styles/utilities.css';
+import './styles/blocks/carousel.css';
+import './styles/blocks/groomer-card.css';
 
 console.log('This log comes from assets/app.js - welcome to AssetMapper! 🎉');

--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -1,5 +1,3 @@
-@import "./blocks/carousel.css";
-@import "./blocks/groomer-card.css";
 
 /* Block: hero */
 .hero {

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -5,6 +5,8 @@
     <link rel="stylesheet" href="{{ asset('styles/forms.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/blocks/search.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/blocks/how-it-works.css') }}">
+    <link rel="stylesheet" href="{{ asset('styles/blocks/carousel.css') }}">
+    <link rel="stylesheet" href="{{ asset('styles/blocks/groomer-card.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/home.css') }}">
     <link rel="stylesheet" href="{{ asset('css/components/button.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/blocks/hero.css') }}">


### PR DESCRIPTION
## Summary
- load carousel and groomer card block styles in the main asset bundle
- drop CSS imports from `home.css` and link blocks directly in home template

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `APP_ENV=test php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68a4cc2dbdb88322925be83dfb606aa0