### PR TITLE
feat: filter autocomplete cities for mobile grooming

### DIFF
--- a/assets/controllers/autocomplete_controller.js
+++ b/assets/controllers/autocomplete_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from '@hotwired/stimulus';
+import initCityAutocomplete from '../js/city-autocomplete.js';
+
+export default class extends Controller {
+    connect() {
+        const inputs = document.querySelectorAll('.city-input');
+        initCityAutocomplete(inputs);
+    }
+}

--- a/assets/js/city-autocomplete.js
+++ b/assets/js/city-autocomplete.js
@@ -17,6 +17,8 @@ export default function initCityAutocomplete(inputsParam) {
         return;
     }
 
+    const service = window.cwMobileService || 'mobile-dog-grooming';
+
     const options = Array.from(listEl.querySelectorAll('.city-suggestion')).map((opt) => ({
         value: opt.dataset.value,
         label: opt.textContent,
@@ -68,7 +70,7 @@ export default function initCityAutocomplete(inputsParam) {
             if (currentInput) {
                 currentInput.value = slug;
             }
-            window.location.href = `/cities/${slug}`;
+            window.location.href = `/groomers/${slug}/${service}`;
         } catch (err) {
             cleanup();
             throw err;
@@ -111,7 +113,7 @@ export default function initCityAutocomplete(inputsParam) {
             card.id = `${input.id}-option-${index}`;
             card.className = 'city-card';
             card.dataset.value = opt.value;
-            card.href = `/cities/${opt.value}`;
+            card.href = `/groomers/${opt.value}/${service}`;
 
             const label = document.createElement('span');
             label.className = 'city-card__label';

--- a/public/js/city-autocomplete.js
+++ b/public/js/city-autocomplete.js
@@ -17,6 +17,8 @@ export default function initCityAutocomplete(inputsParam) {
         return;
     }
 
+    const service = window.cwMobileService || 'mobile-dog-grooming';
+
     const options = Array.from(listEl.querySelectorAll('.city-suggestion')).map((opt) => ({
         value: opt.dataset.value,
         label: opt.textContent,
@@ -68,7 +70,7 @@ export default function initCityAutocomplete(inputsParam) {
             if (currentInput) {
                 currentInput.value = slug;
             }
-            window.location.href = `/cities/${slug}`;
+            window.location.href = `/groomers/${slug}/${service}`;
         } catch (err) {
             cleanup();
             throw err;
@@ -111,7 +113,7 @@ export default function initCityAutocomplete(inputsParam) {
             card.id = `${input.id}-option-${index}`;
             card.className = 'city-card';
             card.dataset.value = opt.value;
-            card.href = `/cities/${opt.value}`;
+            card.href = `/groomers/${opt.value}/${service}`;
 
             const label = document.createElement('span');
             label.className = 'city-card__label';

--- a/src/Repository/CityRepository.php
+++ b/src/Repository/CityRepository.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Service;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -43,6 +45,25 @@ class CityRepository extends ServiceEntityRepository
             ->select('partial c.{id, name, slug, seoIntro}')
             ->orderBy('c.name', 'ASC')
             ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        return $cities;
+    }
+
+    /**
+     * @return City[]
+     */
+    public function findByService(Service $service): array
+    {
+        /** @var City[] $cities */
+        $cities = $this->createQueryBuilder('c')
+            ->distinct()
+            ->innerJoin(GroomerProfile::class, 'gp', 'WITH', 'gp.city = c')
+            ->innerJoin('gp.services', 's')
+            ->where('s = :service')
+            ->setParameter('service', $service)
+            ->orderBy('c.name', 'ASC')
             ->getQuery()
             ->getResult();
 

--- a/src/Twig/CityListExtension.php
+++ b/src/Twig/CityListExtension.php
@@ -6,13 +6,16 @@ namespace App\Twig;
 
 use App\Entity\City;
 use App\Repository\CityRepository;
+use App\Repository\ServiceRepository;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 final class CityListExtension extends AbstractExtension
 {
-    public function __construct(private CityRepository $cityRepository)
-    {
+    public function __construct(
+        private CityRepository $cityRepository,
+        private ServiceRepository $serviceRepository,
+    ) {
     }
 
     /**
@@ -20,7 +23,12 @@ final class CityListExtension extends AbstractExtension
      */
     public function getCityList(): array
     {
-        return $this->cityRepository->findBy([], ['name' => 'ASC']);
+        $service = $this->serviceRepository->findMobileDogGroomingService();
+        if (null === $service) {
+            return [];
+        }
+
+        return $this->cityRepository->findByService($service);
     }
 
     public function getFunctions(): array

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -24,6 +24,9 @@
     <script type="module" src="{{ asset('js/section-reveal.js') }}" defer></script>
     <script src="{{ asset('js/cta-button.js') }}" defer></script>
     <script src="{{ asset('js/lazy-images.js') }}" defer></script>
+    <script>
+        window.cwMobileService = '{{ constant('App\\Entity\\Service::MOBILE_DOG_GROOMING') }}';
+    </script>
 {% endblock %}
 
 {% block body %}

--- a/templates/home/partials/_hero.html.twig
+++ b/templates/home/partials/_hero.html.twig
@@ -19,6 +19,7 @@
                     aria-controls="city-list"
                     aria-haspopup="listbox"
                 >
+                <input type="hidden" name="service" value="{{ constant('App\\Entity\\Service::MOBILE_DOG_GROOMING') }}">
                 <button class="hero__submit search-form__button btn btn--accent" type="submit" id="search-submit">
                     {{ ctaLinks.find.label|trans }}
                 </button>

--- a/templates/home/partials/_sticky_search.html.twig
+++ b/templates/home/partials/_sticky_search.html.twig
@@ -15,6 +15,7 @@
             aria-controls="city-list"
             aria-haspopup="listbox"
         >
+        <input type="hidden" name="service" value="{{ constant('App\\Entity\\Service::MOBILE_DOG_GROOMING') }}">
         <span id="sticky-service-error" class="form-error" aria-live="polite"></span>
         <button class="search-form__button btn btn--accent" type="submit">
             {{ ctaLinks.find.label }}

--- a/templates/partials/_footer.html.twig
+++ b/templates/partials/_footer.html.twig
@@ -42,6 +42,7 @@
             aria-controls="city-list"
             aria-haspopup="listbox"
           >
+          <input type="hidden" name="service" value="{{ constant('App\\Entity\\Service::MOBILE_DOG_GROOMING') }}">
           <button type="submit" class="btn btn--accent">{{ 'Search'|trans }}</button>
         </form>
       </div>

--- a/tests/Integration/Repository/CityRepositoryTest.php
+++ b/tests/Integration/Repository/CityRepositoryTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Repository;
 
 use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Service;
 use App\Repository\CityRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -57,5 +59,32 @@ class CityRepositoryTest extends KernelTestCase
         $cities = $this->repository->findTop(6);
 
         self::assertCount(6, $cities);
+    }
+
+    public function testFindByServiceReturnsOnlyCitiesWithThatService(): void
+    {
+        $service = new Service();
+        $service->setName('Mobile Dog Grooming');
+        $service->refreshSlugFrom('Mobile Dog Grooming');
+        $this->em->persist($service);
+
+        $cityWith = new City('Sofia');
+        $cityWith->refreshSlugFrom('Sofia');
+        $this->em->persist($cityWith);
+
+        $cityWithout = new City('Plovdiv');
+        $cityWithout->refreshSlugFrom('Plovdiv');
+        $this->em->persist($cityWithout);
+
+        $groomer = new GroomerProfile(null, $cityWith, 'Biz', 'About');
+        $groomer->getServices()->add($service);
+        $this->em->persist($groomer);
+
+        $this->em->flush();
+
+        $cities = $this->repository->findByService($service);
+
+        self::assertCount(1, $cities);
+        self::assertSame('Sofia', $cities[0]->getName());
     }
 }


### PR DESCRIPTION
## Summary
- filter city suggestions to those with mobile dog grooming
- redirect autocomplete results to mobile grooming listings
- include mobile grooming service slug in homepage forms

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d zend.enable_gc=0 -d memory_limit=1G ./vendor/bin/phpunit --testdox`
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68af3360a89083229aa10c72a03e25f8