### PR TITLE
Simplify hero section UI

### DIFF
--- a/assets/styles/blocks/hero.css
+++ b/assets/styles/blocks/hero.css
@@ -14,11 +14,6 @@
     margin-bottom: var(--space-4);
 }
 
-.hero__actions {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-3);
-}
 
 .hero__form {
     display: flex;
@@ -44,40 +39,14 @@
     border-radius: var(--radius-sm);
 }
 
-.hero__services {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
-    gap: var(--space-2);
-}
-
-.hero__service {
-    border: 2px solid var(--color-text);
-    background: none;
-    padding: var(--space-2);
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-}
-
-.hero__service[aria-pressed="true"] {
-    background: var(--color-text);
-    color: var(--color-cream);
-}
-
 .hero__submit {
     width: 100%;
 }
 
-.hero__cta {
-    width: 100%;
-    text-align: center;
-}
-
-.hero__cta,
 .hero__submit {
     transition: filter 0.2s ease;
 }
 
-.hero__cta:hover,
 .hero__submit:hover {
     filter: brightness(1.1);
 }
@@ -87,19 +56,12 @@
         font-size: 2.5rem;
     }
 
-    .hero__actions {
-        flex-direction: row;
-        align-items: center;
-        justify-content: center;
-    }
-
     .hero__form {
         flex-direction: row;
-        flex-wrap: wrap;
         align-items: flex-end;
         gap: var(--space-2);
     }
-
+    
     .hero__field {
         flex: 1 1 200px;
         margin: 0;
@@ -107,11 +69,6 @@
 
     .hero__submit {
         width: auto;
-    }
-
-    .hero__cta {
-        width: auto;
-        margin-left: var(--space-2);
     }
 }
 

--- a/templates/home/partials/_hero.html.twig
+++ b/templates/home/partials/_hero.html.twig
@@ -1,34 +1,20 @@
 <section class="hero">
     <div class="hero__container">
         <h1 class="hero__title">{{ 'Book mobile pet grooming in minutes — trusted local professionals.'|trans }}</h1>
-        <div class="hero__actions">
-            <form id="search-form" class="hero__form" method="get" action="/search" role="search">
-                <div class="hero__field hero__field--city">
-                    <label for="city" class="hero__label">{{ 'Where is your pet?'|trans }}</label>
-                    <input class="hero__input" type="text" id="city" name="city" list="city-list" placeholder="{{ 'City or ZIP'|trans }}" required>
-                    <datalist id="city-list">
-                        {% for city in cities %}
-                            <option value="{{ city.slug }}">{{ city.name }}</option>
-                        {% endfor %}
-                    </datalist>
-                </div>
-                <div class="hero__field hero__field--service">
-                    <span class="hero__label">{{ 'Service'|trans }}</span>
-                    <div class="hero__services">
-                        {% for service in services %}
-                            <button type="button" class="hero__service" data-value="{{ service.slug }}" aria-label="{{ service.name }}" aria-pressed="false">
-                                <span aria-hidden="true">{{ service.name }}</span>
-                            </button>
-                        {% endfor %}
-                    </div>
-                </div>
-                <input type="hidden" name="service" id="service">
-                <button class="hero__submit search-form__button btn btn--accent" type="submit" id="search-submit">
-                    {{ ctaLinks.find.label|trans }}
-                </button>
-            </form>
-            <a href="{{ ctaLinks.list.url }}" class="hero__cta btn btn--accent">{{ ctaLinks.list.label|trans }}</a>
-        </div>
+        <form id="search-form" class="hero__form" method="get" action="/search" role="search">
+            <div class="hero__field hero__field--city">
+                <label for="city" class="hero__label">{{ 'Where is your pet?'|trans }}</label>
+                <input class="hero__input" type="text" id="city" name="city" list="city-list" placeholder="{{ 'City or ZIP'|trans }}" required>
+                <datalist id="city-list">
+                    {% for city in cities %}
+                        <option value="{{ city.slug }}">{{ city.name }}</option>
+                    {% endfor %}
+                </datalist>
+            </div>
+            <button class="hero__submit search-form__button btn btn--accent" type="submit" id="search-submit">
+                {{ ctaLinks.find.label|trans }}
+            </button>
+        </form>
     </div>
 </section>
 


### PR DESCRIPTION
## Summary
- remove service selection and extra CTA from hero section
- show only city input and Find a Groomer button
- streamline hero styles for cleaner layout

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox` *(fails: 1 error, 1 failure, 6 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a7054999cc8322b67596d13279c645