### PR TITLE
feat: add hero image placeholder and mobile full height

### DIFF
--- a/assets/styles/blocks/hero.css
+++ b/assets/styles/blocks/hero.css
@@ -1,6 +1,20 @@
 .hero {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     padding: var(--space-5) var(--space-3) var(--space-1);
     background: linear-gradient(135deg, var(--color-pastel), var(--color-neutral));
+    overflow: hidden;
+}
+
+.hero__image {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    z-index: -1;
 }
 
 .hero__container {
@@ -30,6 +44,16 @@
 
 .hero__controls datalist {
     display: none;
+}
+
+@media (max-width: 768px) {
+    .hero {
+        height: 100vh;
+    }
+
+    .hero__image {
+        height: 100vh;
+    }
 }
 
 @media (max-width: 375px) {

--- a/templates/home/partials/_hero.html.twig
+++ b/templates/home/partials/_hero.html.twig
@@ -1,4 +1,5 @@
 <section class="hero">
+    <img class="hero__image" src="/images/hero-placeholder.jpg" alt="" />
     <div class="hero__container">
         <h1 class="hero__title">{{ 'Book mobile pet grooming in minutes — trusted local professionals.'|trans }}</h1>
         <form id="search-form" class="hero__form" method="get" action="/search" role="search">


### PR DESCRIPTION
## Summary
- add placeholder image to hero and center content
- style hero to cover viewport on mobile with object-fit

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test DATABASE_URL=sqlite:///:memory: php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`
- `make setup && make test -k` (fails: No rule to make target 'setup')

------
https://chatgpt.com/codex/tasks/task_e_68add5b4df548322a385fd8bbcc7fdb5