### PR TITLE
feat: add mobile sticky CTA

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -38,5 +38,13 @@
         </main>
 
         {% include 'partials/_footer.html.twig' %}
+
+        {% block sticky_mobile_cta %}
+            <div class="sticky-mobile-cta mobile-only">
+                <a href="{{ path('app_search_redirect') }}" role="button" aria-label="Find a groomer">
+                    <span>{{ 'Find a Groomer'|trans }}</span>
+                </a>
+            </div>
+        {% endblock %}
     </body>
 </html>


### PR DESCRIPTION
## Summary
- add mobile-only sticky CTA linking to the search redirect route

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --testdox`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68ac8cdfeea483229edba9af3906b72e