### PR TITLE
test: verify mobile sticky CTA visibility

### DIFF
--- a/tests/E2E/Homepage/StickyCtaTest.php
+++ b/tests/E2E/Homepage/StickyCtaTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E\Homepage;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Panther\PantherTestCase;
+
+if (!class_exists(PantherTestCase::class)) {
+    class StickyCtaTest extends TestCase
+    {
+        public function testPantherMissing(): void
+        {
+            $this->markTestSkipped('Panther not installed');
+        }
+    }
+
+    return;
+}
+
+use Facebook\WebDriver\WebDriverDimension;
+
+final class StickyCtaTest extends PantherTestCase
+{
+    public function testStickyCtaVisibleOnMobile(): void
+    {
+        $client = self::createPantherClient();
+        $client->manage()->window()->setSize(new WebDriverDimension(375, 667));
+        $client->request('GET', '/');
+
+        self::assertSelectorExists('.sticky-cta__btn');
+        $display = $client->executeScript('return window.getComputedStyle(document.querySelector(".back-to-top")).display;');
+        self::assertSame('none', $display);
+    }
+}


### PR DESCRIPTION
## Summary
- add Panther E2E test ensuring sticky CTA appears on mobile while back-to-top remains hidden

## Testing
- `php bin/console asset-map:compile`
- `composer fix:php`
- `composer stan`
- `composer test`
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`


------
https://chatgpt.com/codex/tasks/task_e_68ac9a42e3f48322ad4778b124cca7d4