### PR TITLE
feat: improve popular cities layout

### DIFF
--- a/public/css/sections/popular-cities.css
+++ b/public/css/sections/popular-cities.css
@@ -2,14 +2,23 @@
     padding: var(--space-4) var(--space-3);
 }
 
+.popular-cities__heading {
+    margin: 0 0 var(--space-2);
+}
+
+.popular-cities__description {
+    margin: 0 0 var(--space-4);
+    color: #4b5563;
+}
+
 .popular-cities__grid {
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
     gap: var(--space-4);
-    grid-template-columns: repeat(auto-fit, minmax(120px, max-content));
-    justify-content: center;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    justify-content: start;
 }
 
 .popular-cities__link {

--- a/templates/home/_popular_cities.html.twig
+++ b/templates/home/_popular_cities.html.twig
@@ -1,5 +1,6 @@
 <section class="popular-cities">
-    <h2>Popular Cities</h2>
+    <h2 class="popular-cities__heading">Popular Cities</h2>
+    <p class="popular-cities__description">Discover groomers in these top locations.</p>
     <ul class="popular-cities__grid" role="list">
         {% for city in popularCities %}
             <li class="popular-cities__item">


### PR DESCRIPTION
## Summary
- add heading and description to popular cities section
- left-align cities with responsive grid layout

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Script APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox handling the test event returned with error code 255)*
- `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a75e96d89083229a900ff77d13b505