### PR TITLE
feat: add reusable loading spinner

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -12,5 +12,8 @@ import './styles/blocks/groomer-card.css';
 import './styles/components/badge.css';
 import './styles/components/mobile-cta.css';
 import './js/mobile-cta.js';
+import './js/loading.js';
+import './js/nav-loading.js';
+import './js/search-loading.js';
 
 console.log('This log comes from assets/app.js - welcome to AssetMapper! 🎉');

--- a/assets/js/city-autocomplete.js
+++ b/assets/js/city-autocomplete.js
@@ -1,3 +1,5 @@
+import { setLoading } from './loading.js';
+
 function debounce(fn, delay = 200) {
     let timer;
     return (...args) => {
@@ -55,13 +57,18 @@ export default function initCityAutocomplete(inputsParam) {
             name.className = 'city-card__name';
             name.textContent = opt.label;
 
-            card.append(icon, name);
+            const spin = document.createElement('span');
+            spin.className = 'spinner';
+            spin.hidden = true;
+
+            card.append(icon, name, spin);
             listbox.appendChild(card);
 
             const select = () => {
                 input.value = opt.value;
                 card.setAttribute('aria-selected', 'true');
                 hide();
+                setLoading(card, true);
 
                 const url = opt.url || (typeof routes !== 'undefined' && routes.cityShow ? routes.cityShow.replace(':slug', opt.value) : null);
                 if (url) window.location.assign(url);

--- a/assets/js/loading.js
+++ b/assets/js/loading.js
@@ -1,0 +1,7 @@
+export function setLoading(el, loading = true) {
+  if (!el) return;
+  const spinner = el.querySelector('.spinner') || el.querySelector('[role="status"], .mobile-cta__spinner');
+  el.classList.toggle('is-loading', loading);
+  el.setAttribute('aria-busy', loading ? 'true' : 'false');
+  if (spinner) spinner.hidden = !loading;
+}

--- a/assets/js/mobile-cta.js
+++ b/assets/js/mobile-cta.js
@@ -1,4 +1,6 @@
 // assets/js/mobile-cta.js
+import { setLoading } from './loading.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const cta = document.getElementById('mobile-cta');
   if (!cta) return;
@@ -6,7 +8,6 @@ document.addEventListener('DOMContentLoaded', () => {
   // Show only on mobile (same as CSS guard; keeps SSR hidden to avoid FOUC)
   const isMobile = () => window.matchMedia('(max-width: 767px)').matches;
   const btn = cta.querySelector('.mobile-cta__btn');
-  const spinner = cta.querySelector('.mobile-cta__spinner');
   const target = cta.getAttribute('data-target-route');
 
   const toggleVisibility = () => {
@@ -26,27 +27,16 @@ document.addEventListener('DOMContentLoaded', () => {
   toggleVisibility();
   window.addEventListener('resize', toggleVisibility);
 
-  const startLoading = () => {
-    btn.setAttribute('aria-disabled', 'true');
-    btn.classList.add('is-loading');
-    if (spinner) spinner.hidden = false;
-  };
-  const stopLoading = () => {
-    btn.removeAttribute('aria-disabled');
-    btn.classList.remove('is-loading');
-    if (spinner) spinner.hidden = true;
-  };
-
   btn.addEventListener('click', async (e) => {
     e.preventDefault();
     if (!target) return;
-    startLoading();
+    setLoading(btn, true);
     try {
       // Lightweight preflight same as cta-button.js pattern
       await fetch(target, { method: 'HEAD' });
       window.location.assign(target);
     } catch (err) {
-      stopLoading();
+      setLoading(btn, false);
       // optional: toast/error UI
     }
   });

--- a/assets/js/nav-loading.js
+++ b/assets/js/nav-loading.js
@@ -1,0 +1,23 @@
+import { setLoading } from './loading.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const link = document.querySelector('.nav__link[href*="app_search_redirect"]');
+  if (!link) return;
+  link.addEventListener('click', async (e) => {
+    const spin = link.querySelector('.spinner') || document.createElement('span');
+    if (!spin.classList.contains('spinner')) {
+      spin.className = 'spinner';
+      spin.hidden = true;
+      link.appendChild(spin);
+    }
+    const btnLike = link; // treat as target
+    setLoading(btnLike, true);
+    try {
+      await fetch(link.href, { method: 'HEAD' });
+      window.location.assign(link.href);
+    } catch {
+      setLoading(btnLike, false);
+    }
+    e.preventDefault();
+  });
+});

--- a/assets/js/search-loading.js
+++ b/assets/js/search-loading.js
@@ -1,0 +1,8 @@
+import { setLoading } from './loading.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('#search-form');
+  const submit = document.querySelector('#search-submit');
+  if (!form || !submit) return;
+  form.addEventListener('submit', () => setLoading(submit, true), { passive: true });
+});

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,3 +1,4 @@
+@import "./components/spinner.css";
 @import "./components/mobile-cta.css";
 @import "./components/city-cards.css";
 

--- a/assets/styles/components/mobile-cta.css
+++ b/assets/styles/components/mobile-cta.css
@@ -38,3 +38,5 @@
 @media (max-width: 767px) {
   .back-to-top { display: none !important; }
 }
+.mobile-cta__spinner { width: 16px; height: 16px; }
+.mobile-cta__spinner::before { content: ""; }

--- a/assets/styles/components/spinner.css
+++ b/assets/styles/components/spinner.css
@@ -1,0 +1,23 @@
+.spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  display: inline-block;
+  animation: spin .7s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .spinner { animation: none; }
+}
+
+/* Button loading state */
+.btn.is-loading {
+  pointer-events: none;
+  opacity: .85;
+}
+.btn.is-loading .btn__label { visibility: hidden; }
+.btn.is-loading .spinner { display: inline-block; }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -41,7 +41,7 @@
         <div id="mobile-cta" class="mobile-cta hidden-md hidden-lg" data-target-route="{{ path('app_search_redirect') }}" hidden>
             <button class="mobile-cta__btn btn btn--accent" type="button" aria-label="Find a Groomer">
                 <span class="mobile-cta__label">Find a Groomer</span>
-                <span class="mobile-cta__spinner" role="status" aria-live="polite" aria-hidden="true" hidden></span>
+                <span class="mobile-cta__spinner spinner" role="status" aria-live="polite" aria-hidden="true" hidden></span>
             </button>
         </div>
     </body>

--- a/templates/home/partials/_hero.html.twig
+++ b/templates/home/partials/_hero.html.twig
@@ -22,8 +22,9 @@
                         <div role="option" class="city-suggestion" data-value="{{ city.slug }}">{{ city.name }}</div>
                     {% endfor %}
                 </div>
-                <button class="hero__submit search-form__button btn btn--accent" type="submit" id="search-submit">
-                    {{ ctaLinks.find.label|trans }}
+                <button id="search-submit" class="hero__submit search-form__button btn btn--accent" type="submit" aria-live="polite" aria-busy="false">
+                    <span class="btn__label">{{ ctaLinks.find.label|trans }}</span>
+                    <span class="spinner" hidden></span>
                 </button>
             </div>
         </form>

--- a/tests/E2E/Homepage/LoadingStateTest.php
+++ b/tests/E2E/Homepage/LoadingStateTest.php
@@ -16,12 +16,13 @@ final class LoadingStateTest extends WebTestCase
         $this->client = static::createClient();
     }
 
-    public function testSearchButtonsDoNotIncludeSpinner(): void
+    public function testSearchButtonIncludesSpinner(): void
     {
         $crawler = $this->client->request('GET', '/');
         self::assertResponseIsSuccessful();
 
-        $spinners = $crawler->filter('.search-form__button .spinner');
-        self::assertCount(0, $spinners);
+        $spinners = $crawler->filter('#search-submit .spinner');
+        self::assertCount(1, $spinners);
+        self::assertSame('false', $crawler->filter('#search-submit')->attr('aria-busy'));
     }
 }


### PR DESCRIPTION
## Summary
- add spinner component and helper to manage loading states
- show spinner for hero search, nav find link, mobile CTA, and city cards
- update tests for new loader markup

## Testing
- `php bin/console asset-map:compile`
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`

------
https://chatgpt.com/codex/tasks/task_e_68ac791529d883228ac254ddbe41e0a0