### PR TITLE
feat: add mobile dog grooming service type

### DIFF
--- a/migrations/Version20250822113001AddMobileDogGroomingService.php
+++ b/migrations/Version20250822113001AddMobileDogGroomingService.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250822113001AddMobileDogGroomingService extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Insert Mobile Dog Grooming service if not exists';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("INSERT INTO service (name, slug) SELECT 'Mobile Dog Grooming', 'mobile-dog-grooming' WHERE NOT EXISTS (SELECT 1 FROM service WHERE slug = 'mobile-dog-grooming')");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("DELETE FROM service WHERE slug = 'mobile-dog-grooming'");
+    }
+}

--- a/src/DataFixtures/Seeder/ServiceSeeder.php
+++ b/src/DataFixtures/Seeder/ServiceSeeder.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures\Seeder;
+
+use App\Entity\Service;
+use App\Repository\ServiceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class ServiceSeeder
+{
+    public function __construct(
+        private readonly ServiceRepository $serviceRepository,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    public function seed(): void
+    {
+        if (null !== $this->serviceRepository->findMobileDogGroomingService()) {
+            return;
+        }
+
+        $service = (new Service())
+            ->setName('Mobile Dog Grooming');
+        $service->refreshSlugFrom('Mobile Dog Grooming');
+
+        $this->em->persist($service);
+        $this->em->flush();
+    }
+}

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -14,6 +14,8 @@ use Doctrine\ORM\Mapping as ORM;
 class Service
 {
     use SluggerTrait;
+
+    public const MOBILE_DOG_GROOMING = 'mobile-dog-grooming';
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]

--- a/src/Repository/ServiceRepository.php
+++ b/src/Repository/ServiceRepository.php
@@ -33,6 +33,11 @@ class ServiceRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+    public function findMobileDogGroomingService(): ?Service
+    {
+        return $this->findOneBySlug(Service::MOBILE_DOG_GROOMING);
+    }
+
     /**
      * @return Service[]
      */

--- a/tests/Integration/Repository/ServiceRepositoryTest.php
+++ b/tests/Integration/Repository/ServiceRepositoryTest.php
@@ -56,4 +56,19 @@ final class ServiceRepositoryTest extends KernelTestCase
 
         self::assertCount(6, $services);
     }
+
+    public function testFindMobileDogGroomingService(): void
+    {
+        $service = (new Service())
+            ->setName('Mobile Dog Grooming');
+        $service->refreshSlugFrom('Mobile Dog Grooming');
+        $this->em->persist($service);
+        $this->em->flush();
+        $this->em->clear();
+
+        $found = $this->repository->findMobileDogGroomingService();
+
+        self::assertNotNull($found);
+        self::assertSame('Mobile Dog Grooming', $found->getName());
+    }
 }

--- a/tests/Unit/DataFixtures/Seeder/ServiceSeederTest.php
+++ b/tests/Unit/DataFixtures/Seeder/ServiceSeederTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\DataFixtures\Seeder;
+
+use App\DataFixtures\Seeder\ServiceSeeder;
+use App\Entity\Service;
+use App\Repository\ServiceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class ServiceSeederTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private ServiceSeeder $seeder;
+    private ServiceRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+        $this->em = $container->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $this->repository = $this->em->getRepository(Service::class);
+        $this->seeder = new ServiceSeeder($this->repository, $this->em);
+    }
+
+    public function testSeedCreatesMobileDogGroomingService(): void
+    {
+        self::assertNull($this->repository->findMobileDogGroomingService());
+
+        $this->seeder->seed();
+
+        $service = $this->repository->findMobileDogGroomingService();
+        self::assertNotNull($service);
+        self::assertSame('Mobile Dog Grooming', $service->getName());
+    }
+}

--- a/tests/Unit/Entity/ServiceTest.php
+++ b/tests/Unit/Entity/ServiceTest.php
@@ -17,5 +17,6 @@ final class ServiceTest extends TestCase
 
         self::assertSame('Bath', $service->getName());
         self::assertSame('bath', $service->getSlug());
+        self::assertSame('mobile-dog-grooming', Service::MOBILE_DOG_GROOMING);
     }
 }


### PR DESCRIPTION
## Summary
- add MOBILE_DOG_GROOMING constant to `Service`
- seed mobile dog grooming service and expose repository helper
- cover seeding and retrieval with unit and integration tests

## Testing
- `make setup && make test -k` *(fails: No rule to make target 'setup')*
- `composer fix:php`
- `composer stan`
- `php bin/console asset-map:compile`
- `composer test` *(fails: Allowed memory size exhausted)*
- `APP_ENV=test php -d memory_limit=-1 ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`


------
https://chatgpt.com/codex/tasks/task_e_68af31763a688322aa4c72f4f0bf7fc9