### PR TITLE
feat: add aria live region for mobile CTA

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -44,6 +44,7 @@
                 <a href="{{ path('app_search_redirect') }}" role="button" aria-label="Find a groomer">
                     <span>{{ 'Find a Groomer'|trans }}</span>
                 </a>
+                <span id="mobile-cta-feedback" class="sr-only" aria-live="polite"></span>
             </div>
         {% endblock %}
     </body>


### PR DESCRIPTION
## Summary
- add `aria-live="polite"` region to sticky mobile CTA for future feedback

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`

------
https://chatgpt.com/codex/tasks/task_e_68ac98ba83e4832297e8d93d6648bf82