### PR TITLE
fix: center footer nav on mobile

### DIFF
--- a/assets/styles/blocks/footer-UjmJUYX.css
+++ b/assets/styles/blocks/footer-UjmJUYX.css
@@ -175,6 +175,15 @@
     .footer-search button {
         width: 100%;
     }
+
+    .footer-nav {
+        align-items: center;
+        text-align: center;
+    }
+
+    .footer-nav nav {
+        text-align: center;
+    }
 }
 
 .footer-bottom {


### PR DESCRIPTION
## Summary
- center footer nav sections on small screens

## Testing
- `php bin/console asset-map:compile`
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php bin/console doctrine:database:create --if-not-exists` *(fails: Operation 'AbstractPlatform::getListDatabasesSQL' is not supported by platform.)*
- `APP_ENV=test php bin/console doctrine:migrations:migrate --no-interaction` *(fails: table "public.city" already exists)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68adb12e5d648322b1aa9bd2dc582dc8