### PR TITLE
fix: tighten hero spacing

### DIFF
--- a/assets/styles/blocks/hero.css
+++ b/assets/styles/blocks/hero.css
@@ -1,5 +1,5 @@
 .hero {
-    padding: var(--space-5) var(--space-3) var(--space-2);
+    padding: var(--space-5) var(--space-3) var(--space-1);
     background: linear-gradient(135deg, var(--color-pastel), var(--color-neutral));
 }
 
@@ -18,17 +18,23 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-3);
+    margin: 0;
 }
 
 .hero__controls {
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
+    margin: 0;
+}
+
+.hero__controls datalist {
+    display: none;
 }
 
 .hero__label {
     display: block;
-    margin-bottom: var(--space-1);
+    margin: 0;
     font-weight: 600;
 }
 

--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -2,7 +2,6 @@
 /* Block: hero */
 .hero {
     position: relative;
-    min-height: 60vh;
     overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- Trim hero padding and reset form margins to remove excessive whitespace
- Let hero height shrink to content for smoother transition to following sections

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox` *(skipped 6 tests: Panther missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a775dab0708322b230883fefdc7812