### PR TITLE
fix: disable autocomplete on form inputs

### DIFF
--- a/templates/admin/blog/post_form.html.twig
+++ b/templates/admin/blog/post_form.html.twig
@@ -1,3 +1,3 @@
-{{ form_start(form) }}
+{{ form_start(form, {'attr': {'autocomplete': 'off'}}) }}
 {{ form_widget(form) }}
 {{ form_end(form) }}

--- a/templates/groomer/list.html.twig
+++ b/templates/groomer/list.html.twig
@@ -2,7 +2,7 @@
 
 {% block body %}
     <h1>Groomers in {{ city.name }} for {{ service.name }}</h1>
-    <form method="get">
+    <form method="get" autocomplete="off">
         <label for="rating">Minimum rating:</label>
         <select id="rating" name="rating">
             <option value="">Any</option>

--- a/templates/home/partials/_hero.html.twig
+++ b/templates/home/partials/_hero.html.twig
@@ -10,6 +10,7 @@
                     id="city"
                     name="city"
                     placeholder="{{ 'City'|trans }}"
+                    autocomplete="off"
                     required
                     role="combobox"
                     aria-autocomplete="list"

--- a/templates/home/partials/_sticky_search.html.twig
+++ b/templates/home/partials/_sticky_search.html.twig
@@ -6,6 +6,7 @@
             id="sticky-city"
             name="city"
             placeholder="City"
+            autocomplete="off"
             aria-describedby="sticky-city-error"
             required
             role="combobox"

--- a/templates/partials/_footer.html.twig
+++ b/templates/partials/_footer.html.twig
@@ -39,6 +39,7 @@
             id="footer-city"
             name="city"
             placeholder="{{ 'City'|trans }}"
+            autocomplete="off"
             required
             class="city-input"
             role="combobox"

--- a/templates/registration/register.html.twig
+++ b/templates/registration/register.html.twig
@@ -3,9 +3,9 @@
 {% block title %}Register{% endblock %}
 
 {% block body %}
-    {{ form_start(registrationForm) }}
-        {{ form_row(registrationForm.email) }}
-        {{ form_row(registrationForm.plainPassword) }}
+    {{ form_start(registrationForm, {'attr': {'autocomplete': 'off'}}) }}
+        {{ form_row(registrationForm.email, {'attr': {'autocomplete': 'off'}}) }}
+        {{ form_row(registrationForm.plainPassword, {'attr': {'autocomplete': 'off'}}) }}
         {{ form_row(registrationForm.role) }}
         <button type="submit">Register</button>
     {{ form_end(registrationForm) }}

--- a/templates/review/new.html.twig
+++ b/templates/review/new.html.twig
@@ -3,9 +3,9 @@
 {% block title %}New Review{% endblock %}
 
 {% block body %}
-    {{ form_start(reviewForm) }}
-        {{ form_row(reviewForm.rating) }}
-        {{ form_row(reviewForm.comment) }}
+    {{ form_start(reviewForm, {'attr': {'autocomplete': 'off'}}) }}
+        {{ form_row(reviewForm.rating, {'attr': {'autocomplete': 'off'}}) }}
+        {{ form_row(reviewForm.comment, {'attr': {'autocomplete': 'off'}}) }}
         <button type="submit">Submit</button>
     {{ form_end(reviewForm) }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- disable browser autocomplete on hero, sticky search, and footer city inputs
- turn off autocomplete in registration, review, admin blog, and groomer forms

## Testing
- `php bin/console asset-map:compile`
- `composer lint:php`
- `composer stan`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`


------
https://chatgpt.com/codex/tasks/task_e_68adb81cdf9c832299d7fae838ac974f