### PR TITLE
refactor: unify desktop and mobile navigation

### DIFF
--- a/assets/js/nav-toggle.js
+++ b/assets/js/nav-toggle.js
@@ -42,11 +42,27 @@
   function initNavToggle(doc) {
     doc = doc || document;
     var nav = doc.getElementById('primary-nav');
-    var menu = nav ? nav.querySelector('.header__menu--mobile') : null;
+    var menu = nav ? nav.querySelector('.nav') : null;
     var toggle = doc.getElementById('nav-toggle');
     if (!menu || !toggle) {
       return;
     }
+    var mq = global.matchMedia('(min-width: 768px)');
+    var syncMenu = function (e) {
+      if (e.matches) {
+        menu.removeAttribute('aria-hidden');
+        doc.body.style.overflow = '';
+        toggle.setAttribute('aria-expanded', 'false');
+      } else {
+        closeMenu(doc, menu, toggle);
+      }
+    };
+    if (mq.addEventListener) {
+      mq.addEventListener('change', syncMenu);
+    } else if (mq.addListener) {
+      mq.addListener(syncMenu);
+    }
+    syncMenu(mq);
     var onKeyDown = function (e) {
       if (e.key === 'Escape') {
         closeMenu(doc, menu, toggle);

--- a/assets/styles/blocks/header.css
+++ b/assets/styles/blocks/header.css
@@ -10,19 +10,11 @@
 }
 
 .header__cta { text-decoration: none; }
-
-.header__menu {
+ 
+.nav {
     list-style: none;
     margin: 0;
     padding: 0;
-}
-
-.header__menu--desktop {
-    display: none;
-    gap: var(--space-4);
-}
-
-.header__menu--mobile {
     position: fixed;
     inset: 0;
     background: var(--color-cream);
@@ -38,15 +30,17 @@
     z-index: 1000;
 }
 
-body[data-menu-open="true"] .header__menu--mobile {
+body[data-menu-open="true"] .nav {
     transform: translateX(0);
     opacity: 1;
     pointer-events: auto;
 }
 
-.header__item {}
+.nav__item {}
 
-.header__link {
+.nav__item--desktop { display: none; }
+
+.nav__link {
     display: block;
     text-decoration: none;
     font-size: var(--fs-base);
@@ -57,8 +51,8 @@ body[data-menu-open="true"] .header__menu--mobile {
     transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-.header__link:hover,
-.header__link:focus {
+.nav__link:hover,
+.nav__link:focus {
     background-color: var(--color-pastel);
 }
 
@@ -79,12 +73,22 @@ body[data-menu-open="true"] .header__menu--mobile {
 
 @media (min-width: 768px) {
     #nav-toggle { display: none; }
-    .header__menu--desktop { display: flex; }
+    .nav {
+        position: static;
+        background: none;
+        padding: 0;
+        box-shadow: none;
+        flex-direction: row;
+        gap: var(--space-4);
+        transform: none;
+        opacity: 1;
+        pointer-events: auto;
+    }
     .header__cta--mobile { display: none; }
-    .header__menu--mobile { display: none; }
+    .nav__item--desktop { display: block; }
 }
 
 @media (min-width: 1024px) {
-    .header__menu--desktop { gap: var(--space-5); }
-    .header__link { font-size: 1.125rem; }
+    .nav { gap: var(--space-5); }
+    .nav__link { font-size: 1.125rem; }
 }

--- a/templates/partials/_header.html.twig
+++ b/templates/partials/_header.html.twig
@@ -4,16 +4,12 @@
     <span class="sr-only">{{ 'Menu'|trans }}</span>
     <span class="hamburger" aria-hidden="true"></span>
   </button>
-  <a href="{{ path('app_search_redirect') }}" class="header__link header__cta header__cta--mobile header__cta--primary">{{ 'Find a Groomer'|trans }}</a>
+  <a href="{{ path('app_search_redirect') }}" class="nav__link header__cta header__cta--mobile header__cta--primary">{{ 'Find a Groomer'|trans }}</a>
   <nav id="primary-nav" class="header__nav" aria-label="Primary">
-    <ul class="nav--desktop header__menu header__menu--desktop">
-      <li class="header__item"><a class="header__link header__cta header__cta--primary" href="{{ path('app_search_redirect') }}">{{ 'Find a Groomer'|trans }}</a></li>
-      <li class="header__item"><a class="header__link header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">{{ 'List Your Business'|trans }}</a></li>
-      <li class="header__item"><a class="header__link" href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>{{ 'Blog'|trans }}</a></li>
-    </ul>
-    <ul class="nav--mobile header__menu header__menu--mobile" aria-hidden="true">
-      <li class="header__item"><a class="header__link header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">{{ 'List Your Business'|trans }}</a></li>
-      <li class="header__item"><a class="header__link" href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>{{ 'Blog'|trans }}</a></li>
+    <ul class="nav">
+      <li class="nav__item nav__item--desktop"><a class="nav__link header__cta header__cta--primary" href="{{ path('app_search_redirect') }}">{{ 'Find a Groomer'|trans }}</a></li>
+      <li class="nav__item"><a class="nav__link header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">{{ 'List Your Business'|trans }}</a></li>
+      <li class="nav__item"><a class="nav__link" href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>{{ 'Blog'|trans }}</a></li>
     </ul>
   </nav>
 </header>

--- a/tests/E2E/HeaderNavigationTest.php
+++ b/tests/E2E/HeaderNavigationTest.php
@@ -30,9 +30,9 @@ final class HeaderNavigationTest extends PantherTestCase
         $client->manage()->window()->setSize(new WebDriverDimension(1280, 800));
         $client->request('GET', '/');
 
-        self::assertSelectorTextContains('.nav--desktop a[href="/search"]', 'Find a Groomer');
-        self::assertSelectorTextContains('.nav--desktop a[href="/register?role=groomer"]', 'List Your Business');
-        self::assertSelectorTextContains('.nav--desktop a[href="/blog"]', 'Blog');
+        self::assertSelectorTextContains('.nav a[href="/search"]', 'Find a Groomer');
+        self::assertSelectorTextContains('.nav a[href="/register?role=groomer"]', 'List Your Business');
+        self::assertSelectorTextContains('.nav a[href="/blog"]', 'Blog');
         $display = $client->executeScript('return window.getComputedStyle(document.getElementById("nav-toggle")).display;');
         self::assertSame('none', $display);
     }


### PR DESCRIPTION
## Summary
- merge desktop and mobile menus into a single semantic `<ul>`
- consolidate header styles with unified nav classes
- adjust nav toggle script and tests for new structure

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --testdox`
- `make setup && make test -k` *(fails: No rule to make target 'setup')*


------
https://chatgpt.com/codex/tasks/task_e_68a57322cf7c832284beac08f14dfe21