### PR TITLE
fix: remove redundant footer CTA

### DIFF
--- a/templates/partials/_footer.html.twig
+++ b/templates/partials/_footer.html.twig
@@ -54,7 +54,6 @@
     </div>
     <div class="footer-bottom">
       <p>&copy; {{ 'now'|date('Y') }} CleanWhiskers</p>
-      <a href="#search-form" class="back-to-top btn btn--accent">{{ 'Find a Groomer'|trans }}</a>
     </div>
   </div>
 </footer>

--- a/tests/Integration/FooterRenderTest.php
+++ b/tests/Integration/FooterRenderTest.php
@@ -29,6 +29,5 @@ final class FooterRenderTest extends WebTestCase
         self::assertSelectorExists('footer .footer-social a[href="https://facebook.com/cleanwhiskers"][rel="noopener"]');
         self::assertSelectorExists('footer .footer-social a[href="https://instagram.com/cleanwhiskers"][rel="noopener"]');
         self::assertSelectorExists('footer form.footer-search input[name="city"]');
-        self::assertSelectorExists('footer .back-to-top[href="#search-form"]');
     }
 }


### PR DESCRIPTION
## Summary
- remove duplicate "Find a Groomer" button from footer
- update footer integration test

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68add0ea077883228cc4da2d4f97981a