### PR TITLE
Reduce hero section spacing

### DIFF
--- a/assets/styles/blocks/hero.css
+++ b/assets/styles/blocks/hero.css
@@ -1,5 +1,5 @@
 .hero {
-    padding: var(--space-5) var(--space-3);
+    padding: var(--space-5) var(--space-3) var(--space-3);
     background: linear-gradient(135deg, var(--color-pastel), var(--color-neutral));
 }
 
@@ -18,6 +18,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-3);
+    margin-bottom: 0;
 }
 
 .hero__field {


### PR DESCRIPTION
## Summary
- trim bottom padding on hero section for tighter layout
- remove residual margin below hero search form

## Testing
- `composer fix:php`
- `composer stan`
- `php -d memory_limit=512M $(which composer) test`


------
https://chatgpt.com/codex/tasks/task_e_68a71e5894788322aff29e061c69e886