### PR TITLE
feat: streamline city autocomplete spacing

### DIFF
--- a/assets/js/city-autocomplete.js
+++ b/assets/js/city-autocomplete.js
@@ -113,10 +113,6 @@ export default function initCityAutocomplete(inputsParam) {
             card.dataset.value = opt.value;
             card.href = `/cities/${opt.value}`;
 
-            const icon = document.createElement('span');
-            icon.className = 'city-card__icon';
-            card.appendChild(icon);
-
             const label = document.createElement('span');
             label.className = 'city-card__label';
             label.innerHTML = regex ? opt.label.replace(regex, '<mark>$1</mark>') : opt.label;

--- a/assets/styles/components/city-card.css
+++ b/assets/styles/components/city-card.css
@@ -3,8 +3,8 @@
     align-items: center;
     gap: var(--space-2);
     width: 100%;
-    padding: var(--space-3);
-    min-height: 48px;
+    padding: 12px 16px;
+    min-height: 44px;
     background-color: #fff;
     border: 1px solid #e5e7eb;
     border-radius: 9999px;
@@ -25,27 +25,6 @@
 
 .city-card:focus {
     outline: none;
-}
-
-.city-card:hover .city-card__icon,
-.city-card:focus .city-card__icon,
-.city-card.active .city-card__icon,
-.city-card[aria-selected="true"] .city-card__icon {
-    background-color: #fff;
-    color: var(--color-accent, #2563eb);
-}
-
-.city-card__icon {
-    --icon-size: 2.75rem;
-    flex-shrink: 0;
-    width: var(--icon-size);
-    height: var(--icon-size);
-    border-radius: 50%;
-    background-color: #f3f4f6;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #111;
 }
 
 .city-card__label {

--- a/public/css/components/city-card.css
+++ b/public/css/components/city-card.css
@@ -3,8 +3,8 @@
     align-items: center;
     gap: var(--space-2);
     width: 100%;
-    padding: var(--space-3);
-    min-height: 48px;
+    padding: 12px 16px;
+    min-height: 44px;
     background-color: #fff;
     border: 1px solid #e5e7eb;
     border-radius: 9999px;
@@ -25,27 +25,6 @@
 
 .city-card:focus {
     outline: none;
-}
-
-.city-card:hover .city-card__icon,
-.city-card:focus .city-card__icon,
-.city-card.active .city-card__icon,
-.city-card[aria-selected="true"] .city-card__icon {
-    background-color: #fff;
-    color: var(--color-accent, #2563eb);
-}
-
-.city-card__icon {
-    --icon-size: 2.75rem;
-    flex-shrink: 0;
-    width: var(--icon-size);
-    height: var(--icon-size);
-    border-radius: 50%;
-    background-color: #f3f4f6;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #111;
 }
 
 .city-card__label {

--- a/public/js/city-autocomplete.js
+++ b/public/js/city-autocomplete.js
@@ -113,10 +113,6 @@ export default function initCityAutocomplete(inputsParam) {
             card.dataset.value = opt.value;
             card.href = `/cities/${opt.value}`;
 
-            const icon = document.createElement('span');
-            icon.className = 'city-card__icon';
-            card.appendChild(icon);
-
             const label = document.createElement('span');
             label.className = 'city-card__label';
             label.innerHTML = regex ? opt.label.replace(regex, '<mark>$1</mark>') : opt.label;


### PR DESCRIPTION
## Summary
- remove city icon from autocomplete results
- tighten city card spacing for better touch targets

## Testing
- `make setup && make test -k` *(fails: No rule to make target 'setup')*
- `php bin/console asset-map:compile`
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=512M ./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68adcf72008c8322bc2a98b2709f215a