### PR TITLE
fix: prevent sticky CTA overlapping footer on iOS

### DIFF
--- a/assets/styles/utilities.css
+++ b/assets/styles/utilities.css
@@ -18,3 +18,11 @@
 /* Margin utilities */
 .mb-4 { margin-bottom: 1rem; }
 .mt-6 { margin-top: 1.5rem; }
+
+/* Sticky CTA spacer */
+@media (max-width: 767px) {
+    .has-sticky-cta {
+        --sticky-cta-h: 64px;
+        padding-bottom: calc(var(--sticky-cta-h) + env(safe-area-inset-bottom));
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -33,7 +33,7 @@
     <body id="top" data-route="{{ app.request.attributes.get('_route') }}">
         <a href="#main-content" class="skip-link">Skip to main content</a>
         {% include 'partials/_header.html.twig' %}
-        <main id="main-content" tabindex="-1">
+        <main id="main-content" tabindex="-1" class="has-sticky-cta">
             {% block body %}{% endblock %}
         </main>
 


### PR DESCRIPTION
## Summary
- add mobile-only spacing utility `.has-sticky-cta` to avoid sticky CTA covering footer
- apply new utility to base layout `<main>` element

## Testing
- `composer fix:php`
- `composer stan`
- `composer test`
- `php bin/console asset-map:compile`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox --log-junit /tmp/phpunit.log`


------
https://chatgpt.com/codex/tasks/task_e_68ac977e23908322acfe8c9ba29747c7