### PR TITLE
fix: smooth sticky search transition

### DIFF
--- a/assets/js/sticky-search-Oh6C6P5.js
+++ b/assets/js/sticky-search-Oh6C6P5.js
@@ -31,15 +31,14 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         lastScrollY = currentY;
+        ticking = false;
     };
 
-    const debounce = (fn, wait = 50) => {
-        let timeout;
-        return (...args) => {
-            clearTimeout(timeout);
-            timeout = setTimeout(() => fn(...args), wait);
-        };
-    };
-
-    window.addEventListener('scroll', debounce(handleScroll));
+    let ticking = false;
+    window.addEventListener('scroll', () => {
+        if (!ticking) {
+            window.requestAnimationFrame(handleScroll);
+            ticking = true;
+        }
+    });
 });

--- a/assets/styles/blocks/search-7jFZvVk.css
+++ b/assets/styles/blocks/search-7jFZvVk.css
@@ -1,3 +1,23 @@
+
+.sticky-search.is-sticky .search-form label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+}
+
+.sticky-search.is-sticky label[for="sticky-city"]::before {
+    content: '';
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23222222' stroke-width='2'%3E%3Cpath d='M12 2C8.134 2 5 5.134 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.866-3.134-7-7-7z'/%3E%3Ccircle cx='12' cy='9' r='2.5'/%3E%3C/svg%3E") no-repeat center/1rem 1rem;
+}
+
+.sticky-search.is-sticky .search-form__input--city {
+    background: none;
+    padding-left: var(--space-1);
+}
+
 .search--compact {
     padding: var(--space-1);
 }


### PR DESCRIPTION
## Summary
- refine sticky search scroll handling to prevent overlapping inputs during activation
- align sticky search label with a pin icon and remove redundant icon from input

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a71544cc2483229f03411622a8eaa1