### PR TITLE
feat: add groomer listing cards

### DIFF
--- a/assets/styles/blocks/_card.scss
+++ b/assets/styles/blocks/_card.scss
@@ -1,0 +1,104 @@
+.cards {
+    display: grid;
+    gap: var(--space-4);
+    grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.card {
+    background-color: var(--color-cream);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.card__photo {
+    width: 100%;
+    height: auto;
+    object-fit: cover;
+}
+
+.card__body {
+    display: flex;
+    flex-direction: column;
+    padding: var(--space-3);
+    flex: 1;
+}
+
+.card__title {
+    font-size: 1.25rem;
+    margin: 0 0 var(--space-1);
+}
+
+.card__description {
+    margin: 0 0 var(--space-2);
+    color: var(--color-dark);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.card__rating {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    margin-top: var(--space-1);
+}
+
+.card__badge {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    cursor: pointer;
+    position: relative;
+    font-size: 1rem;
+}
+
+.card__tooltip {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    transform: translateY(0.5rem);
+    background-color: #333;
+    color: #fff;
+    padding: var(--space-2);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-sm);
+    font-size: 0.875rem;
+    width: 16rem;
+    max-width: 100%;
+    z-index: 10;
+}
+
+.card__tooltip[aria-hidden='false'] {
+    display: block;
+}
+
+.card__testimonial {
+    margin-top: var(--space-2);
+    font-style: italic;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.card__disclaimer {
+    margin-top: var(--space-1);
+    font-size: 0.875rem;
+    color: var(--color-muted);
+}
+
+.card__cta {
+    margin-top: auto;
+    align-self: flex-start;
+    text-decoration: none;
+    font-weight: 600;
+}

--- a/assets/styles/blocks/card.css
+++ b/assets/styles/blocks/card.css
@@ -1,0 +1,104 @@
+.cards {
+    display: grid;
+    gap: var(--space-4);
+    grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.card {
+    background-color: var(--color-cream);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.card__photo {
+    width: 100%;
+    height: auto;
+    object-fit: cover;
+}
+
+.card__body {
+    display: flex;
+    flex-direction: column;
+    padding: var(--space-3);
+    flex: 1;
+}
+
+.card__title {
+    font-size: 1.25rem;
+    margin: 0 0 var(--space-1);
+}
+
+.card__description {
+    margin: 0 0 var(--space-2);
+    color: var(--color-dark);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.card__rating {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    margin-top: var(--space-1);
+}
+
+.card__badge {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    cursor: pointer;
+    position: relative;
+    font-size: 1rem;
+}
+
+.card__tooltip {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    transform: translateY(0.5rem);
+    background-color: #333;
+    color: #fff;
+    padding: var(--space-2);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-sm);
+    font-size: 0.875rem;
+    width: 16rem;
+    max-width: 100%;
+    z-index: 10;
+}
+
+.card__tooltip[aria-hidden='false'] {
+    display: block;
+}
+
+.card__testimonial {
+    margin-top: var(--space-2);
+    font-style: italic;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.card__disclaimer {
+    margin-top: var(--space-1);
+    font-size: 0.875rem;
+    color: var(--color-muted);
+}
+
+.card__cta {
+    margin-top: auto;
+    align-self: flex-start;
+    text-decoration: none;
+    font-weight: 600;
+}

--- a/templates/groomer/list.html.twig
+++ b/templates/groomer/list.html.twig
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="{{ asset('styles/blocks/hero.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/blocks/sort-dropdown.css') }}">
     <link rel="stylesheet" href="{{ asset('styles/blocks/trust-box.css') }}">
+    <link rel="stylesheet" href="{{ asset('styles/blocks/card.css') }}">
 {% endblock %}
 
 {% block javascripts %}
@@ -51,9 +52,40 @@
             <button type="submit">Filter</button>
         </form>
         {% if groomers %}
-            <ul>
+            <ul class="cards">
             {% for groomer in groomers %}
-                <li><a href="/groomers/{{ groomer.slug }}">{{ groomer.businessName }}</a></li>
+                <li>
+                    <article class="card">
+                        <img
+                            class="card__photo"
+                            src="{{ groomer.logo|default('https://placehold.co/320x240?text=No+Photo') }}"
+                            alt="{{ groomer.businessName }} logo"
+                            loading="lazy"
+                            decoding="async"
+                        >
+                        <div class="card__body">
+                            <h3 class="card__title">
+                                <a href="/groomers/{{ groomer.slug }}">{{ groomer.businessName }}</a>
+                            </h3>
+                            <p class="card__description">{{ groomer.about }}</p>
+                            <div class="card__rating" aria-label="Rating {{ groomer.avgRating|default(0)|number_format(1) }} out of 5">
+                                <span class="card__rating-value">{{ groomer.avgRating|default(0)|number_format(1) }}</span>
+                                <span class="card__rating-count">({{ groomer.reviewCount|default(0) }})</span>
+                                {% if groomer.user is not null %}
+                                    <span class="card__badge" data-tooltip aria-describedby="verified-{{ loop.index }}">🛡️ Verified</span>
+                                    <span id="verified-{{ loop.index }}" class="card__tooltip" role="tooltip" aria-hidden="true">Verified groomer: Background checked and approved by CleanWhiskers.</span>
+                                {% endif %}
+                            </div>
+                            {% if groomer.testimonial is defined %}
+                                <blockquote class="card__testimonial" data-placeholder="{{ groomer.testimonial.is_placeholder ? 'true' : 'false' }}">&ldquo;{{ groomer.testimonial.excerpt|default('') }}&rdquo;</blockquote>
+                                {% if groomer.testimonial.is_placeholder %}
+                                    <p class="card__disclaimer">This testimonial is a placeholder.</p>
+                                {% endif %}
+                            {% endif %}
+                            <a class="card__cta btn btn--accent" href="/groomers/{{ groomer.slug }}">Book Now</a>
+                        </div>
+                    </article>
+                </li>
             {% endfor %}
             </ul>
             <div class="pagination">

--- a/tests/e2e/GroomerCardsTest.js
+++ b/tests/e2e/GroomerCardsTest.js
@@ -1,0 +1,23 @@
+describe('Groomer Listing Cards', () => {
+  const citySlug = 'sofia';
+  const serviceSlug = 'mobile-dog-grooming';
+
+  it('renders core details for each card', () => {
+    cy.visit(`/groomers/${citySlug}/${serviceSlug}`);
+    cy.get('.cards .card').should('have.length.at.least', 1);
+    cy.get('.cards .card').first().within(() => {
+      cy.get('.card__title').should('not.be.empty');
+      cy.get('.card__description').should('not.be.empty');
+      cy.get('.card__rating').should('contain', '(');
+      cy.get('.card__badge').should('contain', 'Verified');
+      cy.contains('Book Now').should('have.attr', 'href');
+    });
+  });
+
+  it('shows disclaimer only for placeholder testimonials', () => {
+    cy.visit(`/groomers/${citySlug}/${serviceSlug}`);
+    cy.get('.card__testimonial[data-placeholder="true"]').each(($el) => {
+      cy.wrap($el).siblings('.card__disclaimer').should('exist');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- render groomer listing cards with photo, rating, verified badge, testimonial, and CTA
- style responsive card block with tooltip and truncation
- cover card rendering and placeholder testimonial disclaimer in Cypress tests

## Testing
- `composer lint:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --log-junit /tmp/phpunit.log`
- `php bin/console asset-map:compile`
- `npx cypress run --spec tests/e2e/GroomerCardsTest.js` *(fails: 403 Forbidden when fetching Cypress package)*

------
https://chatgpt.com/codex/tasks/task_e_68b01478d4808322a490be26951b3c14