### PR TITLE
revert: restore footer find a groomer button

### DIFF
--- a/templates/partials/_footer.html.twig
+++ b/templates/partials/_footer.html.twig
@@ -54,6 +54,7 @@
     </div>
     <div class="footer-bottom">
       <p>&copy; {{ 'now'|date('Y') }} CleanWhiskers</p>
+      <a href="#search-form" class="back-to-top btn btn--accent">{{ 'Find a Groomer'|trans }}</a>
     </div>
   </div>
 </footer>

--- a/tests/Integration/FooterRenderTest.php
+++ b/tests/Integration/FooterRenderTest.php
@@ -29,5 +29,6 @@ final class FooterRenderTest extends WebTestCase
         self::assertSelectorExists('footer .footer-social a[href="https://facebook.com/cleanwhiskers"][rel="noopener"]');
         self::assertSelectorExists('footer .footer-social a[href="https://instagram.com/cleanwhiskers"][rel="noopener"]');
         self::assertSelectorExists('footer form.footer-search input[name="city"]');
+        self::assertSelectorExists('footer .back-to-top[href="#search-form"]');
     }
 }


### PR DESCRIPTION
## Summary
- restore footer "Find a Groomer" button
- reinstate integration test for footer button

## Testing
- `composer fix:php`
- `php bin/console asset-map:compile`
- `composer stan`
- `composer test` *(fails: memory exhausted)*
- `APP_ENV=test php -d memory_limit=-1 ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`


------
https://chatgpt.com/codex/tasks/task_e_68add522724c832288e4b968eaf87ace