### PR TITLE
fix: remove request globals from email templates

### DIFF
--- a/.env
+++ b/.env
@@ -50,6 +50,7 @@ LEADS_FEATURE_ENABLED=false
 # --- Application Config ---
 # Company and outreach details used in emails/footers
 OUTREACH_COMPANY_NAME="CleanWhiskers"
+OUTREACH_COMPANY_ADDRESS="123 Business Rd, City, Country"
 OUTREACH_CONTACT_EMAIL="support@example.com"
 
 # Safety controls

--- a/.env.test
+++ b/.env.test
@@ -8,6 +8,7 @@ LEADS_FEATURE_ENABLED=false
 # --- Application Config ---
 # Company and outreach details used in emails/footers
 OUTREACH_COMPANY_NAME="CleanWhiskers"
+OUTREACH_COMPANY_ADDRESS="123 Business Rd, City, Country"
 OUTREACH_CONTACT_EMAIL="support@example.com"
 
 # Safety controls

--- a/templates/emails/lead_already_claimed.html.twig
+++ b/templates/emails/lead_already_claimed.html.twig
@@ -10,14 +10,9 @@
 {% set city_name = cityName is defined ? cityName : (lead is defined ? lead.city.name : null) %}
 
 {# Company/contact fallbacks #}
-{% set _env = app is defined and app.request is defined and app.request ? app.request.server : null %}
-{% set company_name = companyName is defined and companyName ? companyName : (_env ? _env.get('OUTREACH_COMPANY_NAME') : null) %}
-{% set company_address = companyAddress is defined and companyAddress ? companyAddress : (_env ? _env.get('OUTREACH_COMPANY_ADDRESS') : null) %}
-{% set contact_email = contactEmail is defined and contactEmail ? contactEmail : (_env ? _env.get('OUTREACH_CONTACT_EMAIL') : null) %}
-
-{% set company_name = company_name ?: 'CleanWhiskers' %}
-{% set company_address = company_address ?: '123 Business Rd, City, Country' %}
-{% set contact_email = contact_email ?: 'support@example.com' %}
+{% set company_name = companyName is defined and companyName ? companyName : 'CleanWhiskers' %}
+{% set company_address = companyAddress is defined and companyAddress ? companyAddress : '123 Business Rd, City, Country' %}
+{% set contact_email = contactEmail is defined and contactEmail ? contactEmail : 'support@example.com' %}
 
 <!DOCTYPE html>
 <html lang="en">

--- a/templates/emails/lead_invite.html.twig
+++ b/templates/emails/lead_invite.html.twig
@@ -16,15 +16,10 @@
 {% set service_name = serviceName is defined ? serviceName : (lead is defined ? lead.service.name : null) %}
 {% set city_name = cityName is defined ? cityName : (lead is defined ? lead.city.name : null) %}
 
-{# Company/contact fallbacks: prefer explicit context, else try request env, else defaults #}
-{% set _env = app is defined and app.request is defined and app.request ? app.request.server : null %}
-{% set company_name = companyName is defined and companyName ? companyName : (_env ? _env.get('OUTREACH_COMPANY_NAME') : null) %}
-{% set company_address = companyAddress is defined and companyAddress ? companyAddress : (_env ? _env.get('OUTREACH_COMPANY_ADDRESS') : null) %}
-{% set contact_email = contactEmail is defined and contactEmail ? contactEmail : (_env ? _env.get('OUTREACH_CONTACT_EMAIL') : null) %}
-
-{% set company_name = company_name ?: 'CleanWhiskers' %}
-{% set company_address = company_address ?: '123 Business Rd, City, Country' %}
-{% set contact_email = contact_email ?: 'support@example.com' %}
+{# Company/contact fallbacks: prefer explicit context, else defaults #}
+{% set company_name = companyName is defined and companyName ? companyName : 'CleanWhiskers' %}
+{% set company_address = companyAddress is defined and companyAddress ? companyAddress : '123 Business Rd, City, Country' %}
+{% set contact_email = contactEmail is defined and contactEmail ? contactEmail : 'support@example.com' %}
 
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Summary
- avoid `app.request` access in lead invite and already-claimed templates
- add OUTREACH_COMPANY_ADDRESS defaults in `.env` and `.env.test`

## Testing
- `composer lint:php` *(fails: Found 41 fixable files)*
- `composer stan` *(fails: Found 22 errors)*
- `composer test` *(fails: Allowed memory size exhausted)*
- `php bin/console asset-map:compile`


------
https://chatgpt.com/codex/tasks/task_e_68c07d4491908322b7abb732042b41c4