### PR TITLE
feat: prioritize real testimonials with placeholders fallback

### DIFF
--- a/migrations/Version20250822104000AddIsPlaceholder.php
+++ b/migrations/Version20250822104000AddIsPlaceholder.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250822104000AddIsPlaceholder extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add is_placeholder flag to testimonial table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('testimonial');
+        $table->addColumn('is_placeholder', Types::BOOLEAN, ['default' => false]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('testimonial');
+        $table->dropColumn('is_placeholder');
+    }
+}

--- a/src/Command/ImportGMBReviewsCommand.php
+++ b/src/Command/ImportGMBReviewsCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\Testimonial;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:import-gmb-reviews',
+    description: 'Import Google My Business reviews as placeholder testimonials.'
+)]
+final class ImportGMBReviewsCommand extends Command
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('file', InputArgument::REQUIRED, 'Path to CSV file with name,city,quote');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $path = $input->getArgument('file');
+        if (!is_string($path) || !is_readable($path)) {
+            $output->writeln('<error>File not readable.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $handle = fopen($path, 'rb');
+        if (false === $handle) {
+            $output->writeln('<error>Unable to open file.</error>');
+
+            return Command::FAILURE;
+        }
+
+        while (($data = fgetcsv($handle)) !== false) {
+            if (count($data) < 3) {
+                continue;
+            }
+            [$name, $city, $quote] = $data;
+            $testimonial = new Testimonial((string) $name, (string) $city, (string) $quote);
+            $testimonial->markPlaceholder();
+            $this->em->persist($testimonial);
+        }
+
+        fclose($handle);
+        $this->em->flush();
+        $output->writeln('<info>GMB reviews imported.</info>');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/GroomerController.php
+++ b/src/Controller/GroomerController.php
@@ -8,6 +8,7 @@ use App\Repository\CityRepository;
 use App\Repository\GroomerProfileRepository;
 use App\Repository\ReviewRepository;
 use App\Repository\ServiceRepository;
+use App\Repository\TestimonialRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,6 +24,7 @@ final class GroomerController extends AbstractController
         CityRepository $cityRepository,
         ServiceRepository $serviceRepository,
         GroomerProfileRepository $groomerProfileRepository,
+        TestimonialRepository $testimonialRepository,
     ): Response {
         $city = $cityRepository->findOneBySlug($citySlug);
         if (null === $city) {
@@ -41,6 +43,14 @@ final class GroomerController extends AbstractController
         $sort = in_array($sort, ['recommended', 'price_asc', 'rating_desc'], true) ? $sort : 'recommended';
 
         $groomers = $groomerProfileRepository->findByFilters($city, $service, $minRating, $limit, $offset, $sort);
+
+        $testimonialList = $testimonialRepository->findLatestWithFallback(count($groomers));
+        $testimonials = [];
+        foreach ($groomers as $index => $groomer) {
+            if (isset($testimonialList[$index])) {
+                $testimonials[$groomer->getId()] = $testimonialList[$index];
+            }
+        }
 
         $nextOffset = count($groomers) === $limit ? $offset + $limit : null;
         $previousOffset = $offset > 0 ? max(0, $offset - $limit) : null;
@@ -62,6 +72,7 @@ final class GroomerController extends AbstractController
             'groomers' => $groomers,
             'city' => $city,
             'service' => $service,
+            'testimonials' => $testimonials,
             'rating' => $minRating,
             'sort' => $sort,
             'nextOffset' => $nextOffset,

--- a/src/Entity/Testimonial.php
+++ b/src/Entity/Testimonial.php
@@ -28,6 +28,9 @@ class Testimonial
     #[ORM\Column(type: Types::TEXT)]
     private string $quote;
 
+    #[ORM\Column(type: Types::BOOLEAN, name: 'is_placeholder', options: ['default' => false])]
+    private bool $isPlaceholder = false;
+
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE, name: 'created_at')]
     private \DateTimeImmutable $createdAt;
 
@@ -57,6 +60,18 @@ class Testimonial
     public function getQuote(): string
     {
         return $this->quote;
+    }
+
+    public function isPlaceholder(): bool
+    {
+        return $this->isPlaceholder;
+    }
+
+    public function markPlaceholder(): self
+    {
+        $this->isPlaceholder = true;
+
+        return $this;
     }
 
     public function getCreatedAt(): \DateTimeImmutable

--- a/src/Repository/TestimonialRepository.php
+++ b/src/Repository/TestimonialRepository.php
@@ -31,4 +31,40 @@ class TestimonialRepository extends ServiceEntityRepository
 
         return $result;
     }
+
+    /**
+     * Fetches the most recent real testimonials, falling back to placeholders if needed.
+     *
+     * @return list<Testimonial>
+     */
+    public function findLatestWithFallback(int $limit): array
+    {
+        /** @var list<Testimonial> $real */
+        $real = $this->createQueryBuilder('t')
+            ->andWhere('t.isPlaceholder = :real')
+            ->setParameter('real', false)
+            ->orderBy('t.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        $remaining = $limit - count($real);
+        if ($remaining <= 0) {
+            return $real;
+        }
+
+        /** @var list<Testimonial> $placeholders */
+        $placeholders = $this->createQueryBuilder('t')
+            ->andWhere('t.isPlaceholder = :placeholder')
+            ->setParameter('placeholder', true)
+            ->orderBy('t.createdAt', 'DESC')
+            ->setMaxResults($remaining)
+            ->getQuery()
+            ->getResult();
+
+        /** @var list<Testimonial> $merged */
+        $merged = array_merge($real, $placeholders);
+
+        return $merged;
+    }
 }

--- a/templates/groomer/list.html.twig
+++ b/templates/groomer/list.html.twig
@@ -53,7 +53,12 @@
         {% if groomers %}
             <ul>
             {% for groomer in groomers %}
-                <li><a href="/groomers/{{ groomer.slug }}">{{ groomer.businessName }}</a></li>
+                <li>
+                    <a href="/groomers/{{ groomer.slug }}">{{ groomer.businessName }}</a>
+                    {% if testimonials[groomer.id] is defined %}
+                        <blockquote>{{ testimonials[groomer.id].quote }}</blockquote>
+                    {% endif %}
+                </li>
             {% endfor %}
             </ul>
             <div class="pagination">

--- a/tests/Controller/GroomerTestimonialsTest.php
+++ b/tests/Controller/GroomerTestimonialsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\City;
+use App\Entity\GroomerProfile;
+use App\Entity\Service;
+use App\Entity\Testimonial;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class GroomerTestimonialsTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    public function testListPrefersRealTestimonials(): void
+    {
+        $city = new City('Sofia');
+        $city->refreshSlugFrom($city->getName());
+        $service = (new Service())->setName('Bath');
+        $service->refreshSlugFrom($service->getName());
+
+        $user = (new User())
+            ->setEmail('g@example.com')
+            ->setRoles([User::ROLE_GROOMER])
+            ->setPassword('hash');
+        $groomer = new GroomerProfile($user, $city, 'Groomer', 'About');
+        $groomer->refreshSlugFrom($groomer->getBusinessName());
+        $groomer->addService($service);
+
+        $real = new Testimonial('Real', 'City', 'Real quote');
+        $placeholder = new Testimonial('Placeholder', 'City', 'Placeholder quote');
+        $placeholder->markPlaceholder();
+        $prop = new \ReflectionProperty(Testimonial::class, 'createdAt');
+        $prop->setAccessible(true);
+        $prop->setValue($placeholder, new \DateTimeImmutable());
+        $prop->setValue($real, new \DateTimeImmutable('-1 day'));
+
+        $this->em->persist($city);
+        $this->em->persist($service);
+        $this->em->persist($user);
+        $this->em->persist($groomer);
+        $this->em->persist($real);
+        $this->em->persist($placeholder);
+        $this->em->flush();
+
+        $this->client->request('GET', '/groomers/'.$city->getSlug().'/'.$service->getSlug());
+        self::assertResponseIsSuccessful();
+        $content = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('Real quote', $content);
+        self::assertStringNotContainsString('Placeholder quote', $content);
+    }
+
+    public function testListFallsBackToPlaceholder(): void
+    {
+        $city = new City('Plovdiv');
+        $city->refreshSlugFrom($city->getName());
+        $service = (new Service())->setName('Trim');
+        $service->refreshSlugFrom($service->getName());
+
+        $user = (new User())
+            ->setEmail('g2@example.com')
+            ->setRoles([User::ROLE_GROOMER])
+            ->setPassword('hash');
+        $groomer = new GroomerProfile($user, $city, 'Groomer2', 'About');
+        $groomer->refreshSlugFrom($groomer->getBusinessName());
+        $groomer->addService($service);
+
+        $placeholder = new Testimonial('Placeholder', 'City', 'Placeholder quote');
+        $placeholder->markPlaceholder();
+
+        $this->em->persist($city);
+        $this->em->persist($service);
+        $this->em->persist($user);
+        $this->em->persist($groomer);
+        $this->em->persist($placeholder);
+        $this->em->flush();
+
+        $this->client->request('GET', '/groomers/'.$city->getSlug().'/'.$service->getSlug());
+        self::assertResponseIsSuccessful();
+        $content = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('Placeholder quote', $content);
+    }
+}

--- a/tests/Repository/TestimonialRepositoryTest.php
+++ b/tests/Repository/TestimonialRepositoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Entity\Testimonial;
+use App\Repository\TestimonialRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class TestimonialRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private TestimonialRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = static::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $schemaTool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $this->repository = $this->em->getRepository(Testimonial::class);
+    }
+
+    public function testFindLatestWithFallbackPrioritizesReal(): void
+    {
+        $placeholder = new Testimonial('Placeholder', 'City', 'Placeholder quote');
+        $placeholder->markPlaceholder();
+        $prop = new \ReflectionProperty(Testimonial::class, 'createdAt');
+        $prop->setAccessible(true);
+        $prop->setValue($placeholder, new \DateTimeImmutable());
+
+        $real = new Testimonial('Real', 'City', 'Real quote');
+        $prop->setValue($real, new \DateTimeImmutable('-1 day'));
+
+        $this->em->persist($placeholder);
+        $this->em->persist($real);
+        $this->em->flush();
+        $this->em->clear();
+
+        $found = $this->repository->findLatestWithFallback(1);
+        self::assertCount(1, $found);
+        self::assertSame('Real quote', $found[0]->getQuote());
+    }
+
+    public function testFindLatestWithFallbackIncludesPlaceholdersWhenNeeded(): void
+    {
+        $real = new Testimonial('Real', 'City', 'Real quote');
+        $placeholder = new Testimonial('Placeholder', 'City', 'Placeholder quote');
+        $placeholder->markPlaceholder();
+        $prop = new \ReflectionProperty(Testimonial::class, 'createdAt');
+        $prop->setAccessible(true);
+        $prop->setValue($placeholder, new \DateTimeImmutable());
+        $prop->setValue($real, new \DateTimeImmutable('-1 day'));
+
+        $this->em->persist($real);
+        $this->em->persist($placeholder);
+        $this->em->flush();
+        $this->em->clear();
+
+        $found = $this->repository->findLatestWithFallback(2);
+        self::assertCount(2, $found);
+        self::assertSame('Real quote', $found[0]->getQuote());
+        self::assertSame('Placeholder quote', $found[1]->getQuote());
+    }
+}


### PR DESCRIPTION
## Summary
- add placeholder flag to testimonials
- load prioritized testimonials for groomer listings
- import GMB reviews as placeholder testimonials

## Testing
- `php bin/console asset-map:compile`
- `composer fix:php`
- `composer stan`
- `APP_ENV=test php -d memory_limit=512M -d zend.enable_gc=0 ./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68b0149abf108322b21f1a726de68ef1