### PR TITLE
feat: add hero illustration

### DIFF
--- a/assets/styles/blocks/hero.css
+++ b/assets/styles/blocks/hero.css
@@ -9,6 +9,14 @@
     text-align: center;
 }
 
+.hero__image {
+    display: block;
+    max-width: 20rem;
+    width: 100%;
+    height: auto;
+    margin: 0 auto var(--space-4);
+}
+
 .hero__title {
     font-size: calc(var(--fs-h1) * 8 / 7);
     margin-bottom: var(--space-4);
@@ -82,6 +90,10 @@
 @media (min-width: 768px) {
     .hero__title {
         font-size: calc(var(--fs-h1) * 10 / 7);
+    }
+
+    .hero__image {
+        max-width: 25rem;
     }
 
     .hero__controls {

--- a/public/assets/illustrations/hero-grooming.svg
+++ b/public/assets/illustrations/hero-grooming.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="256" viewBox="0 0 512 256">
+  <rect width="512" height="256" fill="#fffdfa"/>
+  <!-- tub -->
+  <rect x="96" y="140" width="320" height="80" rx="20" fill="#e0f7fa"/>
+  <!-- dog head -->
+  <circle cx="256" cy="120" r="60" fill="#ffe0b2"/>
+  <circle cx="236" cy="110" r="10" fill="#fff"/>
+  <circle cx="276" cy="110" r="10" fill="#fff"/>
+  <circle cx="236" cy="110" r="5" fill="#000"/>
+  <circle cx="276" cy="110" r="5" fill="#000"/>
+  <path d="M236 140 Q256 160 276 140" stroke="#d84315" stroke-width="4" fill="none"/>
+  <!-- bubbles -->
+  <circle cx="140" cy="130" r="12" fill="#b3e5fc"/>
+  <circle cx="372" cy="130" r="12" fill="#b3e5fc"/>
+  <circle cx="110" cy="150" r="8" fill="#b3e5fc"/>
+  <circle cx="402" cy="150" r="8" fill="#b3e5fc"/>
+  <circle cx="170" cy="110" r="6" fill="#b3e5fc"/>
+  <circle cx="342" cy="110" r="6" fill="#b3e5fc"/>
+</svg>

--- a/templates/home/partials/_hero.html.twig
+++ b/templates/home/partials/_hero.html.twig
@@ -1,5 +1,14 @@
 <section class="hero">
     <div class="hero__container">
+        <img
+            class="hero__image"
+            src="{{ asset('assets/illustrations/hero-grooming.svg') }}"
+            alt="{{ 'Happy dog enjoying a warm bath'|trans }}"
+            width="512"
+            height="256"
+            loading="lazy"
+            decoding="async"
+        >
         <h1 class="hero__title">{{ 'Book mobile pet grooming in minutes — trusted local professionals.'|trans }}</h1>
         <form id="search-form" class="hero__form" method="get" action="/search" role="search">
             <label for="city" class="hero__label">{{ 'Where is your pet?'|trans }}</label>


### PR DESCRIPTION
## Summary
- add CRO-friendly illustration to homepage hero
- style hero image for responsive layout

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --testdox`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68adbaf7905083228a0697aafcf1b526