### PR TITLE
fix: enlarge city card tap target

### DIFF
--- a/assets/styles/components/city-card.css
+++ b/assets/styles/components/city-card.css
@@ -4,7 +4,7 @@
     gap: var(--space-2);
     width: 100%;
     padding: var(--space-3);
-    min-height: 44px;
+    min-height: 48px;
     background-color: #fff;
     border: 1px solid #e5e7eb;
     border-radius: 9999px;
@@ -51,4 +51,5 @@
 .city-card__label {
     flex: 1;
     overflow-wrap: anywhere;
+    line-height: 1.25;
 }

--- a/public/css/components/city-card.css
+++ b/public/css/components/city-card.css
@@ -4,7 +4,7 @@
     gap: var(--space-2);
     width: 100%;
     padding: var(--space-3);
-    min-height: 44px;
+    min-height: 48px;
     background-color: #fff;
     border: 1px solid #e5e7eb;
     border-radius: 9999px;
@@ -51,4 +51,5 @@
 .city-card__label {
     flex: 1;
     overflow-wrap: anywhere;
+    line-height: 1.25;
 }

--- a/src/public/css/components/city-card.css
+++ b/src/public/css/components/city-card.css
@@ -4,7 +4,7 @@
     gap: var(--space-2);
     width: 100%;
     padding: var(--space-3);
-    min-height: 44px;
+    min-height: 48px;
     background-color: #fff;
     border: 1px solid #e5e7eb;
     border-radius: 9999px;
@@ -51,4 +51,5 @@
 .city-card__label {
     flex: 1;
     overflow-wrap: anywhere;
+    line-height: 1.25;
 }


### PR DESCRIPTION
## Summary
- ensure `.city-card` maintains a larger 48px tap target
- improve `.city-card__label` readability with taller line-height

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68aca5854aa883228301676e7b051e4c