### PR TITLE
feat: improve CTA button hover and focus states

### DIFF
--- a/public/css/components/button.css
+++ b/public/css/components/button.css
@@ -2,3 +2,14 @@
     opacity: 0.6;
     pointer-events: none;
 }
+
+.btn--accent {
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.btn--accent:hover,
+.btn--accent:focus-visible {
+    background-color: #e68900;
+    box-shadow: var(--shadow-md);
+    transform: scale(1.02);
+}

--- a/src/public/css/components/button.css
+++ b/src/public/css/components/button.css
@@ -2,3 +2,14 @@
     opacity: 0.6;
     pointer-events: none;
 }
+
+.btn--accent {
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.btn--accent:hover,
+.btn--accent:focus-visible {
+    background-color: #e68900;
+    box-shadow: var(--shadow-md);
+    transform: scale(1.02);
+}


### PR DESCRIPTION
## Summary
- add hover and focus styles for accent buttons
- include subtle scale, box shadow, and darker background color

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a5d35fe4e88322a8847aaef54ebfc9