### PR TITLE
fix: hide sticky CTA on desktop

### DIFF
--- a/assets/styles/components/sticky-cta.css
+++ b/assets/styles/components/sticky-cta.css
@@ -15,3 +15,9 @@
     width: 100%;
     min-height: 3rem;
 }
+
+@media (min-width: 768px) {
+    .sticky-cta {
+        display: none;
+    }
+}


### PR DESCRIPTION
## Summary
- hide sticky CTA on screens 768px and wider

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=512M ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68ac9091ac8883229e8dc7d61d6e3d7c