### PR TITLE
fix: use variables for heading font sizes

### DIFF
--- a/assets/styles/blocks/footer-UjmJUYX.css
+++ b/assets/styles/blocks/footer-UjmJUYX.css
@@ -48,7 +48,7 @@
 }
 
 .footer-heading {
-    font-size: 1.125rem;
+    font-size: calc(var(--fs-h3) * 3 / 4);
     font-weight: 700;
     margin: 0 0 var(--space-2);
 }

--- a/assets/styles/blocks/hero.css
+++ b/assets/styles/blocks/hero.css
@@ -10,7 +10,7 @@
 }
 
 .hero__title {
-    font-size: 2rem;
+    font-size: calc(var(--fs-h1) * 8 / 7);
     margin-bottom: var(--space-4);
 }
 
@@ -75,7 +75,7 @@
 
 @media (min-width: 768px) {
     .hero__title {
-        font-size: 2.5rem;
+        font-size: calc(var(--fs-h1) * 10 / 7);
     }
 
     .hero__controls {
@@ -96,7 +96,7 @@
 
 @media (min-width: 1024px) {
     .hero__title {
-        font-size: 3rem;
+        font-size: calc(var(--fs-h1) * 12 / 7);
     }
 }
 

--- a/assets/styles/components/card-groomer.css
+++ b/assets/styles/components/card-groomer.css
@@ -63,7 +63,7 @@
 
 .card-groomer__name {
     margin: 0 0 0.25rem;
-    font-size: 1rem;
+    font-size: calc(var(--fs-h3) * 2 / 3);
     font-weight: 600;
     line-height: 1.25;
     overflow: hidden;


### PR DESCRIPTION
## Summary
- replace hard-coded hero title sizes with scaled `--fs-h1` variables
- tie card and footer headings to `--fs-h3` variable values

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68acaba0bce483229d42cb724f3e1467