### PR TITLE
fix: improve back-to-top button

### DIFF
--- a/src/public/css/components/footer.css
+++ b/src/public/css/components/footer.css
@@ -49,7 +49,25 @@
 }
 
 .back-to-top {
-    align-self: flex-start;
+    position: fixed;
+    right: var(--space-3);
+    bottom: var(--space-3);
+    background: var(--color-accent);
+    color: var(--color-cream);
+    padding: var(--space-2) var(--space-3);
+    border: 0;
+    border-radius: var(--radius-md);
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
+    z-index: 1000;
+}
+
+.back-to-top:hover,
+.back-to-top:focus {
+    background: var(--color-text);
+    color: var(--color-cream);
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- style back-to-top button with accent color and fixed bottom-right placement

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68a71220ecbc8322bda4f6dc91b58508