### PR TITLE
fix: initialize mobile navigation toggle

### DIFF
--- a/assets/js/mobile-nav-toggle.js
+++ b/assets/js/mobile-nav-toggle.js
@@ -50,13 +50,14 @@
 
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = { initMobileNav: init, openMenu: openMenu, closeMenu: closeMenu };
-  } else {
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', function () {
-        init(document);
+  }
+  if (global.document) {
+    if (global.document.readyState === 'loading') {
+      global.document.addEventListener('DOMContentLoaded', function () {
+        init(global.document);
       });
     } else {
-      init(document);
+      init(global.document);
     }
   }
-})(this);
+})(typeof window !== 'undefined' ? window : global);

--- a/templates/partials/_header.html.twig
+++ b/templates/partials/_header.html.twig
@@ -2,7 +2,7 @@
 <header class="site-header">
   <div class="nav-container">
     <a href="{{ path('app_homepage') }}" class="site-logo">CleanWhiskers</a>
-    <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="{{ 'Menu'|trans }}" type="button">
+    <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-haspopup="true" aria-label="{{ 'Menu'|trans }}" type="button">
       <span class="nav-toggle__icon" aria-hidden="true"></span>
     </button>
     <nav id="primary-nav" class="nav" aria-label="{{ 'Primary'|trans }}" aria-hidden="true">


### PR DESCRIPTION
## Summary
- ensure mobile nav toggle auto-inits when bundled so menu works on mobile
- expose menu intent with `aria-haspopup` for accessibility

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a768dcefd88322ae70e850c3ac65bb