### PR TITLE
feat: improve mobile navigation accessibility

### DIFF
--- a/assets/js/nav-toggle.js
+++ b/assets/js/nav-toggle.js
@@ -20,52 +20,61 @@
     }
   }
 
-  function openMenu(doc, nav, toggle) {
+  function openMenu(doc, menu, toggle) {
     doc.body.dataset.menuOpen = 'true';
     doc.body.style.overflow = 'hidden';
     toggle.setAttribute('aria-expanded', 'true');
-    var first = nav.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
+    menu.setAttribute('aria-hidden', 'false');
+    var first = menu.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
     if (first && typeof first.focus === 'function') {
       first.focus();
       doc.activeElement = first;
     }
   }
 
-  function closeMenu(doc, nav, toggle) {
+  function closeMenu(doc, menu, toggle) {
     delete doc.body.dataset.menuOpen;
     doc.body.style.overflow = '';
     toggle.setAttribute('aria-expanded', 'false');
+    menu.setAttribute('aria-hidden', 'true');
   }
 
   function initNavToggle(doc) {
     doc = doc || document;
     var nav = doc.getElementById('primary-nav');
+    var menu = nav ? nav.querySelector('.header__menu--mobile') : null;
     var toggle = doc.getElementById('nav-toggle');
-    if (!nav || !toggle) {
+    if (!menu || !toggle) {
       return;
     }
     var onKeyDown = function (e) {
       if (e.key === 'Escape') {
-        closeMenu(doc, nav, toggle);
+        closeMenu(doc, menu, toggle);
         if (typeof toggle.focus === 'function') {
           toggle.focus();
           doc.activeElement = toggle;
         }
       } else {
-        focusTrap(doc, nav, e);
+        focusTrap(doc, menu, e);
       }
     };
     var onClickOutside = function (e) {
-      if (!nav.contains(e.target) && e.target !== toggle) {
-        closeMenu(doc, nav, toggle);
+      if (!menu.contains(e.target) && e.target !== toggle) {
+        closeMenu(doc, menu, toggle);
       }
     };
     toggle.addEventListener('click', function () {
-      if (doc.body.dataset.menuOpen === 'true') {
-        closeMenu(doc, nav, toggle);
+      var expanded = toggle.getAttribute('aria-expanded') === 'true';
+      if (expanded) {
+        closeMenu(doc, menu, toggle);
       } else {
-        openMenu(doc, nav, toggle);
+        openMenu(doc, menu, toggle);
       }
+    });
+    menu.querySelectorAll('a').forEach(function (link) {
+      link.addEventListener('click', function () {
+        closeMenu(doc, menu, toggle);
+      });
     });
     doc.addEventListener('keydown', onKeyDown);
     doc.addEventListener('click', onClickOutside);

--- a/assets/styles/blocks/header.css
+++ b/assets/styles/blocks/header.css
@@ -23,17 +23,25 @@
 }
 
 .header__menu--mobile {
-    display: none;
-    position: absolute;
-    right: 0;
-    top: 100%;
+    position: fixed;
+    inset: 0;
     background: var(--color-cream);
-    padding: var(--space-3);
+    padding: var(--space-6) var(--space-4);
     box-shadow: var(--shadow-sm);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    transform: translateX(100%);
+    opacity: 0;
+    pointer-events: none;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+    z-index: 1000;
 }
 
 body[data-menu-open="true"] .header__menu--mobile {
-    display: block;
+    transform: translateX(0);
+    opacity: 1;
+    pointer-events: auto;
 }
 
 .header__item {}
@@ -73,6 +81,7 @@ body[data-menu-open="true"] .header__menu--mobile {
     #nav-toggle { display: none; }
     .header__menu--desktop { display: flex; }
     .header__cta--mobile { display: none; }
+    .header__menu--mobile { display: none; }
 }
 
 @media (min-width: 1024px) {

--- a/templates/partials/_header.html.twig
+++ b/templates/partials/_header.html.twig
@@ -1,6 +1,6 @@
 {% set currentRoute = app.request.attributes.get('_route') %}
 <header class="header">
-  <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-controls="primary-nav">
+  <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" type="button">
     <span class="sr-only">{{ 'Menu'|trans }}</span>
     <span class="hamburger" aria-hidden="true"></span>
   </button>
@@ -11,7 +11,7 @@
       <li class="header__item"><a class="header__link header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">{{ 'List Your Business'|trans }}</a></li>
       <li class="header__item"><a class="header__link" href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>{{ 'Blog'|trans }}</a></li>
     </ul>
-    <ul class="nav--mobile header__menu header__menu--mobile">
+    <ul class="nav--mobile header__menu header__menu--mobile" aria-hidden="true">
       <li class="header__item"><a class="header__link header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">{{ 'List Your Business'|trans }}</a></li>
       <li class="header__item"><a class="header__link" href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>{{ 'Blog'|trans }}</a></li>
     </ul>


### PR DESCRIPTION
## Summary
- animate mobile menu as slide-in panel and prevent page scrolling when open
- improve nav toggle accessibility and close menu on link click
- mark mobile menu hidden by default in header template

## Testing
- `make setup && make test -k` *(fails: No rule to make target 'setup')*
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*

------
https://chatgpt.com/codex/tasks/task_e_68a56fef0c84832285610de3f40ae753