### PR TITLE
feat: add services and gallery to groomer cards

### DIFF
--- a/assets/styles/components/card-groomer.css
+++ b/assets/styles/components/card-groomer.css
@@ -1,0 +1,181 @@
+.featured-groomers {
+    padding: 1rem 0;
+}
+
+.featured-groomers__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: 1fr;
+}
+
+@media (min-width: 480px) {
+    .featured-groomers__grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (min-width: 768px) {
+    .featured-groomers__grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media (min-width: 1024px) {
+    .featured-groomers__grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}
+
+@media (min-width: 1280px) {
+    .featured-groomers__grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}
+
+.card-groomer {
+    background-color: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.card-groomer__image-wrapper {
+    aspect-ratio: 4 / 3;
+    overflow: hidden;
+    background-color: #f3f4f6;
+}
+
+.card-groomer__image-wrapper img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.card-groomer__body {
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+}
+
+.card-groomer__name {
+    margin: 0 0 0.25rem;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.25;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.card-groomer__name a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.card-groomer__city {
+    margin: 0 0 0.5rem;
+    font-size: 0.875rem;
+    color: #6b7280;
+}
+
+.card-groomer__rating {
+    display: flex;
+    align-items: center;
+    font-size: 0.875rem;
+    margin-bottom: 0.5rem;
+}
+
+.card-groomer__stars {
+    --rating: 0;
+    position: relative;
+    display: inline-block;
+    font-size: 0.875rem;
+    color: #e5e7eb;
+}
+
+.card-groomer__stars::before {
+    content: '★★★★★';
+}
+
+.card-groomer__stars::after {
+    content: '★★★★★';
+    position: absolute;
+    left: 0;
+    top: 0;
+    color: #fbbf24;
+    width: calc(var(--rating) / 5 * 100%);
+    overflow: hidden;
+}
+
+.card-groomer__rating-number {
+    margin-left: 0.25rem;
+    color: #374151;
+}
+
+.card-groomer__review-count {
+    margin-left: 0.125rem;
+    color: #6b7280;
+}
+
+.card-groomer__services {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 0.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+}
+
+.card-groomer__services li {
+    background-color: #f3f4f6;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+}
+
+.card-groomer__cta {
+    margin-top: auto;
+    display: inline-block;
+    text-align: center;
+    padding: 0.5rem;
+    background-color: #2563eb;
+    color: #fff;
+    text-decoration: none;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+}
+
+.card-groomer__cta:hover {
+    background-color: #1e40af;
+}
+
+.skeleton {
+    background-color: #e5e7eb;
+    animation: skeleton-loading 1.5s infinite;
+}
+
+@keyframes skeleton-loading {
+    0% { opacity: 0.6; }
+    50% { opacity: 1; }
+    100% { opacity: 0.6; }
+}
+.card-groomer__gallery {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 0.75rem;
+    display: flex;
+    gap: 0.25rem;
+}
+
+.card-groomer__gallery-item img {
+    width: 80px;
+    height: 80px;
+    object-fit: cover;
+    border-radius: 0.25rem;
+    display: block;
+}

--- a/templates/home/_featured_groomers.html.twig
+++ b/templates/home/_featured_groomers.html.twig
@@ -7,56 +7,15 @@
                 <button class="carousel__button carousel__button--prev" data-carousel-prev aria-label="Previous">&#10094;</button>
                 <div class="carousel__track" tabindex="0">
                     {% for item in featuredGroomers %}
-                    {% set g = item.profile %}
-                    {% set badges = ['New', 'Verified'] %}
-                        <article class="carousel__card card-groomer" data-badges="{{ badges|slice(0,2)|join(',')|lower }}">
-                            <div class="card-groomer__image-wrapper">
-                                <img
-                                    src="{{ g.logo|default('https://placehold.co/320x240?text=No+Photo') }}"
-                                    alt="{{ g.businessName }} logo"
-                                    loading="lazy"
-                                    decoding="async"
-                                    width="320"
-                                    height="240"
-                                    data-skeleton
-                                >
-                            </div>
-                            <div class="card-groomer__body">
-                                <div class="card-groomer__badges">
-                                    {% for badge in badges|slice(0,2) %}
-                                        <span class="badge badge--{{ badge|lower }}">{{ badge }}</span>
-                                    {% endfor %}
-                                </div>
-                                <h3 class="card-groomer__name">
-                                    <a href="{{ path('app_groomer_show', {slug: g.slug}) }}">{{ g.businessName }}</a>
-                                </h3>
-                                <p class="card-groomer__city">{{ g.city.name }}</p>
-                                <div class="card-groomer__rating" aria-label="Rating {{ item.rating|number_format(1) }} out of 5">
-                                    <span class="card-groomer__stars" style="--rating: {{ item.rating|number_format(1, '.', '') }}" aria-hidden="true"></span>
-                                    <span class="card-groomer__rating-number">{{ item.rating|number_format(1) }}</span>
-                                    <span class="card-groomer__review-count">({{ item.reviewCount }})</span>
-                                </div>
-                                {% if g.priceRange %}
-                                    <p class="card-groomer__price">Starting at {{ g.priceRange }}</p>
-                                {% endif %}
-                                {% set iconMap = {
-                                    'grooming': '✂️',
-                                    'bathing': '🛁',
-                                    'walking': '🐕',
-                                    'training': '🎓'
-                                } %}
-                                {% set tags = g.services|slice(0,3) %}
-                                {% if tags|length %}
-                                    <ul class="card-groomer__services">
-                                        {% for service in tags %}
-                                            {% set icon = iconMap[service.slug]|default('🐾') %}
-                                            <li class="card-groomer__service" aria-label="{{ service.name }}" title="{{ service.name }}">{{ icon }}</li>
-                                        {% endfor %}
-                                    </ul>
-                                {% endif %}
-                                <a class="card-groomer__cta card-groomer__book" href="{{ path('app_groomer_show', {slug: g.slug}) }}#book">Book Now</a>
-                            </div>
-                        </article>
+                        {% set g = item.profile %}
+                        {% set badges = ['New', 'Verified'] %}
+                        {{ include('partials/_groomer-card.html.twig', {
+                            profile: g,
+                            rating: item.rating,
+                            reviewCount: item.reviewCount,
+                            badges: badges,
+                            class: 'carousel__card'
+                        }) }}
                     {% endfor %}
                 </div>
                 <button class="carousel__button carousel__button--next" data-carousel-next aria-label="Next">&#10095;</button>
@@ -66,48 +25,12 @@
                 {% for item in featuredGroomers %}
                     {% set g = item.profile %}
                     {% set badges = ['New', 'Verified'] %}
-                    <article class="card-groomer" data-badges="{{ badges|slice(0,2)|join(',')|lower }}">
-                        <div class="card-groomer__image-wrapper">
-                            <img
-                                src="{{ g.logo|default('https://placehold.co/320x240?text=No+Photo') }}"
-                                alt="{{ g.businessName }} logo"
-                                loading="lazy"
-                                decoding="async"
-                                width="320"
-                                height="240"
-                                data-skeleton
-                            >
-                        </div>
-                        <div class="card-groomer__body">
-                            <div class="card-groomer__badges">
-                                {% for badge in badges|slice(0,2) %}
-                                    <span class="badge badge--{{ badge|lower }}">{{ badge }}</span>
-                                {% endfor %}
-                            </div>
-                            <h3 class="card-groomer__name">
-                                <a href="{{ path('app_groomer_show', {slug: g.slug}) }}">{{ g.businessName }}</a>
-                            </h3>
-                            <p class="card-groomer__city">{{ g.city.name }}</p>
-                            <div class="card-groomer__rating" aria-label="Rating {{ item.rating|number_format(1) }} out of 5">
-                                <span class="card-groomer__stars" style="--rating: {{ item.rating|number_format(1, '.', '') }}" aria-hidden="true"></span>
-                                <span class="card-groomer__rating-number">{{ item.rating|number_format(1) }}</span>
-                                <span class="card-groomer__review-count">({{ item.reviewCount }})</span>
-                            </div>
-                            {% if g.priceRange %}
-                                <p class="card-groomer__price">Starting at {{ g.priceRange }}</p>
-                            {% endif %}
-                            {% set tags = g.services|slice(0,3) %}
-                            {% if tags|length %}
-                                <ul class="card-groomer__services">
-                                    {% for service in tags %}
-                                        {% set icon = iconMap[service.slug]|default('🐾') %}
-                                        <li class="card-groomer__service" aria-label="{{ service.name }}" title="{{ service.name }}">{{ icon }}</li>
-                                    {% endfor %}
-                                </ul>
-                            {% endif %}
-                            <a class="card-groomer__cta card-groomer__book" href="{{ path('app_groomer_show', {slug: g.slug}) }}#book">Book Now</a>
-                        </div>
-                    </article>
+                    {{ include('partials/_groomer-card.html.twig', {
+                        profile: g,
+                        rating: item.rating,
+                        reviewCount: item.reviewCount,
+                        badges: badges
+                    }) }}
                 {% endfor %}
             </div>
         {% endif %}

--- a/templates/partials/_groomer-card.html.twig
+++ b/templates/partials/_groomer-card.html.twig
@@ -1,0 +1,61 @@
+{%- set g = profile -%}
+{%- set badges = badges|default([]) -%}
+{%- set extraClass = class|default('') -%}
+<article class="{{ [extraClass, 'card-groomer']|join(' ')|trim }}" data-badges="{{ badges|slice(0,2)|join(',')|lower }}">
+    <div class="card-groomer__image-wrapper">
+        <img
+            src="{{ g.logo|default('https://placehold.co/320x240?text=No+Photo') }}"
+            alt="{{ g.businessName }} logo"
+            loading="lazy"
+            decoding="async"
+            width="320"
+            height="240"
+            data-skeleton
+        >
+    </div>
+    <div class="card-groomer__body">
+        <div class="card-groomer__badges">
+            {% for badge in badges|slice(0,2) %}
+                <span class="badge badge--{{ badge|lower }}">{{ badge }}</span>
+            {% endfor %}
+        </div>
+        <h3 class="card-groomer__name">
+            <a href="{{ path('app_groomer_show', {slug: g.slug}) }}">{{ g.businessName }}</a>
+        </h3>
+        {% set tags = g.services|default([])|slice(0,3) %}
+        {% if tags|length %}
+            <ul class="card-groomer__services">
+                {% for service in tags %}
+                    <li class="card-groomer__service">{{ service.name }}</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+        {% set gallery = g.photos|default([])|slice(0,2) %}
+        {% if gallery|length %}
+            <ul class="card-groomer__gallery">
+                {% for photo in gallery %}
+                    <li class="card-groomer__gallery-item">
+                        <img
+                            src="{{ photo.url|default('https://placehold.co/80x80') }}"
+                            alt="{{ photo.alt|default(g.businessName ~ ' photo') }}"
+                            loading="lazy"
+                            decoding="async"
+                            width="80"
+                            height="80"
+                        >
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+        <p class="card-groomer__city">{{ g.city.name }}</p>
+        <div class="card-groomer__rating" aria-label="Rating {{ rating|number_format(1) }} out of 5">
+            <span class="card-groomer__stars" style="--rating: {{ rating|number_format(1, '.', '') }}" aria-hidden="true"></span>
+            <span class="card-groomer__rating-number">{{ rating|number_format(1) }}</span>
+            <span class="card-groomer__review-count">({{ reviewCount }})</span>
+        </div>
+        {% if g.priceRange %}
+            <p class="card-groomer__price">Starting at {{ g.priceRange }}</p>
+        {% endif %}
+        <a class="card-groomer__cta card-groomer__book" href="{{ path('app_groomer_show', {slug: g.slug}) }}#book">Book Now</a>
+    </div>
+</article>

--- a/tests/Frontend/Unit/CardGroomerMarkupTest.html
+++ b/tests/Frontend/Unit/CardGroomerMarkupTest.html
@@ -17,6 +17,7 @@
             console.assert(card.querySelector('.card-groomer__review-count'), 'review count present');
             console.assert(card.querySelector('.card-groomer__price'), 'price present');
             console.assert(card.querySelector('.card-groomer__services li'), 'service tag present');
+            console.assert(card.querySelector('.card-groomer__gallery img'), 'gallery image present');
             const cta = card.querySelector('.card-groomer__cta');
             console.assert(cta && cta.textContent.includes('Book Now'), 'CTA present');
             console.log('Card groomer markup tests passed');
@@ -32,6 +33,18 @@
             </div>
             <div class="card-groomer__body">
                 <h3 class="card-groomer__name"><a href="#">Fluffy Groomers</a></h3>
+                <ul class="card-groomer__services">
+                    <li class="card-groomer__service">Small dogs</li>
+                    <li class="card-groomer__service">Nail trimming</li>
+                </ul>
+                <ul class="card-groomer__gallery">
+                    <li class="card-groomer__gallery-item">
+                        <img src="https://placehold.co/80x80" alt="Work photo" loading="lazy">
+                    </li>
+                    <li class="card-groomer__gallery-item">
+                        <img src="https://placehold.co/80x80" alt="Work photo" loading="lazy">
+                    </li>
+                </ul>
                 <p class="card-groomer__city">Springfield</p>
                 <div class="card-groomer__rating" aria-label="Rating 4.8 out of 5">
                     <span class="card-groomer__stars" style="--rating:4.8" aria-hidden="true"></span>
@@ -39,9 +52,6 @@
                     <span class="card-groomer__review-count">(10)</span>
                 </div>
                 <p class="card-groomer__price">Starting at $20</p>
-                <ul class="card-groomer__services">
-                    <li aria-label="Baths">🛁</li>
-                </ul>
                 <a class="card-groomer__cta" href="#">Book Now</a>
             </div>
         </article>


### PR DESCRIPTION
## Summary
- add reusable groomer card partial with service tags and optional photo gallery
- style groomer card gallery and tags
- render groomer cards via partial in featured groomers section

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=1G ./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68a82c1a6ba08322ba516aef703d6b04