### PR TITLE
Seed popular cities and coverage data

### DIFF
--- a/migrations/Version20250822104000AddCityCoverageNotes.php
+++ b/migrations/Version20250822104000AddCityCoverageNotes.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250822104000AddCityCoverageNotes extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add coverage_notes column to city';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('city');
+        $table->addColumn('coverage_notes', Types::TEXT, ['notnull' => false]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->getTable('city')->dropColumn('coverage_notes');
+    }
+}

--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -27,6 +27,9 @@ class City
     #[ORM\Column(name: 'seo_intro', type: Types::TEXT, nullable: true)]
     private ?string $seoIntro = null;
 
+    #[ORM\Column(name: 'coverage_notes', type: Types::TEXT, nullable: true)]
+    private ?string $coverageNotes = null;
+
     #[ORM\Column(name: 'created_at', type: Types::DATETIME_IMMUTABLE)]
     private \DateTimeImmutable $createdAt;
 
@@ -54,6 +57,16 @@ class City
     public function setSeoIntro(?string $seoIntro): void
     {
         $this->seoIntro = $seoIntro;
+    }
+
+    public function getCoverageNotes(): ?string
+    {
+        return $this->coverageNotes;
+    }
+
+    public function setCoverageNotes(?string $coverageNotes): void
+    {
+        $this->coverageNotes = $coverageNotes;
     }
 
     public function getCreatedAt(): \DateTimeImmutable


### PR DESCRIPTION
## Summary
- ensure `SeedCommand` seeds five popular cities with coverage notes and baseline groomers
- add optional coverage notes field to `City`
- add migration for new coverage notes column

## Testing
- ⚠️ `composer test` *(memory exhausted)*
- ✅ `DATABASE_URL=sqlite:///:memory: APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --testdox`
- ✅ `composer stan`


------
https://chatgpt.com/codex/tasks/task_e_68a84737f8888322bc271672940538c6