### PR TITLE
fix: toggle mobile nav visibility

### DIFF
--- a/assets/js/mobile-nav-toggle.js
+++ b/assets/js/mobile-nav-toggle.js
@@ -1,11 +1,15 @@
 (function (global) {
   function openMenu(doc, nav, toggle) {
+    doc.body.dataset.menuOpen = 'true';
+    doc.body.style.overflow = 'hidden';
     nav.classList.add('is-open');
     toggle.setAttribute('aria-expanded', 'true');
     nav.setAttribute('aria-hidden', 'false');
   }
 
   function closeMenu(doc, nav, toggle) {
+    delete doc.body.dataset.menuOpen;
+    doc.body.style.overflow = '';
     nav.classList.remove('is-open');
     toggle.setAttribute('aria-expanded', 'false');
     nav.setAttribute('aria-hidden', 'true');

--- a/tests/Frontend/Unit/NavToggleTest.js
+++ b/tests/Frontend/Unit/NavToggleTest.js
@@ -4,7 +4,7 @@ const navToggle = require(path.join(__dirname, '../../../assets/js/mobile-nav-to
 
 function createDocument() {
   return {
-    body: { classList: { add: () => {}, remove: () => {} } },
+    body: { classList: { add: () => {}, remove: () => {} }, dataset: {}, style: {} },
     activeElement: null,
   };
 }
@@ -37,10 +37,14 @@ function createToggle() {
   navToggle.openMenu(doc, nav, toggle);
   assert.ok(nav.classList.contains('is-open'), 'menu open');
   assert.strictEqual(toggle.attrs['aria-expanded'], 'true', 'aria-expanded true');
+  assert.strictEqual(nav['aria-hidden'], 'false', 'aria-hidden false');
+  assert.strictEqual(doc.body.dataset.menuOpen, 'true', 'body dataset set');
 
   navToggle.closeMenu(doc, nav, toggle);
   assert.ok(!nav.classList.contains('is-open'), 'menu closed');
   assert.strictEqual(toggle.attrs['aria-expanded'], 'false', 'aria-expanded false');
+  assert.strictEqual(nav['aria-hidden'], 'true', 'aria-hidden true');
+  assert.strictEqual(doc.body.dataset.menuOpen, undefined, 'body dataset cleared');
 })();
 
 console.log('Nav toggle tests passed');


### PR DESCRIPTION
## Summary
- update mobile nav toggle script to manage body `menuOpen` state and prevent background scrolling
- extend unit test coverage for mobile nav toggle

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `APP_ENV=test php -d memory_limit=512M ./vendor/bin/phpunit --testdox`
- `node tests/Frontend/Unit/NavToggleTest.js`


------
https://chatgpt.com/codex/tasks/task_e_68a773397a308322a63bc7c1e57faa7a