### PR TITLE
feat: wrap sticky CTA label for spinner

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -41,8 +41,8 @@
 
         {% block sticky_mobile_cta %}
             <div class="sticky-mobile-cta mobile-only">
-                <a href="{{ path('app_search_redirect') }}" role="button" aria-label="Find a groomer">
-                    <span>{{ 'Find a Groomer'|trans }}</span>
+                <a href="{{ path('app_search_redirect') }}" class="sticky-cta__btn btn btn--accent" role="button" aria-label="Find a groomer">
+                    <span class="btn__label">{{ 'Find a Groomer'|trans }}</span>
                 </a>
                 <span id="mobile-cta-feedback" class="sr-only" aria-live="polite"></span>
             </div>


### PR DESCRIPTION
## Summary
- wrap sticky CTA label in `.btn__label`
- add button classes for mobile sticky CTA

## Testing
- `composer fix:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68acc3a4fb708322b1b6d5e00ec2994c