### PR TITLE
feat: improve desktop footer layout

### DIFF
--- a/assets/styles/blocks/footer-UjmJUYX.css
+++ b/assets/styles/blocks/footer-UjmJUYX.css
@@ -56,6 +56,13 @@
     text-align: center;
 }
 
+.footer-nav {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    margin-top: var(--space-3);
+}
+
 .footer-heading {
     font-size: calc(var(--fs-h3) * 3 / 4);
     font-weight: 700;
@@ -68,7 +75,7 @@
     gap: var(--space-4);
 }
 
-.footer-columns > * {
+.footer-social {
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
@@ -136,9 +143,14 @@
 /* Footer mini search form */
 .footer-search {
     display: flex;
+    flex-wrap: wrap;
     gap: var(--space-1);
     max-width: 400px;
     width: 100%;
+}
+
+.footer-search > .footer-heading {
+    flex-basis: 100%;
 }
 
 .footer-search input {
@@ -215,6 +227,7 @@
 @media (min-width: 768px) {
     .footer-search {
         max-width: none;
+        margin-left: auto;
     }
 
     .footer-top {
@@ -223,43 +236,26 @@
         align-items: flex-start;
     }
 
+    .footer-brand {
+        margin: 0;
+        text-align: left;
+        max-width: none;
+    }
+
+    .footer-nav {
+        flex-direction: row;
+        gap: var(--space-6);
+    }
+
     .footer-columns {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-        align-items: start;
+        flex-direction: row;
+        align-items: flex-start;
+        gap: var(--space-4);
     }
 
     .footer-bottom {
         flex-direction: row;
         justify-content: space-between;
         align-items: center;
-    }
-}
-
-@media (min-width: 1024px) {
-    .footer-top {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-        gap: var(--space-4);
-    }
-
-    .footer-columns {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-        gap: var(--space-4);
-        align-items: start;
-    }
-
-    .footer-search {
-        grid-column: 1 / -1;
-        max-width: none;
-    }
-
-    .footer-brand {
-        justify-self: center;
-    }
-
-    .footer-social {
-        margin-right: var(--space-4);
     }
 }

--- a/templates/partials/_footer.html.twig
+++ b/templates/partials/_footer.html.twig
@@ -4,8 +4,6 @@
       <div class="footer-brand">
         <a href="{{ path('app_homepage') }}" class="footer-logo">CleanWhiskers</a>
         <p class="footer-tagline">{{ 'Find trusted pet groomers near you.'|trans }}</p>
-      </div>
-      <div class="footer-columns">
         <div class="footer-nav">
           <nav aria-label="{{ 'Site'|trans }}">
             <h3 class="footer-heading">{{ 'Site'|trans }}</h3>
@@ -23,6 +21,8 @@
             </ul>
           </nav>
         </div>
+      </div>
+      <div class="footer-columns">
         <nav class="footer-social" aria-label="{{ 'Social media'|trans }}">
           <h3 class="footer-heading">{{ 'Follow Us'|trans }}</h3>
           <ul>


### PR DESCRIPTION
## Summary
- place Site and Legal navigation below the footer tagline
- align footer navs horizontally and push search to the right on desktop
- keep responsive stacking for mobile

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68adb2a02de8832292a76ce9357dba22