### PR TITLE
feat: support sticky CTA buttons

### DIFF
--- a/src/public/js/cta-button.js
+++ b/src/public/js/cta-button.js
@@ -3,41 +3,48 @@
     doc = doc || document;
     fetchFn = fetchFn || (typeof fetch !== 'undefined' ? fetch.bind(global) : null);
     win = win || global;
-    var button = doc.querySelector('.cta-banner__link--owners');
-    if (!button) {
+    var buttons = doc.querySelectorAll(
+      '.cta-banner__link--owners, .sticky-cta__btn'
+    );
+    if (!buttons.length) {
       return;
     }
-    var errorEl = doc.createElement('span');
-    errorEl.className = 'cta-button__error';
-    errorEl.setAttribute('role', 'status');
-    errorEl.setAttribute('aria-live', 'polite');
-    errorEl.hidden = true;
-    button.after(errorEl);
-    button.removeAttribute('aria-disabled');
-    var pending = false;
-    button.addEventListener('click', function (e) {
-      if (pending) {
-        if (e && typeof e.preventDefault === 'function') {
-          e.preventDefault();
+    function setupButton(button) {
+      var errorEl = doc.createElement('span');
+      errorEl.className = 'cta-button__error';
+      errorEl.setAttribute('role', 'status');
+      errorEl.setAttribute('aria-live', 'polite');
+      errorEl.hidden = true;
+      button.after(errorEl);
+      button.removeAttribute('aria-disabled');
+      var pending = false;
+      button.addEventListener('click', function (e) {
+        if (pending) {
+          if (e && typeof e.preventDefault === 'function') {
+            e.preventDefault();
+          }
+          return;
         }
-        return;
-      }
-      pending = true;
-      button.setAttribute('aria-disabled', 'true');
-      var href = button.getAttribute('href');
-      if (fetchFn) {
-        fetchFn(href, { method: 'HEAD' })
-          .then(function () {
-            win.location.href = href;
-          })
-          .catch(function () {
-            pending = false;
-            button.removeAttribute('aria-disabled');
-            errorEl.textContent = 'Please try again';
-            errorEl.hidden = false;
-          });
-      }
-    });
+        pending = true;
+        button.setAttribute('aria-disabled', 'true');
+        var href = button.getAttribute('href');
+        if (fetchFn) {
+          fetchFn(href, { method: 'HEAD' })
+            .then(function () {
+              win.location.href = href;
+            })
+            .catch(function () {
+              pending = false;
+              button.removeAttribute('aria-disabled');
+              errorEl.textContent = 'Please try again';
+              errorEl.hidden = false;
+            });
+        }
+      });
+    }
+    for (var i = 0; i < buttons.length; i++) {
+      setupButton(buttons[i]);
+    }
   }
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = { initCtaButton: initCtaButton };

--- a/tests/Frontend/Unit/CtaButtonTest.js
+++ b/tests/Frontend/Unit/CtaButtonTest.js
@@ -15,16 +15,16 @@ function createButton() {
   return button;
 }
 
-function createDocument(button) {
+function createDocument(buttons) {
   return {
-    querySelector: () => button,
+    querySelectorAll: () => buttons,
     createElement: () => ({ className: '', hidden: false, setAttribute() {}, after() {} }),
   };
 }
 
 (function testDebounce() {
   const button = createButton();
-  const doc = createDocument(button);
+  const doc = createDocument([button]);
   let fetchCalls = 0;
   function fakeFetch() {
     fetchCalls += 1;
@@ -35,6 +35,23 @@ function createDocument(button) {
   button.eventListeners.click({ preventDefault() {} });
   assert.strictEqual(fetchCalls, 1, 'double click debounced');
   assert.strictEqual(button.attributes['aria-disabled'], 'true', 'button disabled after click');
+})();
+
+(function testMultipleButtons() {
+  const buttonOne = createButton();
+  const buttonTwo = createButton();
+  const doc = createDocument([buttonOne, buttonTwo]);
+  let fetchCalls = 0;
+  function fakeFetch() {
+    fetchCalls += 1;
+    return new Promise(() => {});
+  }
+  initCtaButton(doc, fakeFetch, {});
+  buttonOne.eventListeners.click({ preventDefault() {} });
+  buttonTwo.eventListeners.click({ preventDefault() {} });
+  assert.strictEqual(fetchCalls, 2, 'both buttons handled');
+  assert.strictEqual(buttonOne.attributes['aria-disabled'], 'true');
+  assert.strictEqual(buttonTwo.attributes['aria-disabled'], 'true');
 })();
 
 console.log('CtaButton tests passed');


### PR DESCRIPTION
## Summary
- handle `.sticky-cta__btn` elements alongside existing owner CTA links
- update unit tests for multiple CTA buttons

## Testing
- `composer lint:php`
- `composer stan`
- `node tests/Frontend/Unit/CtaButtonTest.js`
- `php bin/console asset-map:compile`
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d zend.enable_gc=0 -d memory_limit=1G ./vendor/bin/phpunit --testdox`
- `./vendor/bin/phpunit --log-junit /tmp/phpunit.log`


------
https://chatgpt.com/codex/tasks/task_e_68ac95c61ba48322830db8edd4b6bb86