### PR TITLE
feat: add spacing utilities for CTA banner

### DIFF
--- a/assets/styles/utilities.css
+++ b/assets/styles/utilities.css
@@ -14,3 +14,7 @@
 @media (min-width: 1024px) {
     .hidden-lg { display: initial !important; }
 }
+
+/* Margin utilities */
+.mb-4 { margin-bottom: 1rem; }
+.mt-6 { margin-top: 1.5rem; }

--- a/templates/home/partials/_cta_banner.html.twig
+++ b/templates/home/partials/_cta_banner.html.twig
@@ -1,5 +1,5 @@
 <section class="cta-banner">
-    <h2 class="cta-banner__heading">{{ 'Get Started'|trans }}</h2>
-    <a href="#search-form" class="cta-banner__link cta-banner__link--owners btn btn--accent">{{ 'Find a Groomer'|trans }}</a>
-    <a href="/register?role=groomer" class="cta-banner__link cta-banner__link--groomers btn btn--accent">{{ 'List Your Business'|trans }}</a>
+    <h2 class="cta-banner__heading mb-4">{{ 'Get Started'|trans }}</h2>
+    <a href="#search-form" class="cta-banner__link cta-banner__link--owners btn btn--accent mt-6">{{ 'Find a Groomer'|trans }}</a>
+    <a href="/register?role=groomer" class="cta-banner__link cta-banner__link--groomers btn btn--accent mt-6">{{ 'List Your Business'|trans }}</a>
 </section>


### PR DESCRIPTION
## Summary
- add margin utility classes for consistent spacing
- apply spacing utilities to CTA banner heading and links

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=-1 -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a5d73fde1c83228d29e0fdf103867b