### PR TITLE
feat: add groomer selection tips section

### DIFF
--- a/assets/styles/sections/choose-guide.css
+++ b/assets/styles/sections/choose-guide.css
@@ -1,0 +1,37 @@
+.choose-guide {
+    padding: var(--space-5) var(--space-3);
+    background-color: var(--color-neutral);
+}
+
+.choose-guide__list {
+    display: grid;
+    gap: var(--space-3);
+}
+
+@media (min-width: 600px) {
+    .choose-guide__list {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (min-width: 900px) {
+    .choose-guide__list {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}
+
+.choose-guide__item {
+    background-color: #fff;
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
+    padding: var(--space-3);
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.choose-guide__icon {
+    font-size: 1.5rem;
+    line-height: 1;
+    color: var(--color-accent);
+}

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="{{ asset('css/sections/popular-cities.css') }}">
     <link rel="stylesheet" href="{{ asset('css/sections/popular-services.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/sections/testimonials.css') }}">
+    <link rel="stylesheet" href="{{ asset('styles/sections/choose-guide.css') }}">
 {% endblock %}
 
 {% block javascripts %}
@@ -33,6 +34,27 @@
     {% include 'home/partials/_hero.html.twig' %}
     {% include 'home/partials/_cta_banner.html.twig' %}
     {% include 'home/partials/_how_it_works.html.twig' %}
+    <section class="choose-guide reveal-on-scroll">
+        <h2>{{ 'How to Choose a Groomer'|trans }}</h2>
+        <ul class="choose-guide__list">
+            <li class="choose-guide__item">
+                <span class="choose-guide__icon" aria-hidden="true">🐾</span>
+                <span>{{ 'Look for mobile options'|trans }}</span>
+            </li>
+            <li class="choose-guide__item">
+                <span class="choose-guide__icon" aria-hidden="true">❓</span>
+                <span>{{ 'Ask about breed experience'|trans }}</span>
+            </li>
+            <li class="choose-guide__item">
+                <span class="choose-guide__icon" aria-hidden="true">📅</span>
+                <span>{{ 'Check availability and scheduling'|trans }}</span>
+            </li>
+            <li class="choose-guide__item">
+                <span class="choose-guide__icon" aria-hidden="true">💬</span>
+                <span>{{ 'Read reviews from other pet owners'|trans }}</span>
+            </li>
+        </ul>
+    </section>
     <section class="why-cleanwhiskers reveal-on-scroll">
         <h2>{{ 'Why CleanWhiskers?'|trans }}</h2>
         <div class="why-cleanwhiskers__cards">


### PR DESCRIPTION
## Summary
- add "How to Choose a Groomer" tips section under home page flow
- style new guide section with responsive grid layout and icons

## Testing
- `composer lint:php`
- `composer stan`
- `php -d memory_limit=512M $(which composer) test`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a82e0b9f0483228fc31e233b15f0bf