### PR TITLE
fix: improve popular cities responsive layout

### DIFF
--- a/public/css/sections/popular-cities.css
+++ b/public/css/sections/popular-cities.css
@@ -17,15 +17,22 @@
     padding: 0;
     display: grid;
     gap: var(--space-4);
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-    justify-content: start;
+    grid-template-columns: repeat(2, 1fr);
+}
+
+@media (min-width: 1024px) {
+    .popular-cities__grid {
+        grid-template-columns: repeat(5, 1fr);
+    }
 }
 
 .popular-cities__link {
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    padding: var(--space-2) var(--space-3);
+    width: 100%;
+    height: 100%;
+    padding: var(--space-3);
     background-color: #fff;
     border: 1px solid #e5e7eb;
     border-radius: 9999px;
@@ -55,9 +62,10 @@
 }
 
 .popular-cities__avatar {
+    --avatar-size: 2.75rem;
     flex-shrink: 0;
-    width: 2.75rem;
-    height: 2.75rem;
+    width: var(--avatar-size);
+    height: var(--avatar-size);
     border-radius: 50%;
     background-color: #f3f4f6;
     display: flex;
@@ -77,5 +85,6 @@
 }
 
 .popular-cities__name {
+    flex: 1;
     overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Summary
- ensure popular cities grid renders 2 columns on mobile and 5 on desktop
- expand city links to fill grid cells for larger tap targets
- keep avatar sizing consistent with CSS variable

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a7773aca1c83229434ce504ad1cac5