### PR TITLE
feat: refine typography scale and add responsive test

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -31,14 +31,24 @@
 
     /* Typography */
     --font-body: 'Quicksand', system-ui, sans-serif;
-    --fs-base: 1rem;
-    --fs-h1: 2.5rem;
-    --fs-h2: 2rem;
-    --fs-h3: 1.5rem;
-    --lh-body: 1.5;
+    --fs-base: 1rem;      /* 16px */
+    --fs-h1: 1.75rem;     /* 28px */
+    --fs-h2: 1.25rem;     /* 20px */
+    --fs-h3: 1.125rem;    /* 18px (optional slight bump) */
+    --lh-body: 1.6;
     --lh-heading: 1.2;
     --ls-body: 0;
     --ls-heading: 0.02em;
+}
+
+/* Fluid upscale on larger screens using clamp() */
+@media (min-width: 768px) {
+    :root {
+        --fs-base: clamp(1rem, 0.95rem + 0.3vw, 1.0625rem);  /* ~16–17px */
+        --fs-h1:   clamp(1.75rem, 1.5rem + 1.2vw, 2.25rem);  /* 28–36px */
+        --fs-h2:   clamp(1.25rem, 1.1rem + 0.6vw, 1.5rem);   /* 20–24px */
+        --fs-h3:   clamp(1.125rem, 1.05rem + 0.4vw, 1.25rem);/* 18–20px */
+    }
 }
 
 /* Base styles */

--- a/assets/styles/blocks/footer-UjmJUYX.css
+++ b/assets/styles/blocks/footer-UjmJUYX.css
@@ -34,7 +34,7 @@
 
 .footer-brand .footer-logo {
     font-weight: 700;
-    font-size: 1.25rem;
+    font-size: var(--fs-h2);
 }
 
 .footer-brand p {
@@ -48,7 +48,7 @@
 }
 
 .footer-heading {
-    font-size: 1.125rem;
+    font-size: var(--fs-h3);
     font-weight: 700;
     margin: 0 0 var(--space-2);
 }
@@ -132,7 +132,7 @@
 
 .footer-search input {
     flex: 1;
-    font-size: 1rem;
+    font-size: var(--fs-base);
     min-height: 44px;
     padding: var(--space-1) var(--space-3);
     border: 1px solid #ccc;

--- a/assets/styles/blocks/groomer-card.css
+++ b/assets/styles/blocks/groomer-card.css
@@ -38,7 +38,7 @@
 }
 
 .card-groomer__service {
-    font-size: 1.25rem;
+    font-size: var(--fs-h2);
 }
 
 .card-groomer__cta {

--- a/assets/styles/blocks/header.css
+++ b/assets/styles/blocks/header.css
@@ -15,7 +15,7 @@
 
 .site-logo {
     font-weight: 700;
-    font-size: 1.25rem;
+    font-size: var(--fs-h2);
     text-decoration: none;
     color: var(--color-text);
 }
@@ -66,7 +66,7 @@ body[data-menu-open="true"] .nav {
     font-weight: 600;
     color: var(--color-text);
     padding: 0;
-    font-size: 1.25rem;
+    font-size: var(--fs-h2);
     border-radius: var(--radius-sm);
 }
 
@@ -95,7 +95,7 @@ body[data-menu-open="true"] .nav {
     right: var(--space-3);
     background: none;
     border: 0;
-    font-size: 2rem;
+    font-size: var(--fs-h1);
     cursor: pointer;
 }
 
@@ -139,7 +139,7 @@ body[data-menu-open="true"] .nav {
         gap: var(--space-5);
     }
     .nav__link {
-        font-size: 1.125rem;
+        font-size: var(--fs-h3);
     }
 }
 

--- a/assets/styles/blocks/hero.css
+++ b/assets/styles/blocks/hero.css
@@ -10,8 +10,9 @@
 }
 
 .hero__title {
-    font-size: 2rem;
+    font-size: var(--fs-h1);
     margin-bottom: var(--space-4);
+    word-wrap: break-word;
 }
 
 .hero__form {
@@ -42,7 +43,7 @@
     flex: 1 1 60%;
     min-width: 60%;
     width: 100%;
-    font-size: 1rem;
+    font-size: var(--fs-base);
     padding: var(--space-2) var(--space-3);
     border: 1px solid var(--color-neutral);
     border-radius: var(--radius-sm);
@@ -74,10 +75,6 @@
 }
 
 @media (min-width: 768px) {
-    .hero__title {
-        font-size: 2.5rem;
-    }
-
     .hero__controls {
         flex-direction: row;
         align-items: center;
@@ -91,12 +88,6 @@
     .hero__submit {
         width: auto;
         align-self: stretch;
-    }
-}
-
-@media (min-width: 1024px) {
-    .hero__title {
-        font-size: 3rem;
     }
 }
 

--- a/assets/styles/components/card-groomer.css
+++ b/assets/styles/components/card-groomer.css
@@ -63,7 +63,7 @@
 
 .card-groomer__name {
     margin: 0 0 0.25rem;
-    font-size: 1rem;
+    font-size: var(--fs-base);
     font-weight: 600;
     line-height: 1.25;
     overflow: hidden;

--- a/assets/styles/components/city-cards.css
+++ b/assets/styles/components/city-cards.css
@@ -24,20 +24,20 @@
 }
 
 .city-card__icon {
-  width: 32px;
-  height: 32px;
-  border-radius: 9999px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--color-surface-2, #f3f4f6);
-  font-size: 18px;
+    width: 32px;
+    height: 32px;
+    border-radius: 9999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-surface-2, #f3f4f6);
+    font-size: var(--fs-h3);
 }
 
 .city-card__name {
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.25;
+    font-weight: 600;
+    font-size: var(--fs-base);
+    line-height: 1.25;
 }
 
 @media (min-width: 640px) {

--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -102,7 +102,7 @@
 
 .sticky-search .search-form__input,
 .sticky-search .search-form__select {
-    font-size: 1rem;
+    font-size: var(--fs-base);
 }
 
 .sticky-search .search-form__input,

--- a/assets/styles/nav.css
+++ b/assets/styles/nav.css
@@ -97,7 +97,7 @@
   .nav__link {
     display: block;
     padding: 0;
-    font-size: 1.25rem;
+    font-size: var(--fs-h2);
   }
 
   .nav-toggle {
@@ -110,7 +110,7 @@
     right: 1rem;
     background: none;
     border: 0;
-    font-size: 2rem;
+    font-size: var(--fs-h1);
     cursor: pointer;
   }
 

--- a/tests/E2E/TypographyScaleTest.php
+++ b/tests/E2E/TypographyScaleTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Panther\PantherTestCase;
+
+if (!class_exists(PantherTestCase::class)) {
+    class TypographyScaleTest extends TestCase
+    {
+        public function testPantherMissing(): void
+        {
+            $this->markTestSkipped('Panther not installed');
+        }
+    }
+
+    return;
+}
+
+use Facebook\WebDriver\WebDriverDimension;
+
+final class TypographyScaleTest extends PantherTestCase
+{
+    public function testFontSizesResponsive(): void
+    {
+        $client = self::createPantherClient();
+        $client->manage()->window()->setSize(new WebDriverDimension(375, 800));
+        $client->request('GET', '/');
+
+        $h1 = $client->executeScript('return parseFloat(getComputedStyle(document.querySelector("h1")).fontSize);');
+        $h2 = $client->executeScript('return parseFloat(getComputedStyle(document.querySelector("h2")).fontSize);');
+        $body = $client->executeScript('return parseFloat(getComputedStyle(document.body).fontSize);');
+
+        self::assertGreaterThanOrEqual(27, $h1);
+        self::assertLessThanOrEqual(29, $h1);
+        self::assertGreaterThanOrEqual(19, $h2);
+        self::assertLessThanOrEqual(21, $h2);
+        self::assertGreaterThanOrEqual(15, $body);
+        self::assertLessThanOrEqual(17, $body);
+
+        $client->manage()->window()->setSize(new WebDriverDimension(1024, 800));
+        $client->reload();
+
+        $h1Desktop = $client->executeScript('return parseFloat(getComputedStyle(document.querySelector("h1")).fontSize);');
+        $h2Desktop = $client->executeScript('return parseFloat(getComputedStyle(document.querySelector("h2")).fontSize);');
+        $bodyDesktop = $client->executeScript('return parseFloat(getComputedStyle(document.body).fontSize);');
+
+        self::assertGreaterThanOrEqual(28, $h1Desktop);
+        self::assertLessThanOrEqual(36, $h1Desktop);
+        self::assertGreaterThanOrEqual(20, $h2Desktop);
+        self::assertLessThanOrEqual(24, $h2Desktop);
+        self::assertGreaterThanOrEqual(16, $bodyDesktop);
+        self::assertLessThanOrEqual(18, $bodyDesktop);
+    }
+}


### PR DESCRIPTION
## Summary
- add CSS variables for base, h1, h2, and h3 sizes with fluid clamp scaling
- replace hard-coded font sizes with variables and ensure hero titles wrap
- add Panther E2E test validating font-size scale

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `APP_ENV=test php -d memory_limit=1G ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `APP_ENV=test php bin/console doctrine:database:create --if-not-exists` *(fails: operation not supported by platform)*
- `APP_ENV=test php bin/console doctrine:migrations:migrate --no-interaction` *(fails: table already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68ac748092ec8322997ad59acf30af98