### PR TITLE
fix: initialize nav toggle when dom is ready

### DIFF
--- a/assets/js/nav-toggle.js
+++ b/assets/js/nav-toggle.js
@@ -99,8 +99,12 @@
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = { initNavToggle: initNavToggle, openMenu: openMenu, closeMenu: closeMenu, focusTrap: focusTrap };
   } else {
-    document.addEventListener('DOMContentLoaded', function () {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', function () {
+        initNavToggle(document);
+      });
+    } else {
       initNavToggle(document);
-    });
+    }
   }
 })(this);

--- a/public/js/nav-toggle.js
+++ b/public/js/nav-toggle.js
@@ -74,8 +74,12 @@
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = { initNavToggle: initNavToggle, openMenu: openMenu, closeMenu: closeMenu, focusTrap: focusTrap };
   } else {
-    document.addEventListener('DOMContentLoaded', function () {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', function () {
+        initNavToggle(document);
+      });
+    } else {
       initNavToggle(document);
-    });
+    }
   }
 })(this);

--- a/src/public/js/nav-toggle.js
+++ b/src/public/js/nav-toggle.js
@@ -74,8 +74,12 @@
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = { initNavToggle: initNavToggle, openMenu: openMenu, closeMenu: closeMenu, focusTrap: focusTrap };
   } else {
-    document.addEventListener('DOMContentLoaded', function () {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', function () {
+        initNavToggle(document);
+      });
+    } else {
       initNavToggle(document);
-    });
+    }
   }
 })(this);


### PR DESCRIPTION
## Summary
- ensure built nav menu toggle initializes even if DOM is already loaded
- require nav toggle unit test to load from source assets

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d zend.enable_gc=0 -d memory_limit=-1 ./vendor/bin/phpunit --testdox`
- `node tests/Frontend/Unit/NavToggleTest.js`


------
https://chatgpt.com/codex/tasks/task_e_68a58bc7219083228a18f568062c913e