### PR TITLE
fix: correct hero asset paths and prevent 404s

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -223,6 +223,8 @@ Definition of Done (DoD)
 
  Security, perf, and error handling considered
 
+ Static asset links (CSS/JS) verified to point to existing files to prevent 404s
+
  PR template completed
 
 

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="{{ asset('styles/blocks/groomer-card.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/home.css') }}">
     <link rel="stylesheet" href="{{ asset('css/components/button.css') }}">
-    <link rel="stylesheet" href="{{ asset('assets/styles/blocks/hero.css') }}">
+    <link rel="stylesheet" href="{{ asset('styles/blocks/hero.css') }}">
     <link rel="stylesheet" href="{{ asset('css/components/card-groomer.css') }}">
     <link rel="stylesheet" href="{{ asset('css/sections/popular-cities.css') }}">
     <link rel="stylesheet" href="{{ asset('css/sections/popular-services.css') }}">
@@ -21,7 +21,7 @@
     <script type="module" src="{{ asset('js/sticky-search.js') }}" defer></script>
     <script type="module" src="{{ asset('js/section-reveal.js') }}" defer></script>
     <script src="{{ asset('js/cta-button.js') }}" defer></script>
-    <script type="module" src="{{ asset('assets/js/hero-search.js') }}"></script>
+    <script type="module" src="{{ asset('js/hero-search.js') }}"></script>
     <script src="{{ asset('js/lazy-images.js') }}" defer></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- fix home page hero and hero-search asset paths to avoid 404s
- document requirement to verify asset links to existing files in AGENTS

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Script APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox handling the test event returned with error code 255)*


------
https://chatgpt.com/codex/tasks/task_e_68a581e347748322a3384c71503c3f08