### PR TITLE
fix: ensure buttons use base font size

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -79,6 +79,7 @@ h3 { font-size: var(--fs-h3); }
     cursor: pointer;
     text-decoration: none;
     font-weight: 600;
+    font-size: var(--fs-base);
 }
 
 .btn--accent {


### PR DESCRIPTION
## Summary
- ensure `.btn` text uses `--fs-base`

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php bin/console doctrine:database:create --if-not-exists` *(fails: Operation 'Doctrine\\DBAL\\Platforms\\AbstractPlatform::getListDatabasesSQL' is not supported by platform)*
- `APP_ENV=test php bin/console doctrine:migrations:migrate --no-interaction` *(fails: table with name "public.city" already exists)*
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68acadc44b40832293e3d74cc8a65715