### PR TITLE
Guard back-to-top JS against missing element

### DIFF
--- a/assets/js/back-to-top.js
+++ b/assets/js/back-to-top.js
@@ -3,7 +3,7 @@
 
 const initBackToTop = () => {
     const btn = document.querySelector('.back-to-top');
-    if (!btn) {
+    if (!btn || window.getComputedStyle(btn).display === 'none') {
         return;
     }
 


### PR DESCRIPTION
## Summary
- avoid scroll listener if back-to-top button missing or hidden

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68ac94f68a1c8322a2d0a623e0ad4156