### PR TITLE
feat: improve navigation accessibility

### DIFF
--- a/assets/js/nav-toggle.js
+++ b/assets/js/nav-toggle.js
@@ -1,6 +1,6 @@
 (function (global) {
   function focusTrap(doc, nav, e) {
-    if (e.key !== 'Tab') {
+    if (e.key !== 'Tab' || doc.body.dataset.menuOpen !== 'true') {
       return;
     }
     var focusable = nav.querySelectorAll('a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])');
@@ -37,6 +37,10 @@
     doc.body.style.overflow = '';
     toggle.setAttribute('aria-expanded', 'false');
     menu.setAttribute('aria-hidden', 'true');
+    if (typeof toggle.focus === 'function') {
+      toggle.focus();
+      doc.activeElement = toggle;
+    }
   }
 
   function initNavToggle(doc) {
@@ -66,11 +70,7 @@
     var onKeyDown = function (e) {
       if (e.key === 'Escape') {
         closeMenu(doc, menu, toggle);
-        if (typeof toggle.focus === 'function') {
-          toggle.focus();
-          doc.activeElement = toggle;
-        }
-      } else {
+      } else if (doc.body.dataset.menuOpen === 'true') {
         focusTrap(doc, menu, e);
       }
     };

--- a/templates/partials/_header.html.twig
+++ b/templates/partials/_header.html.twig
@@ -1,12 +1,11 @@
 {% set currentRoute = app.request.attributes.get('_route') %}
 <header class="header">
-  <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" type="button">
-    <span class="sr-only">{{ 'Menu'|trans }}</span>
+  <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="{{ 'Menu'|trans }}" type="button">
     <span class="hamburger" aria-hidden="true"></span>
   </button>
   <a href="{{ path('app_search_redirect') }}" class="nav__link header__cta header__cta--mobile header__cta--primary">{{ 'Find a Groomer'|trans }}</a>
-  <nav id="primary-nav" class="header__nav" aria-label="Primary">
-    <ul class="nav">
+  <nav id="primary-nav" class="header__nav" role="navigation" aria-label="{{ 'Primary'|trans }}">
+    <ul class="nav" aria-hidden="true">
       <li class="nav__item nav__item--desktop"><a class="nav__link header__cta header__cta--primary" href="{{ path('app_search_redirect') }}">{{ 'Find a Groomer'|trans }}</a></li>
       <li class="nav__item"><a class="nav__link header__cta header__cta--secondary" href="{{ path('app_register', {'role': 'groomer'}) }}">{{ 'List Your Business'|trans }}</a></li>
       <li class="nav__item"><a class="nav__link" href="{{ path('app_blog_index') }}" {% if currentRoute starts with 'app_blog' %}aria-current="page"{% endif %}>{{ 'Blog'|trans }}</a></li>

--- a/tests/Frontend/Unit/NavToggleTest.js
+++ b/tests/Frontend/Unit/NavToggleTest.js
@@ -30,6 +30,7 @@ function createLink(doc) {
     querySelector: () => first,
     querySelectorAll: () => [first, last],
     contains: () => false,
+    setAttribute: () => {},
   };
   const toggle = {
     setAttribute: () => {},
@@ -51,7 +52,7 @@ function createLink(doc) {
   const nav = {
     querySelectorAll: () => [first, last],
   };
-
+  doc.body.dataset.menuOpen = 'true';
   doc.activeElement = first;
   const backward = { key: 'Tab', shiftKey: true, preventDefault: function () { this.called = true; }, called: false };
   navToggle.focusTrap(doc, nav, backward);


### PR DESCRIPTION
## Summary
- ensure nav toggle button uses aria-label and restore focus when menu closes
- add explicit navigation roles and hidden state for mobile menu
- trap tab focus only when mobile menu is open

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testsuite Unit --testdox`
- `node tests/Frontend/Unit/NavToggleTest.js`
- `make setup && make test -k` *(fails: No rule to make target 'setup')*

------
https://chatgpt.com/codex/tasks/task_e_68a57523436883229a32a95327c6759e