### PR TITLE
fix: update hero asset paths

### DIFF
--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="{{ asset('styles/blocks/groomer-card.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/home.css') }}">
     <link rel="stylesheet" href="{{ asset('css/components/button.css') }}">
-    <link rel="stylesheet" href="{{ asset('styles/blocks/hero.css') }}">
+    <link rel="stylesheet" href="{{ asset('assets/styles/blocks/hero.css') }}">
     <link rel="stylesheet" href="{{ asset('css/components/card-groomer.css') }}">
     <link rel="stylesheet" href="{{ asset('css/sections/popular-cities.css') }}">
     <link rel="stylesheet" href="{{ asset('css/sections/popular-services.css') }}">
@@ -21,7 +21,7 @@
     <script type="module" src="{{ asset('js/sticky-search.js') }}" defer></script>
     <script type="module" src="{{ asset('js/section-reveal.js') }}" defer></script>
     <script src="{{ asset('js/cta-button.js') }}" defer></script>
-    <script src="{{ asset('js/hero-search.js') }}" defer></script>
+    <script type="module" src="{{ asset('assets/js/hero-search.js') }}"></script>
     <script src="{{ asset('js/lazy-images.js') }}" defer></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- update home template to load hero styles and script via Asset Mapper paths

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*
- `yarn encore prod` *(fails: package not in lockfile; run "yarn install")*
- `yarn install` *(fails: RequestError: Bad response: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a56b5e22408322939bd6f12a67f792