### PR TITLE
fix: increase hero form gap on small screens

### DIFF
--- a/assets/styles/blocks/hero.css
+++ b/assets/styles/blocks/hero.css
@@ -32,6 +32,12 @@
     display: none;
 }
 
+@media (max-width: 375px) {
+    .hero__controls {
+        gap: var(--space-3);
+    }
+}
+
 .hero__label {
     display: block;
     margin: 0;


### PR DESCRIPTION
## Summary
- improve small-screen hero layout by increasing form control gap at <=375px

## Testing
- `composer lint:php`
- `composer stan`
- `php -d memory_limit=512M $(which composer) test`
- `APP_ENV=test php -d memory_limit=512M ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68acb6cb25d48322829ad7f95ceb3034