### PR TITLE
feat: add city card component styles

### DIFF
--- a/assets/styles/components/city-card.css
+++ b/assets/styles/components/city-card.css
@@ -1,0 +1,54 @@
+.city-card {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    width: 100%;
+    padding: var(--space-3);
+    min-height: 44px;
+    background-color: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 9999px;
+    text-decoration: none;
+    color: #111;
+    transition: background-color 0.2s, color 0.2s, box-shadow 0.2s, border-color 0.2s;
+}
+
+.city-card:hover,
+.city-card:focus,
+.city-card.active,
+.city-card[aria-selected="true"] {
+    background-color: var(--color-accent, #2563eb);
+    color: #fff;
+    border-color: var(--color-accent, #2563eb);
+    box-shadow: 0 0 0 2px var(--color-accent, #2563eb);
+}
+
+.city-card:focus {
+    outline: none;
+}
+
+.city-card:hover .city-card__icon,
+.city-card:focus .city-card__icon,
+.city-card.active .city-card__icon,
+.city-card[aria-selected="true"] .city-card__icon {
+    background-color: #fff;
+    color: var(--color-accent, #2563eb);
+}
+
+.city-card__icon {
+    --icon-size: 2.75rem;
+    flex-shrink: 0;
+    width: var(--icon-size);
+    height: var(--icon-size);
+    border-radius: 50%;
+    background-color: #f3f4f6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #111;
+}
+
+.city-card__label {
+    flex: 1;
+    overflow-wrap: anywhere;
+}

--- a/public/css/components/city-card.css
+++ b/public/css/components/city-card.css
@@ -1,0 +1,54 @@
+.city-card {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    width: 100%;
+    padding: var(--space-3);
+    min-height: 44px;
+    background-color: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 9999px;
+    text-decoration: none;
+    color: #111;
+    transition: background-color 0.2s, color 0.2s, box-shadow 0.2s, border-color 0.2s;
+}
+
+.city-card:hover,
+.city-card:focus,
+.city-card.active,
+.city-card[aria-selected="true"] {
+    background-color: var(--color-accent, #2563eb);
+    color: #fff;
+    border-color: var(--color-accent, #2563eb);
+    box-shadow: 0 0 0 2px var(--color-accent, #2563eb);
+}
+
+.city-card:focus {
+    outline: none;
+}
+
+.city-card:hover .city-card__icon,
+.city-card:focus .city-card__icon,
+.city-card.active .city-card__icon,
+.city-card[aria-selected="true"] .city-card__icon {
+    background-color: #fff;
+    color: var(--color-accent, #2563eb);
+}
+
+.city-card__icon {
+    --icon-size: 2.75rem;
+    flex-shrink: 0;
+    width: var(--icon-size);
+    height: var(--icon-size);
+    border-radius: 50%;
+    background-color: #f3f4f6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #111;
+}
+
+.city-card__label {
+    flex: 1;
+    overflow-wrap: anywhere;
+}

--- a/src/public/css/components/city-card.css
+++ b/src/public/css/components/city-card.css
@@ -1,0 +1,54 @@
+.city-card {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    width: 100%;
+    padding: var(--space-3);
+    min-height: 44px;
+    background-color: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 9999px;
+    text-decoration: none;
+    color: #111;
+    transition: background-color 0.2s, color 0.2s, box-shadow 0.2s, border-color 0.2s;
+}
+
+.city-card:hover,
+.city-card:focus,
+.city-card.active,
+.city-card[aria-selected="true"] {
+    background-color: var(--color-accent, #2563eb);
+    color: #fff;
+    border-color: var(--color-accent, #2563eb);
+    box-shadow: 0 0 0 2px var(--color-accent, #2563eb);
+}
+
+.city-card:focus {
+    outline: none;
+}
+
+.city-card:hover .city-card__icon,
+.city-card:focus .city-card__icon,
+.city-card.active .city-card__icon,
+.city-card[aria-selected="true"] .city-card__icon {
+    background-color: #fff;
+    color: var(--color-accent, #2563eb);
+}
+
+.city-card__icon {
+    --icon-size: 2.75rem;
+    flex-shrink: 0;
+    width: var(--icon-size);
+    height: var(--icon-size);
+    border-radius: 50%;
+    background-color: #f3f4f6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #111;
+}
+
+.city-card__label {
+    flex: 1;
+    overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Summary
- add reusable `.city-card` CSS component with hover, focus, and selected styles

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68ac9e7512508322bd3ab84037521ca2