### PR TITLE
feat: redesign mobile navigation menu

### DIFF
--- a/assets/styles/nav.css
+++ b/assets/styles/nav.css
@@ -8,27 +8,47 @@
   background: none;
   border: 0;
   cursor: pointer;
+  padding: 0;
+  width: 2rem;
+  height: 2rem;
+  position: relative;
 }
 
 .nav-toggle__icon,
 .nav-toggle__icon::before,
 .nav-toggle__icon::after {
-  display: block;
-  width: 24px;
+  position: absolute;
+  left: 0;
+  width: 100%;
   height: 2px;
   background: #333;
-  position: relative;
+  transition: transform 0.3s ease, top 0.3s ease, opacity 0.3s ease;
+}
+
+.nav-toggle__icon {
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .nav-toggle__icon::before,
 .nav-toggle__icon::after {
   content: '';
-  position: absolute;
-  left: 0;
 }
 
-.nav-toggle__icon::before { top: -6px; }
-.nav-toggle__icon::after { top: 6px; }
+.nav-toggle--open .nav-toggle__icon::before { top: -6px; }
+.nav-toggle--open .nav-toggle__icon::after { top: 6px; }
+
+.nav-toggle--close .nav-toggle__icon {
+  background: transparent;
+}
+
+.nav-toggle--close .nav-toggle__icon::before {
+  transform: rotate(45deg);
+}
+
+.nav-toggle--close .nav-toggle__icon::after {
+  transform: rotate(-45deg);
+}
 
 .nav {
   --gap: 1.5rem;
@@ -54,31 +74,58 @@
   border-radius: 4px;
 }
 
+body.nav-open {
+  overflow: hidden;
+}
+
 @media (max-width: 767px) {
+  .nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    background: #fff;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    padding: 5rem 2rem;
+  }
+
+  .nav.is-open {
+    transform: translateX(0);
+  }
+
   .nav__list {
     flex-direction: column;
-    gap: 0;
-  }
-
-  body.js .nav {
-    display: none;
-  }
-
-  body.js .nav.is-open {
-    display: block;
   }
 
   .nav__link {
     display: block;
-    padding: 0.75rem 0;
   }
 
   .nav-toggle {
     display: block;
   }
+
+  .nav-toggle--close {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+  }
 }
 
 @media (min-width: 768px) {
+  .nav {
+    position: static;
+    transform: none;
+    height: auto;
+    padding: 0;
+  }
+
+  .nav__list {
+    flex-direction: row;
+  }
+
   .nav-toggle {
     display: none;
   }

--- a/public/js/mobile-nav-toggle.js
+++ b/public/js/mobile-nav-toggle.js
@@ -1,0 +1,56 @@
+(function (global) {
+  function initMobileNav(doc) {
+    doc = doc || document;
+    var openBtn = doc.getElementById('nav-open');
+    var closeBtn = doc.getElementById('nav-close');
+    var nav = doc.getElementById('primary-nav');
+    if (!openBtn || !closeBtn || !nav) {
+      return;
+    }
+
+    doc.body.classList.add('js');
+
+    function openMenu() {
+      nav.hidden = false;
+      nav.classList.add('is-open');
+      openBtn.hidden = true;
+      closeBtn.hidden = false;
+      openBtn.setAttribute('aria-expanded', 'true');
+      closeBtn.setAttribute('aria-expanded', 'true');
+      doc.body.classList.add('nav-open');
+      var firstLink = nav.querySelector('a');
+      if (firstLink && typeof firstLink.focus === 'function') {
+        firstLink.focus();
+      }
+    }
+
+    function closeMenu() {
+      nav.classList.remove('is-open');
+      nav.hidden = true;
+      openBtn.hidden = false;
+      closeBtn.hidden = true;
+      openBtn.setAttribute('aria-expanded', 'false');
+      closeBtn.setAttribute('aria-expanded', 'false');
+      doc.body.classList.remove('nav-open');
+      if (typeof openBtn.focus === 'function') {
+        openBtn.focus();
+      }
+    }
+
+    openBtn.addEventListener('click', openMenu);
+    closeBtn.addEventListener('click', closeMenu);
+    doc.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && !nav.hidden) {
+        closeMenu();
+      }
+    });
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { initMobileNav: initMobileNav };
+  } else if (global.document) {
+    global.document.addEventListener('DOMContentLoaded', function () {
+      initMobileNav(global.document);
+    });
+  }
+})(this);

--- a/templates/partials/_header.html.twig
+++ b/templates/partials/_header.html.twig
@@ -2,10 +2,13 @@
 <header class="site-header">
   <div class="nav-container">
     <a href="{{ path('app_homepage') }}" class="site-logo">CleanWhiskers</a>
-    <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-haspopup="true" aria-label="{{ 'Menu'|trans }}" type="button">
+    <button id="nav-open" class="nav-toggle nav-toggle--open" aria-expanded="false" aria-controls="primary-nav" aria-label="{{ 'Open menu'|trans }}" type="button">
       <span class="nav-toggle__icon" aria-hidden="true"></span>
     </button>
-    <nav id="primary-nav" class="nav" aria-label="{{ 'Primary'|trans }}" aria-hidden="true">
+    <button id="nav-close" class="nav-toggle nav-toggle--close" aria-expanded="true" aria-controls="primary-nav" aria-label="{{ 'Close menu'|trans }}" type="button" hidden>
+      <span class="nav-toggle__icon" aria-hidden="true"></span>
+    </button>
+    <nav id="primary-nav" class="nav" aria-label="{{ 'Primary'|trans }}" hidden>
       <ul class="nav__list">
         <li class="nav__item"><a class="nav__link" href="{{ path('app_search_redirect') }}">{{ 'Find a Groomer'|trans }}</a></li>
         <li class="nav__item"><a class="nav__link nav__link--cta" href="{{ path('app_register', {'role': 'groomer'}) }}">{{ 'List Your Business'|trans }}</a></li>


### PR DESCRIPTION
## Summary
- enhance header markup with accessible open/close menu buttons
- implement slide-in mobile nav and scroll lock styles
- add vanilla JS controller for mobile nav toggle

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `node tests/Frontend/Unit/NavToggleTest.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8e18d03048322a190b9bf42499de0