### PR TITLE
feat: add spinner helper to CTA button

### DIFF
--- a/src/public/js/cta-button.js
+++ b/src/public/js/cta-button.js
@@ -18,6 +18,28 @@
       button.after(errorEl);
       button.removeAttribute('aria-disabled');
       var pending = false;
+
+      function addSpinner() {
+        var spinner = doc.createElement('span');
+        spinner.className = 'spinner';
+        spinner.setAttribute('role', 'status');
+        spinner.setAttribute('aria-live', 'polite');
+        var hidden = doc.createElement('span');
+        hidden.className = 'visually-hidden';
+        hidden.textContent = 'Loading';
+        spinner.appendChild(hidden);
+        button.insertBefore(spinner, button.firstChild);
+        button.setAttribute('aria-busy', 'true');
+        return spinner;
+      }
+
+      function removeSpinner(spinner) {
+        button.removeAttribute('aria-busy');
+        if (spinner && spinner.parentNode === button) {
+          button.removeChild(spinner);
+        }
+      }
+
       button.addEventListener('click', function (e) {
         if (pending) {
           if (e && typeof e.preventDefault === 'function') {
@@ -27,6 +49,7 @@
         }
         pending = true;
         button.setAttribute('aria-disabled', 'true');
+        var spinner = addSpinner();
         var href = button.getAttribute('href');
         if (fetchFn) {
           fetchFn(href, { method: 'HEAD' })
@@ -36,6 +59,7 @@
             .catch(function () {
               pending = false;
               button.removeAttribute('aria-disabled');
+              removeSpinner(spinner);
               errorEl.textContent = 'Please try again';
               errorEl.hidden = false;
             });


### PR DESCRIPTION
## Summary
- add spinner injection for CTA button and remove on error

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `APP_ENV=test php -d memory_limit=512M ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68acbd3a28608322ac868b97d19c7507