### PR TITLE
feat: add slide-in mobile nav overlay

### DIFF
--- a/assets/js/mobile-nav-toggle.js
+++ b/assets/js/mobile-nav-toggle.js
@@ -1,24 +1,33 @@
 (function (global) {
-  function openMenu(doc, nav, toggle) {
+  function openMenu(doc, nav, toggle, overlay) {
     doc.body.dataset.menuOpen = 'true';
     doc.body.style.overflow = 'hidden';
     nav.classList.add('is-open');
     toggle.setAttribute('aria-expanded', 'true');
     nav.setAttribute('aria-hidden', 'false');
+    if (overlay) {
+      overlay.classList.add('is-open');
+      overlay.setAttribute('aria-hidden', 'false');
+    }
   }
 
-  function closeMenu(doc, nav, toggle) {
+  function closeMenu(doc, nav, toggle, overlay) {
     delete doc.body.dataset.menuOpen;
     doc.body.style.overflow = '';
     nav.classList.remove('is-open');
     toggle.setAttribute('aria-expanded', 'false');
     nav.setAttribute('aria-hidden', 'true');
+    if (overlay) {
+      overlay.classList.remove('is-open');
+      overlay.setAttribute('aria-hidden', 'true');
+    }
   }
 
   function init(doc) {
     doc = doc || document;
     var toggle = doc.getElementById('nav-toggle');
     var nav = doc.getElementById('primary-nav');
+    var overlay = doc.getElementById('nav-overlay');
     if (!toggle || !nav) {
       return;
     }
@@ -26,13 +35,13 @@
 
     function onDocumentClick(e) {
       if (!nav.contains(e.target) && !toggle.contains(e.target)) {
-        closeMenu(doc, nav, toggle);
+        closeMenu(doc, nav, toggle, overlay);
       }
     }
 
     function onKeyDown(e) {
       if (e.key === 'Escape') {
-        closeMenu(doc, nav, toggle);
+        closeMenu(doc, nav, toggle, overlay);
         if (typeof toggle.focus === 'function') {
           toggle.focus();
           doc.activeElement = toggle;
@@ -40,11 +49,17 @@
       }
     }
 
+    if (overlay) {
+      overlay.addEventListener('click', function () {
+        closeMenu(doc, nav, toggle, overlay);
+      });
+    }
+
     toggle.addEventListener('click', function () {
       if (nav.classList.contains('is-open')) {
-        closeMenu(doc, nav, toggle);
+        closeMenu(doc, nav, toggle, overlay);
       } else {
-        openMenu(doc, nav, toggle);
+        openMenu(doc, nav, toggle, overlay);
       }
     });
 

--- a/assets/styles/nav.css
+++ b/assets/styles/nav.css
@@ -55,17 +55,31 @@
 }
 
 @media (max-width: 767px) {
+  .nav {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: auto;
+    width: 80%;
+    max-width: 300px;
+    background: #fff;
+    padding: 2rem 1.5rem;
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
+  }
+
+  .nav.is-open {
+    transform: translateX(0);
+  }
+
   .nav__list {
     flex-direction: column;
     gap: 0;
-  }
-
-  body.js .nav {
-    display: none;
-  }
-
-  body.js .nav.is-open {
-    display: block;
   }
 
   .nav__link {
@@ -75,6 +89,22 @@
 
   .nav-toggle {
     display: block;
+  }
+
+  .nav-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+  }
+
+  .nav-overlay.is-open {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
   }
 }
 

--- a/templates/partials/_header.html.twig
+++ b/templates/partials/_header.html.twig
@@ -13,4 +13,5 @@
       </ul>
     </nav>
   </div>
+  <div id="nav-overlay" class="nav-overlay" aria-hidden="true"></div>
 </header>


### PR DESCRIPTION
## Summary
- add overlay element to header and slide-in mobile nav styles
- enhance mobile-nav-toggle to sync overlay visibility

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `node tests/Frontend/Unit/NavToggleTest.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8e9e45bcc8322aaa1df642bc2bed7