### PR TITLE
fix: restore mobile menu toggle

### DIFF
--- a/assets/styles/blocks/header.css
+++ b/assets/styles/blocks/header.css
@@ -5,6 +5,25 @@
     padding: var(--space-3);
 }
 
+#nav-toggle {
+    background: none;
+    border: 0;
+    width: 1.5rem;
+    height: 1.5rem;
+    padding: var(--space-2);
+    cursor: pointer;
+    position: relative;
+    z-index: 1001;
+}
+
+#nav-toggle .hamburger {
+    display: block;
+    width: 100%;
+    height: 2px;
+    background: var(--color-text);
+    box-shadow: 0 6px 0 var(--color-text), 0 12px 0 var(--color-text);
+}
+
 .header__nav {
     position: relative;
 }

--- a/tests/E2E/HeaderNavigationTest.php
+++ b/tests/E2E/HeaderNavigationTest.php
@@ -68,4 +68,30 @@ final class HeaderNavigationTest extends PantherTestCase
         $active = $client->executeScript('return document.activeElement.id');
         self::assertSame('nav-toggle', $active);
     }
+
+    public function testMobileNavigationToggleButtonClosesMenu(): void
+    {
+        $client = self::createPantherClient();
+        $client->manage()->window()->setSize(new WebDriverDimension(375, 667));
+        $client->request('GET', '/');
+
+        $client->executeScript('document.getElementById("nav-toggle").click();');
+        $expanded = $client->executeScript('return document.getElementById("nav-toggle").getAttribute("aria-expanded");');
+        self::assertSame('true', $expanded);
+
+        $idAtPoint = $client->executeScript(
+            'var t=document.getElementById("nav-toggle");'
+            .'var r=t.getBoundingClientRect();'
+            .'return document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2).id;'
+        );
+        self::assertSame('nav-toggle', $idAtPoint);
+
+        $client->executeScript(
+            'var t=document.getElementById("nav-toggle");'
+            .'var r=t.getBoundingClientRect();'
+            .'document.elementFromPoint(r.left + 1, r.top + 1).click();'
+        );
+        $expanded = $client->executeScript('return document.getElementById("nav-toggle").getAttribute("aria-expanded");');
+        self::assertSame('false', $expanded);
+    }
 }

--- a/tests/Frontend/E2E/header.e2e.md
+++ b/tests/Frontend/E2E/header.e2e.md
@@ -10,5 +10,6 @@
 2. Activate the hamburger button.
 3. Ensure body has `data-menu-open="true"` and scrolling is disabled.
 4. Tab through links; focus cycles within the menu.
-5. Press `Escape` to close the menu and verify body no longer has `data-menu-open`.
-6. Click outside the menu and ensure it closes.
+5. Click the toggle again to close the menu and verify body no longer has `data-menu-open`.
+6. Press `Escape` to close the menu and verify body no longer has `data-menu-open`.
+7. Click outside the menu and ensure it closes.


### PR DESCRIPTION
## Summary
- style mobile nav toggle with hamburger icon
- keep toggle accessible above slide-in menu
- test mobile toggle closes menu

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `node tests/Frontend/Unit/NavToggleTest.js`
- `composer audit` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a585ca02908322addabee9695821f4