### PR TITLE
test: adjust hero search E2E for city-card structure

### DIFF
--- a/tests/E2E/HeroSearchTest.php
+++ b/tests/E2E/HeroSearchTest.php
@@ -61,16 +61,21 @@ final class HeroSearchTest extends PantherTestCase
 
         $input = $client->getWebDriver()->findElement(WebDriverBy::cssSelector('#city'));
         $input->sendKeys('va');
-        $client->waitFor('#city-list [role="option"]');
+        $client->waitFor('#city-list .city-card');
+        self::assertSelectorExists('#city-list .city-card[role="option"]');
         $visible = $client->executeScript('return !document.getElementById("city-list").hidden;');
         self::assertTrue($visible);
-        $count = $client->executeScript('return document.querySelectorAll("#city-list [role=\\"option\\"]").length;');
+        $count = $client->executeScript('return document.querySelectorAll("#city-list .city-card").length;');
         self::assertSame(1, $count);
 
         $input->clear();
         $input->sendKeys('so');
-        $client->waitFor('#city-list [role="option"]');
+        $client->waitFor('#city-list .city-card');
+        $option = $client->getWebDriver()->findElement(WebDriverBy::cssSelector('#city-list .city-card'));
+        self::assertSame('option', $option->getAttribute('role'));
+        self::assertSame('false', $option->getAttribute('aria-selected'));
         $input->sendKeys(WebDriverKeys::ARROW_DOWN);
+        self::assertSame('true', $option->getAttribute('aria-selected'));
         $input->sendKeys(WebDriverKeys::ENTER);
         $hidden = $client->executeScript('return document.getElementById("city-list").hidden;');
         self::assertTrue($hidden);


### PR DESCRIPTION
## Summary
- update hero search test to target `.city-card` results and assert selection with aria semantics

## Testing
- `composer fix:php -- tests/E2E/HeroSearchTest.php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68aca7ef853c8322a0c0b4558d7aa5c7