### PR TITLE
feat: add trust box with tooltip

### DIFF
--- a/assets/controllers/tooltip.js
+++ b/assets/controllers/tooltip.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-tooltip]').forEach((trigger) => {
+        const id = trigger.getAttribute('aria-describedby');
+        const tooltip = document.getElementById(id);
+        if (!tooltip) {
+            return;
+        }
+
+        const show = () => tooltip.setAttribute('aria-hidden', 'false');
+        const hide = () => tooltip.setAttribute('aria-hidden', 'true');
+        const toggle = (e) => {
+            e.preventDefault();
+            if (tooltip.getAttribute('aria-hidden') === 'true') {
+                show();
+            } else {
+                hide();
+            }
+        };
+
+        trigger.addEventListener('mouseenter', show);
+        trigger.addEventListener('focus', show);
+        trigger.addEventListener('mouseleave', hide);
+        trigger.addEventListener('blur', hide);
+        trigger.addEventListener('touchstart', toggle);
+    });
+});

--- a/assets/styles/blocks/_trust-box.scss
+++ b/assets/styles/blocks/_trust-box.scss
@@ -1,0 +1,40 @@
+.trust-box {
+    position: relative;
+    padding: var(--space-2) var(--space-3);
+    background-color: var(--color-neutral);
+    border-left: 4px solid var(--color-accent);
+    margin-bottom: var(--space-3);
+
+    &__label {
+        font-weight: 600;
+        cursor: pointer;
+    }
+
+    &__tooltip {
+        display: none;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        transform: translateY(0.5rem);
+        background-color: #333;
+        color: #fff;
+        padding: var(--space-2);
+        border-radius: var(--radius-sm);
+        box-shadow: var(--shadow-sm);
+        font-size: 0.875rem;
+        width: 16rem;
+        max-width: 100%;
+        z-index: 10;
+    }
+
+    &__tooltip[aria-hidden='false'] {
+        display: block;
+    }
+}
+
+@media (min-width: 768px) {
+    .trust-box {
+        float: right;
+        margin-left: var(--space-3);
+    }
+}

--- a/assets/styles/blocks/trust-box.css
+++ b/assets/styles/blocks/trust-box.css
@@ -1,0 +1,36 @@
+.trust-box {
+    position: relative;
+    padding: var(--space-2) var(--space-3);
+    background-color: var(--color-neutral);
+    border-left: 4px solid var(--color-accent);
+    margin-bottom: var(--space-3);
+}
+.trust-box__label {
+    font-weight: 600;
+    cursor: pointer;
+}
+.trust-box__tooltip {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    transform: translateY(0.5rem);
+    background-color: #333;
+    color: #fff;
+    padding: var(--space-2);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-sm);
+    font-size: 0.875rem;
+    width: 16rem;
+    max-width: 100%;
+    z-index: 10;
+}
+.trust-box__tooltip[aria-hidden='false'] {
+    display: block;
+}
+@media (min-width: 768px) {
+    .trust-box {
+        float: right;
+        margin-left: var(--space-3);
+    }
+}

--- a/public/js/tooltip.js
+++ b/public/js/tooltip.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-tooltip]').forEach((trigger) => {
+        const id = trigger.getAttribute('aria-describedby');
+        const tooltip = document.getElementById(id);
+        if (!tooltip) {
+            return;
+        }
+
+        const show = () => tooltip.setAttribute('aria-hidden', 'false');
+        const hide = () => tooltip.setAttribute('aria-hidden', 'true');
+        const toggle = (e) => {
+            e.preventDefault();
+            if (tooltip.getAttribute('aria-hidden') === 'true') {
+                show();
+            } else {
+                hide();
+            }
+        };
+
+        trigger.addEventListener('mouseenter', show);
+        trigger.addEventListener('focus', show);
+        trigger.addEventListener('mouseleave', hide);
+        trigger.addEventListener('blur', hide);
+        trigger.addEventListener('touchstart', toggle);
+    });
+});

--- a/public/styles/blocks/trust-box.css
+++ b/public/styles/blocks/trust-box.css
@@ -1,0 +1,36 @@
+.trust-box {
+    position: relative;
+    padding: var(--space-2) var(--space-3);
+    background-color: var(--color-neutral);
+    border-left: 4px solid var(--color-accent);
+    margin-bottom: var(--space-3);
+}
+.trust-box__label {
+    font-weight: 600;
+    cursor: pointer;
+}
+.trust-box__tooltip {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    transform: translateY(0.5rem);
+    background-color: #333;
+    color: #fff;
+    padding: var(--space-2);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-sm);
+    font-size: 0.875rem;
+    width: 16rem;
+    max-width: 100%;
+    z-index: 10;
+}
+.trust-box__tooltip[aria-hidden='false'] {
+    display: block;
+}
+@media (min-width: 768px) {
+    .trust-box {
+        float: right;
+        margin-left: var(--space-3);
+    }
+}

--- a/templates/groomer/list.html.twig
+++ b/templates/groomer/list.html.twig
@@ -5,12 +5,14 @@
     <link rel="stylesheet" href="{{ asset('css/components/button.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/blocks/hero.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/blocks/sort-dropdown.css') }}">
+    <link rel="stylesheet" href="{{ asset('styles/blocks/trust-box.css') }}">
 {% endblock %}
 
 {% block javascripts %}
     {{ parent() }}
     <script type="module" src="{{ asset('controllers/heroScroll.js') }}" defer></script>
     <script type="module" src="{{ asset('controllers/sortHandler.js') }}" defer></script>
+    <script type="module" src="{{ asset('controllers/tooltip.js') }}" defer></script>
 {% endblock %}
 
 {% block body %}
@@ -24,6 +26,10 @@
     </section>
 
     <section id="groomer-listings">
+        <div class="trust-box">
+            <span class="trust-box__label" data-tooltip aria-describedby="verified-tooltip">🛡️ Verified groomer</span>
+            <span id="verified-tooltip" class="trust-box__tooltip" role="tooltip" aria-hidden="true">Verified groomer: Background checked and approved by CleanWhiskers.</span>
+        </div>
         <h2>Groomers in {{ city.name }} for {{ service.name }}</h2>
         <div class="sort-dropdown">
             <label for="sort" class="sort-dropdown__label">Sort by:</label>

--- a/tests/e2e/TrustBoxTest.js
+++ b/tests/e2e/TrustBoxTest.js
@@ -1,0 +1,9 @@
+describe('Trust Box', () => {
+  it('shows tooltip on hover', () => {
+    const citySlug = 'sofia';
+    const serviceSlug = 'mobile-dog-grooming';
+    cy.visit(`/groomers/${citySlug}/${serviceSlug}`);
+    cy.get('.trust-box__label').trigger('mouseenter');
+    cy.get('#verified-tooltip').should('be.visible').and('contain', 'Background checked');
+  });
+});


### PR DESCRIPTION
## Summary
- add trust box badge with accessible tooltip on groomer listings
- style trust box for mobile and desktop layouts
- provide vanilla JS tooltip controller and accompanying Cypress test

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=1G -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`
- `npx cypress run --spec tests/e2e/TrustBoxTest.js` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b01360a2748322ab88ef054d768b57