### PR TITLE
fix: prevent duplicate spinners

### DIFF
--- a/assets/js/city-autocomplete.js
+++ b/assets/js/city-autocomplete.js
@@ -45,18 +45,23 @@ export default function initCityAutocomplete(inputsParam) {
         }
         navigating = true;
         listEl.setAttribute('aria-busy', 'true');
-        const spinner = document.createElement('span');
-        spinner.className = 'spinner';
-        spinner.setAttribute('role', 'status');
-        spinner.setAttribute('aria-live', 'polite');
-        const hidden = document.createElement('span');
-        hidden.className = 'visually-hidden';
-        hidden.textContent = 'Loading';
-        spinner.appendChild(hidden);
-        card.appendChild(spinner);
+        let spinner = card.querySelector('.spinner');
+        if (!spinner) {
+            spinner = document.createElement('span');
+            spinner.className = 'spinner';
+            spinner.setAttribute('role', 'status');
+            spinner.setAttribute('aria-live', 'polite');
+            const hidden = document.createElement('span');
+            hidden.className = 'visually-hidden';
+            hidden.textContent = 'Loading';
+            spinner.appendChild(hidden);
+            card.appendChild(spinner);
+        }
 
         const cleanup = () => {
-            spinner.remove();
+            if (spinner && spinner.parentNode) {
+                spinner.remove();
+            }
             listEl.removeAttribute('aria-busy');
             navigating = false;
         };

--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -17,14 +17,17 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         submit.setAttribute('aria-busy', 'true');
         submit.disabled = true;
-        const spinner = document.createElement('span');
-        spinner.className = 'spinner';
-        spinner.setAttribute('role', 'status');
-        spinner.setAttribute('aria-live', 'polite');
-        const hidden = document.createElement('span');
-        hidden.className = 'visually-hidden';
-        hidden.textContent = 'Loading';
-        spinner.appendChild(hidden);
-        submit.insertBefore(spinner, submit.firstChild);
+        let spinner = submit.querySelector('.spinner');
+        if (!spinner) {
+            spinner = document.createElement('span');
+            spinner.className = 'spinner';
+            spinner.setAttribute('role', 'status');
+            spinner.setAttribute('aria-live', 'polite');
+            const hidden = document.createElement('span');
+            hidden.className = 'visually-hidden';
+            hidden.textContent = 'Loading';
+            spinner.appendChild(hidden);
+            submit.insertBefore(spinner, submit.firstChild);
+        }
     });
 });

--- a/src/public/js/cta-button.js
+++ b/src/public/js/cta-button.js
@@ -20,7 +20,11 @@
       var pending = false;
 
       function addSpinner() {
-        var spinner = doc.createElement('span');
+        var spinner = button.querySelector('.spinner');
+        if (spinner) {
+          return spinner;
+        }
+        spinner = doc.createElement('span');
         spinner.className = 'spinner';
         spinner.setAttribute('role', 'status');
         spinner.setAttribute('aria-live', 'polite');


### PR DESCRIPTION
## Summary
- ensure CTA buttons reuse existing spinner instead of inserting duplicate elements
- guard search form submit and city autocomplete navigation against adding multiple spinners

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Panther missing)*
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68acc74d1f4883228d7bccea88fa3ee7