### PR TITLE
fix: support forwarded host for staging robots

### DIFF
--- a/src/Controller/RobotsController.php
+++ b/src/Controller/RobotsController.php
@@ -14,7 +14,8 @@ final class RobotsController extends AbstractController
     #[Route('/robots.txt', name: 'app_robots', methods: ['GET'])]
     public function __invoke(Request $request): Response
     {
-        $host = $request->getHost();
+        $host = $request->headers->get('x-forwarded-host') ?: $request->getHost();
+        $host = strtolower(rtrim($host, '.'));
 
         if ('staging.cleanwhiskers.com' === $host) {
             $content = "User-agent: *\nDisallow: /\n";

--- a/tests/Controller/RobotsControllerTest.php
+++ b/tests/Controller/RobotsControllerTest.php
@@ -25,6 +25,20 @@ final class RobotsControllerTest extends WebTestCase
         self::assertSame("User-agent: *\nDisallow: /\n", $content);
     }
 
+    public function testForwardedHostDisallowsAll(): void
+    {
+        $server = [
+            'HTTP_HOST' => 'internal',
+            'HTTP_X_FORWARDED_HOST' => 'staging.cleanwhiskers.com',
+        ];
+
+        $this->client->request('GET', '/robots.txt', server: $server);
+        self::assertResponseIsSuccessful();
+
+        $content = (string) $this->client->getResponse()->getContent();
+        self::assertSame("User-agent: *\nDisallow: /\n", $content);
+    }
+
     public function testOtherDomainsServeRobotsWithSitemap(): void
     {
         $host = 'cleanwhiskers.com';


### PR DESCRIPTION
## Summary
- handle `x-forwarded-host` to ensure staging domain serves blocking robots
- cover forwarded host logic in controller tests

## Testing
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox` *(fails: Tests: 129, Assertions: 437, Failures: 2, Skipped: 8)*
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68af4f66a0bc8322b8e0e8284b6d0b32