### PR TITLE
feat: add menu transitions and accessibility

### DIFF
--- a/assets/styles/blocks/header.css
+++ b/assets/styles/blocks/header.css
@@ -27,6 +27,7 @@
     opacity: 0;
     pointer-events: none;
     transition: transform 0.3s ease, opacity 0.3s ease;
+    will-change: transform, opacity;
     z-index: 1000;
 }
 
@@ -52,8 +53,19 @@ body[data-menu-open="true"] .nav {
 }
 
 .nav__link:hover,
-.nav__link:focus {
+.nav__link:focus-visible {
     background-color: var(--color-pastel);
+}
+
+.nav__link:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}
+
+.nav__link[aria-current="page"] {
+    color: var(--color-accent);
+    text-decoration: underline;
+    font-weight: 600;
 }
 
 .header__cta--primary {


### PR DESCRIPTION
## Summary
- improve mobile menu with hardware-accelerated slide/fade transition
- add focus-visible outlines and active link styles for clearer navigation

## Testing
- `make setup && make test -k` *(fails: No rule to make target 'setup')*
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68a57ade26f883228bd79287121c810e