### PR TITLE
test: add small-screen tap target spacing

### DIFF
--- a/tests/E2E/Mobile/TapTargetsTest.php
+++ b/tests/E2E/Mobile/TapTargetsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\E2E\Mobile;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Panther\PantherTestCase;
+
+if (!class_exists(PantherTestCase::class)) {
+    class TapTargetsTest extends TestCase
+    {
+        public function testPantherMissing(): void
+        {
+            $this->markTestSkipped('Panther not installed');
+        }
+    }
+
+    return;
+}
+
+use App\Entity\City;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Facebook\WebDriver\WebDriverBy;
+use Facebook\WebDriver\WebDriverDimension;
+
+final class TapTargetsTest extends PantherTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testTapTargetsAreLargeEnough(): void
+    {
+        $city = new City('Sofia');
+        $city->refreshSlugFrom($city->getName());
+        $this->em->persist($city);
+        $this->em->flush();
+
+        $client = self::createPantherClient();
+        $client->manage()->window()->setSize(new WebDriverDimension(360, 640));
+        $client->request('GET', '/');
+
+        $client->executeScript('document.getElementById("nav-toggle").click();');
+
+        $input = $client->getWebDriver()->findElement(WebDriverBy::cssSelector('#city'));
+        $input->sendKeys('so');
+        $client->waitFor('#city-list .city-card');
+
+        $btnHeight = $client->executeScript('return document.querySelector(".btn").getBoundingClientRect().height;');
+        $navLinkHeight = $client->executeScript('return document.querySelector(".nav__link").getBoundingClientRect().height;');
+        $cityCardHeight = $client->executeScript('return document.querySelector("#city-list .city-card").getBoundingClientRect().height;');
+
+        self::assertGreaterThanOrEqual(44, $btnHeight);
+        self::assertGreaterThanOrEqual(44, $navLinkHeight);
+        self::assertGreaterThanOrEqual(44, $cityCardHeight);
+    }
+}


### PR DESCRIPTION
## Summary
- check .btn, .nav__link, and .city-card are at least 44px tall at 360x640 using `getBoundingClientRect`

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=1G ./vendor/bin/phpunit --testdox`
- `APP_ENV=test php -d memory_limit=1G ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68acb96487048322a654c9f53afa3ea1