### PR TITLE
fix: align choose-guide items on mobile

### DIFF
--- a/assets/styles/sections/choose-guide-e03A9Nu.css
+++ b/assets/styles/sections/choose-guide-e03A9Nu.css
@@ -8,6 +8,9 @@
     gap: var(--space-3);
     justify-content: center;
     justify-items: center;
+    margin: 0;
+    padding: 0;
+    list-style: none;
 }
 
 @media (min-width: 600px) {
@@ -29,15 +32,17 @@
     box-shadow: var(--shadow-sm);
     padding: var(--space-3);
     display: flex;
-    flex-direction: column;
     align-items: center;
     justify-content: center;
     gap: var(--space-2);
-    text-align: center;
+    text-align: left;
 }
 
 @media (min-width: 600px) {
     .choose-guide__item {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
         padding: var(--space-4);
     }
 }

--- a/assets/styles/sections/choose-guide.css
+++ b/assets/styles/sections/choose-guide.css
@@ -8,6 +8,9 @@
 .choose-guide__list {
     display: grid;
     gap: var(--space-3);
+    margin: 0;
+    padding: 0;
+    list-style: none;
 }
 
 @media (min-width: 768px) {
@@ -28,9 +31,17 @@
     box-shadow: var(--shadow-sm);
     padding: var(--space-3);
     display: flex;
-    flex-direction: column;
     align-items: center;
     gap: var(--space-2);
+    text-align: left;
+}
+
+@media (min-width: 768px) {
+    .choose-guide__item {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+    }
 }
 
 .choose-guide__icon {


### PR DESCRIPTION
## Summary
- align choose-guide items horizontally on small screens and vertically on larger breakpoints
- reset list styles for consistent spacing

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68adaf6ec1088322b53ac8af5a38b8d2