### PR TITLE
fix: expand popular city link spacing

### DIFF
--- a/public/css/sections/popular-cities.css
+++ b/public/css/sections/popular-cities.css
@@ -33,14 +33,21 @@
     width: 100%;
     height: 100%;
     padding: var(--space-3);
+    margin-bottom: var(--space-2);
     background-color: #fff;
     border: 1px solid #e5e7eb;
     border-radius: 9999px;
     text-decoration: none;
     color: #111;
     min-width: 44px;
-    min-height: 44px;
+    min-height: 48px;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s, border-color 0.2s;
+}
+
+@media (min-width: 640px) {
+    .popular-cities__link {
+        margin-bottom: 0;
+    }
 }
 
 .popular-cities__link:hover,


### PR DESCRIPTION
## Summary
- ensure popular cities links have larger touch target and margin on mobile

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `APP_ENV=test php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `APP_ENV=test php -d memory_limit=1G ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68acb59146f883229401c7502a95937c