### PR TITLE
fix: hide back-to-top button on small screens

### DIFF
--- a/assets/styles/blocks/footer-UjmJUYX.css
+++ b/assets/styles/blocks/footer-UjmJUYX.css
@@ -192,6 +192,12 @@
     transform: translateY(-2px);
 }
 
+@media (max-width: 768px) {
+    .back-to-top {
+        display: none;
+    }
+}
+
 @media (min-width: 768px) {
     .footer-search {
         max-width: none;


### PR DESCRIPTION
## Summary
- hide the `back-to-top` button on screens 768px wide or smaller

## Testing
- `composer lint:php`
- `composer stan`
- ⚠️ `composer test` (memory exhausted)
- `php -d memory_limit=512M ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68ac93dc6ec08322b92ba1363942ab7a