### PR TITLE
fix: align choose guide items on mobile

### DIFF
--- a/assets/styles/sections/choose-guide-e03A9Nu.css
+++ b/assets/styles/sections/choose-guide-e03A9Nu.css
@@ -8,6 +8,8 @@
     gap: var(--space-3);
     justify-content: center;
     justify-items: center;
+    margin: 0;
+    padding: 0;
 }
 
 @media (min-width: 600px) {
@@ -27,17 +29,19 @@
     background-color: #fff;
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-sm);
-    padding: var(--space-3);
+    padding: var(--space-3) var(--space-4);
     display: flex;
-    flex-direction: column;
     align-items: center;
     justify-content: center;
     gap: var(--space-2);
-    text-align: center;
+    width: 100%;
+    text-align: left;
 }
 
 @media (min-width: 600px) {
     .choose-guide__item {
+        flex-direction: column;
+        text-align: center;
         padding: var(--space-4);
     }
 }

--- a/assets/styles/sections/choose-guide.css
+++ b/assets/styles/sections/choose-guide.css
@@ -8,6 +8,8 @@
 .choose-guide__list {
     display: grid;
     gap: var(--space-3);
+    margin: 0;
+    padding: 0;
 }
 
 @media (min-width: 768px) {
@@ -26,11 +28,19 @@
     background-color: #fff;
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-sm);
-    padding: var(--space-3);
+    padding: var(--space-3) var(--space-4);
     display: flex;
-    flex-direction: column;
     align-items: center;
     gap: var(--space-2);
+    width: 100%;
+    text-align: left;
+}
+
+@media (min-width: 768px) {
+    .choose-guide__item {
+        flex-direction: column;
+        text-align: center;
+    }
 }
 
 .choose-guide__icon {


### PR DESCRIPTION
## Summary
- ensure choose guide list items span full width on mobile with balanced padding
- adjust responsive flex layout so icons and text align evenly

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size of 134217728 bytes exhausted)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68adad69e3a083228e8745db73681e82