### PR TITLE
Expand seed data with multiple groomers and cities

### DIFF
--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -17,18 +17,17 @@ class AppFixtures extends Fixture
 {
     public function load(ObjectManager $manager): void
     {
-        $city = new City('Sofia');
-        $manager->persist($city);
+        $cityNames = ['Sofia', 'Plovdiv', 'Varna', 'Burgas', 'Ruse'];
+        $cities = [];
+        foreach ($cityNames as $name) {
+            $city = new City($name);
+            $manager->persist($city);
+            $cities[$name] = $city;
+        }
 
         $service = (new Service())
             ->setName('Mobile Dog Grooming');
         $manager->persist($service);
-
-        $groomerUser = (new User())
-            ->setEmail('groomer@example.com')
-            ->setPassword('hash')
-            ->setRoles([User::ROLE_GROOMER]);
-        $manager->persist($groomerUser);
 
         $petOwner = (new User())
             ->setEmail('owner@example.com')
@@ -36,21 +35,29 @@ class AppFixtures extends Fixture
             ->setRoles([User::ROLE_PET_OWNER]);
         $manager->persist($petOwner);
 
-        $profile = new GroomerProfile(
-            $groomerUser,
-            $city,
-            'Sofia Mobile Groomer',
-            'Professional mobile grooming services.',
-        );
-        $profile->addService($service);
-        $manager->persist($profile);
+        foreach ($cityNames as $index => $name) {
+            $groomerUser = (new User())
+                ->setEmail(sprintf('groomer%d@example.com', $index + 1))
+                ->setPassword('hash')
+                ->setRoles([User::ROLE_GROOMER]);
+            $manager->persist($groomerUser);
 
-        $review = new Review($profile, $petOwner, 5, 'Excellent service!');
-        $manager->persist($review);
+            $profile = new GroomerProfile(
+                $groomerUser,
+                $cities[$name],
+                sprintf('%s Mobile Groomer', $name),
+                'Professional mobile grooming services.',
+            );
+            $profile->addService($service);
+            $manager->persist($profile);
 
-        $booking = (new BookingRequest($profile, $petOwner))
-            ->setService($service);
-        $manager->persist($booking);
+            $review = new Review($profile, $petOwner, 5, 'Excellent service!');
+            $manager->persist($review);
+
+            $booking = (new BookingRequest($profile, $petOwner))
+                ->setService($service);
+            $manager->persist($booking);
+        }
 
         $manager->flush();
     }

--- a/src/Seed/SeedDataset.php
+++ b/src/Seed/SeedDataset.php
@@ -39,19 +39,55 @@ final class SeedDataset
         return new self(
             cities: [
                 ['name' => 'Sofia'],
+                ['name' => 'Plovdiv'],
+                ['name' => 'Varna'],
+                ['name' => 'Burgas'],
+                ['name' => 'Ruse'],
             ],
             services: [
                 ['name' => 'Mobile Dog Grooming'],
             ],
             users: [
-                ['email' => 'groomer@example.com', 'password' => 'hash', 'roles' => [User::ROLE_GROOMER]],
+                ['email' => 'groomer1@example.com', 'password' => 'hash', 'roles' => [User::ROLE_GROOMER]],
+                ['email' => 'groomer2@example.com', 'password' => 'hash', 'roles' => [User::ROLE_GROOMER]],
+                ['email' => 'groomer3@example.com', 'password' => 'hash', 'roles' => [User::ROLE_GROOMER]],
+                ['email' => 'groomer4@example.com', 'password' => 'hash', 'roles' => [User::ROLE_GROOMER]],
+                ['email' => 'groomer5@example.com', 'password' => 'hash', 'roles' => [User::ROLE_GROOMER]],
                 ['email' => 'owner@example.com', 'password' => 'hash', 'roles' => [User::ROLE_PET_OWNER]],
             ],
             groomerProfiles: [
                 [
-                    'userEmail' => 'groomer@example.com',
+                    'userEmail' => 'groomer1@example.com',
                     'city' => 'Sofia',
                     'businessName' => 'Sofia Mobile Groomer',
+                    'about' => 'Professional mobile grooming services.',
+                    'services' => ['Mobile Dog Grooming'],
+                ],
+                [
+                    'userEmail' => 'groomer2@example.com',
+                    'city' => 'Plovdiv',
+                    'businessName' => 'Plovdiv Mobile Groomer',
+                    'about' => 'Professional mobile grooming services.',
+                    'services' => ['Mobile Dog Grooming'],
+                ],
+                [
+                    'userEmail' => 'groomer3@example.com',
+                    'city' => 'Varna',
+                    'businessName' => 'Varna Mobile Groomer',
+                    'about' => 'Professional mobile grooming services.',
+                    'services' => ['Mobile Dog Grooming'],
+                ],
+                [
+                    'userEmail' => 'groomer4@example.com',
+                    'city' => 'Burgas',
+                    'businessName' => 'Burgas Mobile Groomer',
+                    'about' => 'Professional mobile grooming services.',
+                    'services' => ['Mobile Dog Grooming'],
+                ],
+                [
+                    'userEmail' => 'groomer5@example.com',
+                    'city' => 'Ruse',
+                    'businessName' => 'Ruse Mobile Groomer',
                     'about' => 'Professional mobile grooming services.',
                     'services' => ['Mobile Dog Grooming'],
                 ],

--- a/tests/Unit/Command/SeedBootstrapCommandOptionsTest.php
+++ b/tests/Unit/Command/SeedBootstrapCommandOptionsTest.php
@@ -13,6 +13,7 @@ use App\Repository\ServiceRepository;
 use App\Repository\UserRepository;
 use App\Seed\Seeder;
 use App\Seed\SeedPackProvider;
+use App\Seed\SeedDataset;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -79,7 +80,8 @@ final class SeedBootstrapCommandOptionsTest extends TestCase
         self::assertSame(SeedBootstrapCommand::SUCCESS, $status);
         $display = $tester->getDisplay();
         self::assertStringContainsString('Dry run', $display);
-        self::assertStringContainsString('Cities: 1', $display);
+        $cityCount = count(SeedDataset::default()->cities);
+        self::assertStringContainsString(sprintf('Cities: %d', $cityCount), $display);
     }
 
     private function kernelMock(string $env): KernelInterface

--- a/tests/Unit/Seed/SeedDatasetTest.php
+++ b/tests/Unit/Seed/SeedDatasetTest.php
@@ -16,15 +16,16 @@ final class SeedDatasetTest extends TestCase
 
         self::assertNotEmpty($dataset->cities);
         self::assertSame('Sofia', $dataset->cities[0]['name']);
+        self::assertGreaterThanOrEqual(5, count($dataset->cities));
 
         self::assertNotEmpty($dataset->services);
         self::assertSame('Mobile Dog Grooming', $dataset->services[0]['name']);
 
-        self::assertCount(2, $dataset->users);
-        self::assertSame('groomer@example.com', $dataset->users[0]['email']);
+        self::assertGreaterThanOrEqual(6, count($dataset->users));
+        self::assertSame('groomer1@example.com', $dataset->users[0]['email']);
         self::assertContains(User::ROLE_GROOMER, $dataset->users[0]['roles']);
 
-        self::assertCount(1, $dataset->groomerProfiles);
+        self::assertGreaterThanOrEqual(5, count($dataset->groomerProfiles));
         self::assertSame('Sofia Mobile Groomer', $dataset->groomerProfiles[0]['businessName']);
     }
 }

--- a/tests/Unit/Seed/SeederIdempotencyTest.php
+++ b/tests/Unit/Seed/SeederIdempotencyTest.php
@@ -39,11 +39,17 @@ final class SeederIdempotencyTest extends KernelTestCase
         $this->seeder->seed($dataset, true);
         $this->seeder->seed($dataset, true);
 
-        self::assertSame(1, $this->em->getRepository(City::class)->count([]));
-        self::assertSame(1, $this->em->getRepository(Service::class)->count([]));
-        self::assertSame(2, $this->em->getRepository(User::class)->count([]));
-        self::assertSame(1, $this->em->getRepository(GroomerProfile::class)->count([]));
-        self::assertSame(1, $this->em->getRepository(Review::class)->count([]));
-        self::assertSame(1, $this->em->getRepository(BookingRequest::class)->count([]));
+        $expectedCityCount = count($dataset->cities);
+        $expectedServiceCount = count($dataset->services);
+        $expectedUserCount = count($dataset->users);
+        $expectedProfileCount = count($dataset->groomerProfiles);
+        $expectedSampleCount = $expectedProfileCount;
+
+        self::assertSame($expectedCityCount, $this->em->getRepository(City::class)->count([]));
+        self::assertSame($expectedServiceCount, $this->em->getRepository(Service::class)->count([]));
+        self::assertSame($expectedUserCount, $this->em->getRepository(User::class)->count([]));
+        self::assertSame($expectedProfileCount, $this->em->getRepository(GroomerProfile::class)->count([]));
+        self::assertSame($expectedSampleCount, $this->em->getRepository(Review::class)->count([]));
+        self::assertSame($expectedSampleCount, $this->em->getRepository(BookingRequest::class)->count([]));
     }
 }


### PR DESCRIPTION
## Summary
- add five cities and groomer profiles to default seed dataset
- update fixtures to seed multiple groomers and cities
- adjust unit tests for expanded seed data and dynamic counts

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` (fails: Allowed memory size exhausted)
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `composer audit` (fails: curl error 56 while downloading https://packagist.org/api/security-advisories/: CONNECT tunnel failed, response 403)

------
https://chatgpt.com/codex/tasks/task_e_68a4d0846dd883228cc1556ff306a994