### PR TITLE
fix: prevent mobile zoom on form inputs

### DIFF
--- a/assets/styles/blocks/footer-UjmJUYX.css
+++ b/assets/styles/blocks/footer-UjmJUYX.css
@@ -146,6 +146,7 @@
 
 .footer-search input {
     flex: 1;
+    font-size: 1rem;
 }
 
 .footer-bottom {

--- a/assets/styles/blocks/hero.css
+++ b/assets/styles/blocks/hero.css
@@ -38,6 +38,7 @@
 
 .hero__input {
     width: 100%;
+    font-size: 1rem;
     padding: var(--space-2);
     border: 1px solid var(--color-neutral);
     border-radius: var(--radius-sm);

--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -101,6 +101,11 @@
 }
 
 .sticky-search .search-form__input,
+.sticky-search .search-form__select {
+    font-size: 1rem;
+}
+
+.sticky-search .search-form__input,
 .sticky-search .search-form__select,
 .sticky-search .search-form__button {
     flex: 1;


### PR DESCRIPTION
## Summary
- enforce 16px font size on hero search input
- ensure sticky search inputs use 16px font size
- set footer search input font size to 16px to avoid mobile zoom

## Testing
- `composer lint:php`
- `composer stan`
- `COMPOSER_MEMORY_LIMIT=-1 composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a6c0fc4b708322802e5600be8c142e