### PR TITLE
fix: center mobile footer social links

### DIFF
--- a/assets/styles/blocks/footer-UjmJUYX.css
+++ b/assets/styles/blocks/footer-UjmJUYX.css
@@ -196,6 +196,23 @@
     .footer-nav nav {
         text-align: center;
     }
+
+    .footer-social ul {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .footer-social .social-link {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .footer-social .social-link::before {
+        margin-right: 0;
+        margin-bottom: var(--space-1);
+    }
 }
 
 .footer-bottom {


### PR DESCRIPTION
## Summary
- center footer social links on small screens
- ensure follow-us icons stack vertically with proper spacing on mobile

## Testing
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68adb53452388322b674d26ff52c0441