### PR TITLE
feat: include sticky CTA styles in main bundle

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,3 +1,5 @@
+@import "./components/sticky-cta.css";
+
 *, *::before, *::after {
     box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- import sticky CTA component stylesheet into main app CSS

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68ac8ef9cbec8322a9f02aa2c2e05330