### PR TITLE
fix: improve city listbox accessibility

### DIFF
--- a/assets/js/city-autocomplete.js
+++ b/assets/js/city-autocomplete.js
@@ -38,7 +38,14 @@ export default function initCityAutocomplete(inputsParam) {
         activeIndex = -1;
     };
 
-    const select = (opt) => {
+    const select = (opt, item) => {
+        if (item) {
+            listEl.querySelectorAll('[role="option"]').forEach((el) => {
+                const isSelected = el === item;
+                el.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+                el.classList.toggle('active', isSelected);
+            });
+        }
         if (currentInput) {
             currentInput.value = opt.value;
         }
@@ -88,12 +95,12 @@ export default function initCityAutocomplete(inputsParam) {
 
             card.addEventListener('mousedown', (e) => {
                 e.preventDefault();
-                select(opt);
+                select(opt, card);
             });
             card.addEventListener('keydown', (e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault();
-                    select(opt);
+                    select(opt, card);
                 }
             });
             card.addEventListener('click', (e) => e.preventDefault());
@@ -141,7 +148,7 @@ export default function initCityAutocomplete(inputsParam) {
                 if (activeIndex >= 0) {
                     e.preventDefault();
                     const item = listEl.querySelectorAll('[role="option"]')[activeIndex];
-                    select({ value: item.dataset.value, label: item.textContent });
+                    select({ value: item.dataset.value, label: item.textContent }, item);
                 }
             } else if (e.key === 'Escape') {
                 hide();

--- a/templates/home/partials/_hero.html.twig
+++ b/templates/home/partials/_hero.html.twig
@@ -19,7 +19,7 @@
                 >
                 <div id="city-list" class="city-suggestions" role="listbox" hidden>
                     {% for city in cities %}
-                        <div role="option" class="city-suggestion" data-value="{{ city.slug }}">{{ city.name }}</div>
+                        <div role="option" aria-selected="false" class="city-suggestion" data-value="{{ city.slug }}">{{ city.name }}</div>
                     {% endfor %}
                 </div>
                 <button class="hero__submit search-form__button btn btn--accent" type="submit" id="search-submit">


### PR DESCRIPTION
## Summary
- ensure city suggestions expose option roles with aria-selected state
- toggle aria-selected when options are highlighted or chosen

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68aca1d5c91c8322af5384bb96c9081e