### PR TITLE
fix: hide sticky search on mobile

### DIFF
--- a/assets/js/sticky-search-Oh6C6P5.js
+++ b/assets/js/sticky-search-Oh6C6P5.js
@@ -1,4 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
+    if (window.matchMedia('(max-width: 768px)').matches) {
+        return;
+    }
     const sticky = document.getElementById('sticky-search');
     const hero = document.querySelector('.hero');
     if (!sticky || !hero) {

--- a/assets/styles/blocks/search-7jFZvVk.css
+++ b/assets/styles/blocks/search-7jFZvVk.css
@@ -15,3 +15,9 @@
 .search--compact .search-form__button {
     min-height: 36px;
 }
+
+@media (max-width: 768px) {
+    .sticky-search {
+        display: none;
+    }
+}

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -3,7 +3,7 @@
 {% block stylesheets %}
     {{ parent() }}
     <link rel="stylesheet" href="{{ asset('styles/forms.css') }}">
-    <link rel="stylesheet" href="{{ asset('styles/blocks/search.css') }}">
+    <link rel="stylesheet" href="{{ asset('styles/blocks/search-7jFZvVk.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/blocks/how-it-works.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/blocks/carousel.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/blocks/groomer-card.css') }}">
@@ -18,7 +18,7 @@
 {% block javascripts %}
     {{ parent() }}
     <script type="module" src="{{ asset('js/form-enhance.js') }}" defer></script>
-    <script type="module" src="{{ asset('js/sticky-search.js') }}" defer></script>
+    <script type="module" src="{{ asset('js/sticky-search-Oh6C6P5.js') }}" defer></script>
     <script type="module" src="{{ asset('js/section-reveal.js') }}" defer></script>
     <script src="{{ asset('js/cta-button.js') }}" defer></script>
     <script type="module" src="{{ asset('js/hero-search.js') }}"></script>


### PR DESCRIPTION
## Summary
- hide sticky search on mobile via CSS media query
- disable sticky search JS on small viewports
- update asset references for renamed files

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*

------
https://chatgpt.com/codex/tasks/task_e_68a587be2a8c8322a229c24b64e39173