### PR TITLE
test: add typography font size assertions

### DIFF
--- a/tests/UI/TypographyTest.php
+++ b/tests/UI/TypographyTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\UI;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Panther\PantherTestCase;
+
+if (!class_exists(PantherTestCase::class)) {
+    final class TypographyTest extends TestCase
+    {
+        public function testPantherMissing(): void
+        {
+            $this->markTestSkipped('Panther not installed');
+        }
+    }
+
+    return;
+}
+
+final class TypographyTest extends PantherTestCase
+{
+    public function testComputedFontSizes(): void
+    {
+        $client = self::createPantherClient();
+        $client->request('GET', '/');
+
+        $body = $client->executeScript('return window.getComputedStyle(document.body).fontSize;');
+        self::assertSame('16px', $body);
+
+        $h1 = $client->executeScript('return window.getComputedStyle(document.querySelector("h1")).fontSize;');
+        self::assertSame('28px', $h1);
+
+        $h2 = $client->executeScript('return window.getComputedStyle(document.querySelector("h2")).fontSize;');
+        self::assertSame('20px', $h2);
+    }
+}


### PR DESCRIPTION
## Summary
- add UI test ensuring body, h1, and h2 font sizes match design tokens

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` (fails: Allowed memory size of 134217728 bytes exhausted)
- `php bin/console asset-map:compile`
- `APP_ENV=test php -d memory_limit=512M ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`


------
https://chatgpt.com/codex/tasks/task_e_68acb1117dfc83229552e5490c071c72