### PR TITLE
fix: unify copy across templates

### DIFF
--- a/templates/home/partials/_cta_banner.html.twig
+++ b/templates/home/partials/_cta_banner.html.twig
@@ -1,5 +1,5 @@
 <section class="cta-banner">
-    <h2 class="cta-banner__heading">Get started</h2>
-    <a href="#search-form" class="cta-banner__link cta-banner__link--owners btn btn--accent">Find a Groomer</a>
-    <a href="/register?role=groomer" class="cta-banner__link cta-banner__link--groomers btn btn--accent">Join as Groomer</a>
+    <h2 class="cta-banner__heading">{{ 'Get Started'|trans }}</h2>
+    <a href="#search-form" class="cta-banner__link cta-banner__link--owners btn btn--accent">{{ 'Find a Groomer'|trans }}</a>
+    <a href="/register?role=groomer" class="cta-banner__link cta-banner__link--groomers btn btn--accent">{{ 'List Your Business'|trans }}</a>
 </section>

--- a/templates/home/partials/_hero.html.twig
+++ b/templates/home/partials/_hero.html.twig
@@ -1,20 +1,20 @@
 <section class="hero">
     <div class="hero__card">
         <div class="hero__content">
-            <h1>Book mobile pet grooming in minutes — trusted local professionals.</h1>
+            <h1>{{ 'Book mobile pet grooming in minutes — trusted local professionals.'|trans }}</h1>
         </div>
         <form id="search-form" class="hero__form" method="get" action="/search" role="search">
             <div class="hero__field hero__field--city">
-                <label for="city">Where is your pet?</label>
-                <input class="hero__input" type="text" id="city" name="city" list="city-list" placeholder="City or ZIP" required>
-                <datalist id="city-list">
+                <label for="city">{{ 'Where is your pet?'|trans }}</label>
+                <input class="hero__input" type="text" id="city" name="city" list="city-list" placeholder="{{ 'City or ZIP'|trans }}" required>
+            <datalist id="city-list">
                     {% for city in cities %}
                         <option value="{{ city.slug }}">{{ city.name }}</option>
                     {% endfor %}
                 </datalist>
             </div>
             <div class="hero__field hero__field--service">
-                <span class="hero__label">Service</span>
+                <span class="hero__label">{{ 'Service'|trans }}</span>
                 <div class="hero__services">
                     {% for service in services %}
                         <button type="button" class="hero__service" data-value="{{ service.slug }}" aria-label="{{ service.name }}" aria-pressed="false">
@@ -25,10 +25,10 @@
             </div>
             <input type="hidden" name="service" id="service">
             <button class="hero__submit search-form__button btn btn--accent" type="submit" id="search-submit">
-                {{ ctaLinks.find.label }}
+                {{ ctaLinks.find.label|trans }}
             </button>
         </form>
-        <a href="{{ ctaLinks.list.url }}" class="hero__cta-link btn btn--accent">{{ ctaLinks.list.label }}</a>
+        <a href="{{ ctaLinks.list.url }}" class="hero__cta-link btn btn--accent">{{ ctaLinks.list.label|trans }}</a>
     </div>
 </section>
 

--- a/templates/home/partials/_how_it_works.html.twig
+++ b/templates/home/partials/_how_it_works.html.twig
@@ -1,20 +1,20 @@
 <section id="how-it-works" class="how-it-works reveal-on-scroll">
-    <h2>How It Works</h2>
+    <h2>{{ 'How It Works'|trans }}</h2>
     <div class="how-it-works__cards">
-        <a href="#search-form" class="how-it-works__card" aria-label="Browse vetted groomers in your area.">
+        <a href="#search-form" class="how-it-works__card" aria-label="{{ 'Browse vetted groomers in your area.'|trans }}">
             <img src="{{ asset('assets/illustrations/search.svg') }}" alt="" aria-hidden="true" width="80" height="80" loading="lazy" decoding="async">
-            <h3>Search</h3>
-            <p>Browse vetted groomers in your area.</p>
+            <h3>{{ 'Search'|trans }}</h3>
+            <p>{{ 'Browse vetted groomers in your area.'|trans }}</p>
         </a>
-        <a href="/blog/how-to-book" class="how-it-works__card" aria-label="Choose a time that fits your schedule.">
+        <a href="/blog/how-to-book" class="how-it-works__card" aria-label="{{ 'Choose a time that fits your schedule.'|trans }}">
             <img src="{{ asset('assets/illustrations/calendar.svg') }}" alt="" aria-hidden="true" width="80" height="80" loading="lazy" decoding="async">
-            <h3>Book</h3>
-            <p>Choose a time that fits your schedule.</p>
+            <h3>{{ 'Book'|trans }}</h3>
+            <p>{{ 'Choose a time that fits your schedule.'|trans }}</p>
         </a>
-        <a href="#featured-groomers" class="how-it-works__card" aria-label="Your pet returns fresh, happy, and healthy.">
+        <a href="#featured-groomers" class="how-it-works__card" aria-label="{{ 'Your pet returns fresh, happy, and healthy.'|trans }}">
             <img src="{{ asset('assets/illustrations/paw.svg') }}" alt="" aria-hidden="true" width="80" height="80" loading="lazy" decoding="async">
-            <h3>Relax</h3>
-            <p>Your pet returns fresh, happy, and healthy.</p>
+            <h3>{{ 'Relax'|trans }}</h3>
+            <p>{{ 'Your pet returns fresh, happy, and healthy.'|trans }}</p>
         </a>
     </div>
 </section>

--- a/templates/partials/_footer.html.twig
+++ b/templates/partials/_footer.html.twig
@@ -2,7 +2,7 @@
   <div class="footer-top">
     <div class="footer-brand">
       <a href="{{ path('app_homepage') }}" class="footer-logo">CleanWhiskers</a>
-      <p class="footer-tagline">Find trusted pet care near you.</p>
+      <p class="footer-tagline">{{ 'Find trusted pet groomers near you.'|trans }}</p>
     </div>
     <nav class="footer-nav" aria-label="Footer">
       <ul>
@@ -18,8 +18,8 @@
       </ul>
     </nav>
     <div class="footer-trust">
-      <span class="trust-seal trust-seal--ssl">SSL Secured</span>
-      <span class="trust-seal trust-seal--reviews">Verified Reviews</span>
+      <span class="trust-seal trust-seal--ssl">{{ 'SSL Secured'|trans }}</span>
+      <span class="trust-seal trust-seal--reviews">{{ 'Verified Reviews'|trans }}</span>
     </div>
     <nav class="footer-social" aria-label="Social media">
       <ul>
@@ -29,13 +29,13 @@
       </ul>
     </nav>
     <form id="footer-search" class="footer-search" method="get" action="{{ path('app_search_redirect') }}" role="search">
-      <label for="footer-city" class="sr-only">Search by city</label>
-      <input type="text" id="footer-city" name="city" list="city-list" placeholder="City or ZIP" required>
-      <button type="submit">Search</button>
+      <label for="footer-city" class="sr-only">{{ 'Search by city'|trans }}</label>
+      <input type="text" id="footer-city" name="city" list="city-list" placeholder="{{ 'City or ZIP'|trans }}" required>
+      <button type="submit">{{ 'Search'|trans }}</button>
     </form>
   </div>
   <div class="footer-bottom">
-    <a href="#top" class="back-to-top">Back to top</a>
+    <a href="#top" class="back-to-top">{{ 'Back to top'|trans }}</a>
     <p>&copy; {{ 'now'|date('Y') }} CleanWhiskers</p>
   </div>
 </footer>

--- a/templates/partials/_header.html.twig
+++ b/templates/partials/_header.html.twig
@@ -1,19 +1,19 @@
 {% set currentRoute = app.request.attributes.get('_route') %}
 <header class="header">
   <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
-    <span class="sr-only">Menu</span>
+    <span class="sr-only">{{ 'Menu'|trans }}</span>
     <span class="hamburger" aria-hidden="true"></span>
   </button>
-  <a href="{{ path('app_search_redirect') }}" class="header__cta header__cta--mobile header__cta--primary">Find a Groomer</a>
+  <a href="{{ path('app_search_redirect') }}" class="header__cta header__cta--mobile header__cta--primary">{{ 'Find a Groomer'|trans }}</a>
   <nav id="primary-nav" class="header__nav" aria-label="Primary">
     <ul class="nav--desktop">
-      <li><a class="header__cta header__cta--primary" href="{{ path('app_search_redirect') }}">Find a Groomer</a></li>
-      <li><a class="header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">List Your Business</a></li>
-      <li><a href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>Blog</a></li>
+      <li><a class="header__cta header__cta--primary" href="{{ path('app_search_redirect') }}">{{ 'Find a Groomer'|trans }}</a></li>
+      <li><a class="header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">{{ 'List Your Business'|trans }}</a></li>
+      <li><a href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>{{ 'Blog'|trans }}</a></li>
     </ul>
     <ul class="nav--mobile">
-      <li><a class="header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">List Your Business</a></li>
-      <li><a href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>Blog</a></li>
+      <li><a class="header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">{{ 'List Your Business'|trans }}</a></li>
+      <li><a href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>{{ 'Blog'|trans }}</a></li>
     </ul>
   </nav>
 </header>

--- a/tests/Twig/CopyConsistencyTest.php
+++ b/tests/Twig/CopyConsistencyTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Twig;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class CopyConsistencyTest extends KernelTestCase
+{
+    public function testCopyIsConsistentAcrossTemplates(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        $twig = $container->get('twig');
+
+        // Header
+        $requestStack = $container->get('request_stack');
+        $request = new Request();
+        $request->attributes->set('_route', 'app_homepage');
+        $requestStack->push($request);
+        $header = $twig->render('partials/_header.html.twig');
+        self::assertStringContainsString('Find a Groomer', $header);
+        self::assertStringContainsString('List Your Business', $header);
+        self::assertStringNotContainsString('Join as Groomer', $header);
+
+        // Hero
+        $hero = $twig->render('home/partials/_hero.html.twig', [
+            'ctaLinks' => [
+                'find' => ['label' => 'Find a Groomer'],
+                'list' => ['label' => 'List Your Business', 'url' => '/register'],
+            ],
+            'cities' => [
+                ['slug' => 'sofia', 'name' => 'Sofia'],
+            ],
+            'services' => [
+                ['slug' => 'grooming', 'name' => 'Grooming'],
+            ],
+        ]);
+        self::assertStringContainsString('Book mobile pet grooming in minutes — trusted local professionals.', $hero);
+        self::assertStringContainsString('List Your Business', $hero);
+        self::assertStringNotContainsString('Join as Groomer', $hero);
+
+        // CTA banner
+        $banner = $twig->render('home/partials/_cta_banner.html.twig');
+        self::assertStringContainsString('Get Started', $banner);
+        self::assertStringContainsString('Find a Groomer', $banner);
+        self::assertStringContainsString('List Your Business', $banner);
+
+        // Footer
+        $footer = $twig->render('partials/_footer.html.twig');
+        self::assertStringContainsString('Find trusted pet groomers near you.', $footer);
+    }
+}


### PR DESCRIPTION
## Summary
- harmonize CTA and hero copy, add translation filters
- update footer tagline and trust text
- add test ensuring copy consistency

## Testing
- `make setup` (fails: No rule to make target 'setup')
- `make test -k` (fails: No rule to make target 'test')
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a4cf03df108322a00d6c33c2937cce