### PR TITLE
fix: make sticky search input full width

### DIFF
--- a/assets/styles/blocks/search-7jFZvVk.css
+++ b/assets/styles/blocks/search-7jFZvVk.css
@@ -1,3 +1,19 @@
+.sticky-search {
+    width: 100%;
+}
+
+.sticky-search .search-form {
+    width: 100%;
+}
+
+.sticky-search .search-form__input--city {
+    flex: 1 1 80%;
+}
+
+.sticky-search .search-form__select--service,
+.sticky-search .search-form__button {
+    flex: 0 0 auto;
+}
 
 .sticky-search.is-sticky .search-form label {
     display: flex;

--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -93,6 +93,7 @@
     align-items: center;
     gap: var(--space-2);
     margin: 0;
+    width: 100%;
 }
 
 .sticky-search .search-form label {
@@ -107,10 +108,14 @@
 .sticky-search .search-form__input,
 .sticky-search .search-form__select,
 .sticky-search .search-form__button {
-    flex: 1;
     min-height: 44px;
 }
 
+.sticky-search .search-form__input--city {
+    flex: 1 1 80%;
+}
+
+.sticky-search .search-form__select--service,
 .sticky-search .search-form__button {
     flex: 0 0 auto;
 }


### PR DESCRIPTION
## Summary
- make sticky search form take full width on desktop
- expand city input while keeping controls on one line

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68a77a1e6fa48322a5d42783f750cc15