### PR TITLE
feat: simplify hero section

### DIFF
--- a/assets/styles/blocks/hero.css
+++ b/assets/styles/blocks/hero.css
@@ -14,12 +14,6 @@
     margin-bottom: var(--space-4);
 }
 
-.hero__actions {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-3);
-}
-
 .hero__form {
     display: flex;
     flex-direction: column;
@@ -44,40 +38,10 @@
     border-radius: var(--radius-sm);
 }
 
-.hero__services {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
-    gap: var(--space-2);
-}
-
-.hero__service {
-    border: 2px solid var(--color-text);
-    background: none;
-    padding: var(--space-2);
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-}
-
-.hero__service[aria-pressed="true"] {
-    background: var(--color-text);
-    color: var(--color-cream);
-}
-
 .hero__submit {
     width: 100%;
-}
-
-.hero__cta {
-    width: 100%;
-    text-align: center;
-}
-
-.hero__cta,
-.hero__submit {
     transition: filter 0.2s ease;
 }
-
-.hero__cta:hover,
 .hero__submit:hover {
     filter: brightness(1.1);
 }
@@ -85,12 +49,6 @@
 @media (min-width: 768px) {
     .hero__title {
         font-size: 2.5rem;
-    }
-
-    .hero__actions {
-        flex-direction: row;
-        align-items: center;
-        justify-content: center;
     }
 
     .hero__form {
@@ -109,10 +67,6 @@
         width: auto;
     }
 
-    .hero__cta {
-        width: auto;
-        margin-left: var(--space-2);
-    }
 }
 
 @media (min-width: 1024px) {

--- a/templates/home/partials/_hero.html.twig
+++ b/templates/home/partials/_hero.html.twig
@@ -1,34 +1,20 @@
 <section class="hero">
     <div class="hero__container">
         <h1 class="hero__title">{{ 'Book mobile pet grooming in minutes — trusted local professionals.'|trans }}</h1>
-        <div class="hero__actions">
-            <form id="search-form" class="hero__form" method="get" action="/search" role="search">
-                <div class="hero__field hero__field--city">
-                    <label for="city" class="hero__label">{{ 'Where is your pet?'|trans }}</label>
-                    <input class="hero__input" type="text" id="city" name="city" list="city-list" placeholder="{{ 'City or ZIP'|trans }}" required>
-                    <datalist id="city-list">
-                        {% for city in cities %}
-                            <option value="{{ city.slug }}">{{ city.name }}</option>
-                        {% endfor %}
-                    </datalist>
-                </div>
-                <div class="hero__field hero__field--service">
-                    <span class="hero__label">{{ 'Service'|trans }}</span>
-                    <div class="hero__services">
-                        {% for service in services %}
-                            <button type="button" class="hero__service" data-value="{{ service.slug }}" aria-label="{{ service.name }}" aria-pressed="false">
-                                <span aria-hidden="true">{{ service.name }}</span>
-                            </button>
-                        {% endfor %}
-                    </div>
-                </div>
-                <input type="hidden" name="service" id="service">
-                <button class="hero__submit search-form__button btn btn--accent" type="submit" id="search-submit">
-                    {{ ctaLinks.find.label|trans }}
-                </button>
-            </form>
-            <a href="{{ ctaLinks.list.url }}" class="hero__cta btn btn--accent">{{ ctaLinks.list.label|trans }}</a>
-        </div>
+        <form id="search-form" class="hero__form" method="get" action="/search" role="search">
+            <div class="hero__field hero__field--city">
+                <label for="city" class="hero__label">{{ 'Where is your pet?'|trans }}</label>
+                <input class="hero__input" type="text" id="city" name="city" list="city-list" placeholder="{{ 'City or ZIP'|trans }}" required>
+                <datalist id="city-list">
+                    {% for city in cities %}
+                        <option value="{{ city.slug }}">{{ city.name }}</option>
+                    {% endfor %}
+                </datalist>
+            </div>
+            <button class="hero__submit search-form__button btn btn--accent" type="submit" id="search-submit">
+                {{ ctaLinks.find.label|trans }}
+            </button>
+        </form>
     </div>
 </section>
 

--- a/tests/E2E/Homepage/HeroSearchFlowTest.php
+++ b/tests/E2E/Homepage/HeroSearchFlowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Tests\E2E\Homepage;
 
 use App\Entity\City;
-use App\Entity\Service;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -25,14 +24,11 @@ final class HeroSearchFlowTest extends WebTestCase
         $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
     }
 
-    public function testTypingCityAndServiceRedirectsToListing(): void
+    public function testTypingCityRedirectsToListing(): void
     {
         $city = new City('Sofia');
         $city->refreshSlugFrom($city->getName());
-        $service = (new Service())->setName('Grooming');
-        $service->refreshSlugFrom($service->getName());
         $this->em->persist($city);
-        $this->em->persist($service);
         $this->em->flush();
 
         $crawler = $this->client->request('GET', '/');
@@ -40,11 +36,10 @@ final class HeroSearchFlowTest extends WebTestCase
 
         $form = $crawler->filter('#search-form')->form([
             'city' => $city->getSlug(),
-            'service' => $service->getSlug(),
         ]);
         $this->client->submit($form);
 
-        self::assertResponseRedirects('/groomers/'.$city->getSlug().'/'.$service->getSlug());
+        self::assertResponseRedirects('/groomers/'.$city->getSlug());
         $this->client->followRedirect();
         self::assertResponseIsSuccessful();
     }

--- a/tests/Integration/HomePageLoadsTest.php
+++ b/tests/Integration/HomePageLoadsTest.php
@@ -15,8 +15,8 @@ final class HomePageLoadsTest extends WebTestCase
 
         self::assertResponseIsSuccessful();
         self::assertSelectorExists('input#city');
-        self::assertSelectorExists('input#service[type="hidden"]');
+        self::assertSelectorNotExists('input#service');
         self::assertSelectorTextContains('button#search-submit', 'Find a Groomer');
-        self::assertSelectorTextContains('a.hero__cta', 'List Your Business');
+        self::assertSelectorNotExists('a.hero__cta');
     }
 }

--- a/tests/Twig/CopyConsistencyTest.php
+++ b/tests/Twig/CopyConsistencyTest.php
@@ -29,17 +29,13 @@ final class CopyConsistencyTest extends KernelTestCase
         $hero = $twig->render('home/partials/_hero.html.twig', [
             'ctaLinks' => [
                 'find' => ['label' => 'Find a Groomer'],
-                'list' => ['label' => 'List Your Business', 'url' => '/register'],
             ],
             'cities' => [
                 ['slug' => 'sofia', 'name' => 'Sofia'],
             ],
-            'services' => [
-                ['slug' => 'grooming', 'name' => 'Grooming'],
-            ],
         ]);
         self::assertStringContainsString('Book mobile pet grooming in minutes — trusted local professionals.', $hero);
-        self::assertStringContainsString('List Your Business', $hero);
+        self::assertStringNotContainsString('List Your Business', $hero);
         self::assertStringNotContainsString('Join as Groomer', $hero);
 
         // CTA banner

--- a/tests/Twig/HeroTemplateTest.php
+++ b/tests/Twig/HeroTemplateTest.php
@@ -16,18 +16,14 @@ final class HeroTemplateTest extends KernelTestCase
         $html = $twig->render('home/partials/_hero.html.twig', [
             'ctaLinks' => [
                 'find' => ['label' => 'Find a Groomer'],
-                'list' => ['label' => 'List Your Business', 'url' => '/register'],
             ],
             'cities' => [
                 ['slug' => 'sofia', 'name' => 'Sofia'],
-            ],
-            'services' => [
-                ['slug' => 'grooming', 'name' => 'Grooming'],
             ],
         ]);
 
         self::assertStringContainsString('Book mobile pet grooming in minutes — trusted local professionals.', $html);
         self::assertStringContainsString('name="city"', $html);
-        self::assertStringContainsString('name="service"', $html);
+        self::assertStringNotContainsString('name="service"', $html);
     }
 }


### PR DESCRIPTION
## Summary
- remove service selection and CTA link from hero
- streamline hero styles for city-only search
- update tests for new hero flow

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a70d5e3e1c8322b4c755f9b8440b3d