### PR TITLE
feat: align footer links horizontally

### DIFF
--- a/assets/styles/blocks/footer-UjmJUYX.css
+++ b/assets/styles/blocks/footer-UjmJUYX.css
@@ -263,3 +263,10 @@
         align-items: center;
     }
 }
+
+@media (min-width: 1024px) {
+    .footer-links ul {
+        flex-direction: row;
+        gap: 24px;
+    }
+}

--- a/public/styles/blocks/footer-UjmJUYX.css
+++ b/public/styles/blocks/footer-UjmJUYX.css
@@ -263,3 +263,10 @@
         align-items: center;
     }
 }
+
+@media (min-width: 1024px) {
+    .footer-links ul {
+        flex-direction: row;
+        gap: 24px;
+    }
+}

--- a/templates/partials/_footer.html.twig
+++ b/templates/partials/_footer.html.twig
@@ -5,17 +5,11 @@
         <a href="{{ path('app_homepage') }}" class="footer-logo">CleanWhiskers</a>
         <p class="footer-tagline">{{ 'Find trusted pet groomers near you.'|trans }}</p>
         <div class="footer-nav">
-          <nav aria-label="{{ 'Site'|trans }}">
-            <h3 class="footer-heading">{{ 'Site'|trans }}</h3>
+          <nav class="footer-links" aria-label="{{ 'Footer links'|trans }}">
             <ul>
               <li><a href="#about">About</a></li>
               <li><a href="#contact">Contact</a></li>
               <li><a href="#faq">FAQ</a></li>
-            </ul>
-          </nav>
-          <nav aria-label="{{ 'Legal'|trans }}">
-            <h3 class="footer-heading">{{ 'Legal'|trans }}</h3>
-            <ul>
               <li><a href="#terms">Terms</a></li>
               <li><a href="#privacy">Privacy</a></li>
             </ul>

--- a/tests/Integration/FooterRenderTest.php
+++ b/tests/Integration/FooterRenderTest.php
@@ -20,11 +20,11 @@ final class FooterRenderTest extends WebTestCase
         $this->client->request('GET', '/');
 
         self::assertResponseIsSuccessful();
-        self::assertSelectorExists('footer .footer-nav nav[aria-label="Site"] a[href="#about"]');
-        self::assertSelectorExists('footer .footer-nav nav[aria-label="Site"] a[href="#contact"]');
-        self::assertSelectorExists('footer .footer-nav nav[aria-label="Site"] a[href="#faq"]');
-        self::assertSelectorExists('footer .footer-nav nav[aria-label="Legal"] a[href="#terms"]');
-        self::assertSelectorExists('footer .footer-nav nav[aria-label="Legal"] a[href="#privacy"]');
+        self::assertSelectorExists('footer .footer-nav nav.footer-links a[href="#about"]');
+        self::assertSelectorExists('footer .footer-nav nav.footer-links a[href="#contact"]');
+        self::assertSelectorExists('footer .footer-nav nav.footer-links a[href="#faq"]');
+        self::assertSelectorExists('footer .footer-nav nav.footer-links a[href="#terms"]');
+        self::assertSelectorExists('footer .footer-nav nav.footer-links a[href="#privacy"]');
         self::assertSelectorExists('footer .footer-social a[href="https://twitter.com/cleanwhiskers"][rel="noopener"]');
         self::assertSelectorExists('footer .footer-social a[href="https://facebook.com/cleanwhiskers"][rel="noopener"]');
         self::assertSelectorExists('footer .footer-social a[href="https://instagram.com/cleanwhiskers"][rel="noopener"]');


### PR DESCRIPTION
## Summary
- consolidate about/contact/faq/terms/privacy links into a single footer nav
- arrange footer links horizontally on desktop with flex layout
- adjust footer render test for new markup

## Testing
- `php bin/console asset-map:compile`
- `composer fix:php`
- `composer stan`
- `composer test`
- `make setup` *(fails: No rule to make target 'setup')*
- `make test -k` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68adde5636908322a418ea456c25556e