### PR TITLE
feat: redesign desktop navigation menu

### DIFF
--- a/assets/styles/blocks/header.css
+++ b/assets/styles/blocks/header.css
@@ -9,24 +9,20 @@
     position: relative;
 }
 
-.header__cta {
-    text-decoration: none;
-    margin-left: var(--space-2);
-}
+.header__cta { text-decoration: none; }
 
-.nav--desktop,
-.nav--mobile {
+.header__menu {
     list-style: none;
     margin: 0;
     padding: 0;
 }
 
-.nav--desktop {
+.header__menu--desktop {
     display: none;
-    gap: var(--space-2);
+    gap: var(--space-4);
 }
 
-.nav--mobile {
+.header__menu--mobile {
     display: none;
     position: absolute;
     right: 0;
@@ -36,8 +32,37 @@
     box-shadow: var(--shadow-sm);
 }
 
-body[data-menu-open="true"] .nav--mobile {
+body[data-menu-open="true"] .header__menu--mobile {
     display: block;
+}
+
+.header__item {}
+
+.header__link {
+    display: block;
+    text-decoration: none;
+    font-size: var(--fs-base);
+    font-weight: 500;
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-sm);
+    color: var(--color-text);
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.header__link:hover,
+.header__link:focus {
+    background-color: var(--color-pastel);
+}
+
+.header__cta--primary {
+    background-color: var(--color-accent);
+    color: var(--color-text);
+    font-weight: 600;
+}
+
+.header__cta--secondary {
+    border: 1px solid var(--color-text);
+    font-weight: 600;
 }
 
 .header__cta--mobile {
@@ -45,13 +70,12 @@ body[data-menu-open="true"] .nav--mobile {
 }
 
 @media (min-width: 768px) {
-    #nav-toggle {
-        display: none;
-    }
-    .nav--desktop {
-        display: flex;
-    }
-    .header__cta--mobile {
-        display: none;
-    }
+    #nav-toggle { display: none; }
+    .header__menu--desktop { display: flex; }
+    .header__cta--mobile { display: none; }
+}
+
+@media (min-width: 1024px) {
+    .header__menu--desktop { gap: var(--space-5); }
+    .header__link { font-size: 1.125rem; }
 }

--- a/templates/partials/_header.html.twig
+++ b/templates/partials/_header.html.twig
@@ -4,16 +4,16 @@
     <span class="sr-only">{{ 'Menu'|trans }}</span>
     <span class="hamburger" aria-hidden="true"></span>
   </button>
-  <a href="{{ path('app_search_redirect') }}" class="header__cta header__cta--mobile header__cta--primary">{{ 'Find a Groomer'|trans }}</a>
+  <a href="{{ path('app_search_redirect') }}" class="header__link header__cta header__cta--mobile header__cta--primary">{{ 'Find a Groomer'|trans }}</a>
   <nav id="primary-nav" class="header__nav" aria-label="Primary">
-    <ul class="nav--desktop">
-      <li><a class="header__cta header__cta--primary" href="{{ path('app_search_redirect') }}">{{ 'Find a Groomer'|trans }}</a></li>
-      <li><a class="header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">{{ 'List Your Business'|trans }}</a></li>
-      <li><a href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>{{ 'Blog'|trans }}</a></li>
+    <ul class="nav--desktop header__menu header__menu--desktop">
+      <li class="header__item"><a class="header__link header__cta header__cta--primary" href="{{ path('app_search_redirect') }}">{{ 'Find a Groomer'|trans }}</a></li>
+      <li class="header__item"><a class="header__link header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">{{ 'List Your Business'|trans }}</a></li>
+      <li class="header__item"><a class="header__link" href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>{{ 'Blog'|trans }}</a></li>
     </ul>
-    <ul class="nav--mobile">
-      <li><a class="header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">{{ 'List Your Business'|trans }}</a></li>
-      <li><a href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>{{ 'Blog'|trans }}</a></li>
+    <ul class="nav--mobile header__menu header__menu--mobile">
+      <li class="header__item"><a class="header__link header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">{{ 'List Your Business'|trans }}</a></li>
+      <li class="header__item"><a class="header__link" href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>{{ 'Blog'|trans }}</a></li>
     </ul>
   </nav>
 </header>


### PR DESCRIPTION
## Summary
- redesign header nav markup with BEM classes and prominent CTA
- modernize header styles for desktop spacing, hover, and responsive typography

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a56df46e6c8322a5e1707e1437b722