### PR TITLE
fix: include mobile CTA styles

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -204,6 +204,8 @@ composer stan
 
 composer test
 
+php bin/console asset-map:compile
+
 
 Before completing a task, run all PHPUnit tests using the command:
 
@@ -232,6 +234,8 @@ Definition of Done (DoD)
  Security, perf, and error handling considered
 
  Static asset links (CSS/JS) verified to point to existing files to prevent 404s
+
+ Asset map compiles without missing references: php bin/console asset-map:compile
 
  PR template completed
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -10,6 +10,7 @@ import './styles/utilities.css';
 import './styles/blocks/carousel-mmGYQrl.css';
 import './styles/blocks/groomer-card.css';
 import './styles/components/badge.css';
+import './styles/components/mobile-cta.css';
 import './js/mobile-cta.js';
 
 console.log('This log comes from assets/app.js - welcome to AssetMapper! 🎉');


### PR DESCRIPTION
## Summary
- include mobile CTA styles in main asset entry so asset map publishes the file
- document required asset map compilation to prevent missing CSS/JS

## Testing
- `php bin/console asset-map:compile`
- `composer fix:php`
- `composer stan`
- `PHP_MEMORY_LIMIT=1G composer test` *(failed: memory exhausted)*
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`


------
https://chatgpt.com/codex/tasks/task_e_68ac7329a5cc832298ca94899463a37e