### PR TITLE
feat: seed groomer badges and specialties

### DIFF
--- a/migrations/Version20250816120000AddBadgesAndSpecialties.php
+++ b/migrations/Version20250816120000AddBadgesAndSpecialties.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250816120000AddBadgesAndSpecialties extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add badges and specialties to groomer_profile';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('groomer_profile');
+        $table->addColumn('badges', Types::JSON, ['notnull' => false]);
+        $table->addColumn('specialties', Types::JSON, ['notnull' => false]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('groomer_profile');
+        $table->dropColumn('badges');
+        $table->dropColumn('specialties');
+    }
+}

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Command;
 
+use App\Repository\GroomerProfileRepository;
 use App\Seeder\BlogSeed;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,8 +16,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'app:seed', description: 'Seed demo data')]
 final class SeedCommand extends Command
 {
-    public function __construct(private readonly BlogSeed $blogSeed)
-    {
+    public function __construct(
+        private readonly BlogSeed $blogSeed,
+        private readonly GroomerProfileRepository $groomerRepository,
+        private readonly EntityManagerInterface $em,
+    ) {
         parent::__construct();
     }
 
@@ -31,6 +36,47 @@ final class SeedCommand extends Command
             $output->writeln('<info>Blog content seeded.</info>');
         }
 
+        $this->seedGroomerExtras($output);
+
         return Command::SUCCESS;
+    }
+
+    private function seedGroomerExtras(OutputInterface $output): void
+    {
+        $badgePool = ['New', 'Mobile', 'Verified'];
+        $specialtyPool = [
+            'Small dogs',
+            'Large dogs',
+            'Nail trimming',
+            'Haircuts',
+            'Cat grooming',
+        ];
+
+        foreach ($this->groomerRepository->findAll() as $profile) {
+            if (random_int(1, 10) <= 8) {
+                $profile->setBadges($this->sample($badgePool, random_int(1, 2)));
+            }
+            if (random_int(1, 10) <= 8) {
+                $profile->setSpecialties($this->sample($specialtyPool, random_int(1, 3)));
+            }
+        }
+
+        $this->em->flush();
+        $output->writeln('<info>Groomer badges and specialties seeded.</info>');
+    }
+
+    /**
+     * @param string[] $pool
+     *
+     * @return string[]
+     */
+    private function sample(array $pool, int $count): array
+    {
+        if ($count <= 0) {
+            return [];
+        }
+        shuffle($pool);
+
+        return array_slice($pool, 0, min($count, count($pool)));
     }
 }

--- a/src/Entity/GroomerProfile.php
+++ b/src/Entity/GroomerProfile.php
@@ -8,6 +8,7 @@ use App\Domain\Shared\SluggerTrait;
 use App\Repository\GroomerProfileRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: GroomerProfileRepository::class)]
@@ -48,6 +49,18 @@ class GroomerProfile
 
     #[ORM\Column(name: 'price_range', length: 64, nullable: true)]
     private ?string $priceRange = null;
+
+    /**
+     * @var string[]|null
+     */
+    #[ORM\Column(type: Types::JSON, nullable: true)]
+    private ?array $badges = null;
+
+    /**
+     * @var string[]|null
+     */
+    #[ORM\Column(type: Types::JSON, nullable: true)]
+    private ?array $specialties = null;
 
     /** @var Collection<int, Service> */
     #[ORM\ManyToMany(targetEntity: Service::class)]
@@ -137,6 +150,42 @@ class GroomerProfile
     public function setPriceRange(?string $priceRange): self
     {
         $this->priceRange = $priceRange;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getBadges(): array
+    {
+        return $this->badges ?? [];
+    }
+
+    /**
+     * @param string[] $badges
+     */
+    public function setBadges(array $badges): self
+    {
+        $this->badges = $badges;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSpecialties(): array
+    {
+        return $this->specialties ?? [];
+    }
+
+    /**
+     * @param string[] $specialties
+     */
+    public function setSpecialties(array $specialties): self
+    {
+        $this->specialties = $specialties;
 
         return $this;
     }

--- a/tests/Unit/Entity/GroomerProfileFieldsTest.php
+++ b/tests/Unit/Entity/GroomerProfileFieldsTest.php
@@ -24,15 +24,21 @@ final class GroomerProfileFieldsTest extends TestCase
         self::assertNull($profile->getPhone());
         self::assertNull($profile->getServicesOffered());
         self::assertNull($profile->getPriceRange());
+        self::assertSame([], $profile->getBadges());
+        self::assertSame([], $profile->getSpecialties());
 
         $profile->setServiceArea('Downtown');
         $profile->setPhone('123-456');
         $profile->setServicesOffered('Bathing');
         $profile->setPriceRange('$$');
+        $profile->setBadges(['New']);
+        $profile->setSpecialties(['Nail trimming']);
 
         self::assertSame('Downtown', $profile->getServiceArea());
         self::assertSame('123-456', $profile->getPhone());
         self::assertSame('Bathing', $profile->getServicesOffered());
         self::assertSame('$$', $profile->getPriceRange());
+        self::assertSame(['New'], $profile->getBadges());
+        self::assertSame(['Nail trimming'], $profile->getSpecialties());
     }
 }


### PR DESCRIPTION
## Summary
- add badges and specialties fields to groomer profiles
- seed random groomer badges and specialties
- cover new fields with migration and tests

## Testing
- `composer lint:php`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a842bd3ee88322967a892e7afa23cf