### PR TITLE
fix: prevent duplicate spinners

### DIFF
--- a/assets/js/city-autocomplete.js
+++ b/assets/js/city-autocomplete.js
@@ -45,15 +45,18 @@ export default function initCityAutocomplete(inputsParam) {
         }
         navigating = true;
         listEl.setAttribute('aria-busy', 'true');
-        const spinner = document.createElement('span');
-        spinner.className = 'spinner';
-        spinner.setAttribute('role', 'status');
-        spinner.setAttribute('aria-live', 'polite');
-        const hidden = document.createElement('span');
-        hidden.className = 'visually-hidden';
-        hidden.textContent = 'Loading';
-        spinner.appendChild(hidden);
-        card.appendChild(spinner);
+        let spinner = card.querySelector('.spinner');
+        if (!spinner) {
+            spinner = document.createElement('span');
+            spinner.className = 'spinner';
+            spinner.setAttribute('role', 'status');
+            spinner.setAttribute('aria-live', 'polite');
+            const hidden = document.createElement('span');
+            hidden.className = 'visually-hidden';
+            hidden.textContent = 'Loading';
+            spinner.appendChild(hidden);
+            card.appendChild(spinner);
+        }
 
         const cleanup = () => {
             spinner.remove();

--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -17,14 +17,27 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         submit.setAttribute('aria-busy', 'true');
         submit.disabled = true;
-        const spinner = document.createElement('span');
-        spinner.className = 'spinner';
-        spinner.setAttribute('role', 'status');
-        spinner.setAttribute('aria-live', 'polite');
-        const hidden = document.createElement('span');
-        hidden.className = 'visually-hidden';
-        hidden.textContent = 'Loading';
-        spinner.appendChild(hidden);
-        submit.insertBefore(spinner, submit.firstChild);
+        let existing = null;
+        if (typeof submit.querySelector === 'function') {
+            existing = submit.querySelector('.spinner');
+        } else if (submit.children) {
+            for (let i = 0; i < submit.children.length; i++) {
+                if (submit.children[i].className === 'spinner') {
+                    existing = submit.children[i];
+                    break;
+                }
+            }
+        }
+        if (!existing) {
+            const spinner = document.createElement('span');
+            spinner.className = 'spinner';
+            spinner.setAttribute('role', 'status');
+            spinner.setAttribute('aria-live', 'polite');
+            const hidden = document.createElement('span');
+            hidden.className = 'visually-hidden';
+            hidden.textContent = 'Loading';
+            spinner.appendChild(hidden);
+            submit.insertBefore(spinner, submit.firstChild);
+        }
     });
 });

--- a/src/public/js/cta-button.js
+++ b/src/public/js/cta-button.js
@@ -20,6 +20,20 @@
       var pending = false;
 
       function addSpinner() {
+        var existing = null;
+        if (typeof button.querySelector === 'function') {
+          existing = button.querySelector('.spinner');
+        } else if (button.children) {
+          for (var i = 0; i < button.children.length; i++) {
+            if (button.children[i].className === 'spinner') {
+              existing = button.children[i];
+              break;
+            }
+          }
+        }
+        if (existing) {
+          return existing;
+        }
         var spinner = doc.createElement('span');
         spinner.className = 'spinner';
         spinner.setAttribute('role', 'status');


### PR DESCRIPTION
## Summary
- avoid adding another spinner if one is already present on CTA buttons
- guard search form submit from inserting multiple spinners
- ensure city autocomplete cards only get a single spinner when navigating

## Testing
- `composer fix:php`
- `composer stan`
- `php bin/console asset-map:compile`
- `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`

------
https://chatgpt.com/codex/tasks/task_e_68accb060acc832292329fa95bd941c1